### PR TITLE
www/npm: Fix build on DragonFly

### DIFF
--- a/ports/www/npm/Makefile.DragonFly
+++ b/ports/www/npm/Makefile.DragonFly
@@ -1,0 +1,2 @@
+pre-patch:
+	${REINPLACE_CMD} -e 's|"nobody"|${:!/usr/bin/id -u nobody!}|' ${WRKSRC}/lib/config/defaults.js


### PR DESCRIPTION
This only fixes a symptome, as it avoids username to uid lookups
via the node_modules/uid-number module. The module in question
exploits a number of bugs in nodejs (www/node) and libuv:

1. process.execPath returns "node\0test.js" instead of just "node".
   This is actually a bug in the DragonFly port of libuv in function
   uv_exepath(). Upstream patches send!

2. node is somehow unable to fork itself and open stdin/stdout
   correctly in the child. Replacing the
   node_modules/uid-number/get-uid-git.js script by an equivalent
   in shell works, but would break the module checksums.