### PR TITLE
D1507 fix tcl autools

### DIFF
--- a/ports/devel/tclbsd/Makefile.DragonFly
+++ b/ports/devel/tclbsd/Makefile.DragonFly
@@ -1,3 +1,3 @@
-dfly-patch:
-	cd ${WRKSRC} ; autoconf # needed to gen configure first
+# must be invoked after autotools but before configure steo
+run-autotools-fixup:
 	${REINPLACE_CMD} -e 's/FreeBSD-\*/FreeBSD-*|DragonFly-*/g' ${WRKSRC}/configure

--- a/ports/devel/yajl-tcl/Makefile.DragonFly
+++ b/ports/devel/yajl-tcl/Makefile.DragonFly
@@ -1,3 +1,3 @@
-dfly-patch:
-	cd ${WRKSRC} ; autoconf # needed to gen configure first
+# must be invoked after autotools but before configure steo
+run-autotools-fixup:
 	${REINPLACE_CMD} -e 's/FreeBSD-\*/FreeBSD-*|DragonFly-*/g' ${WRKSRC}/configure


### PR DESCRIPTION
This should fix-up ./configure patching during build.
Patching should be invoked before do-configure target but after run-autotools one.