### PR TITLE
fixes openjdk8 networking issues on DFly4.2

### DIFF
--- a/ports/java/openjdk8/Makefile.DragonFly
+++ b/ports/java/openjdk8/Makefile.DragonFly
@@ -1,3 +1,5 @@
+MAKE_ENV+=     DONT_ENABLE_IPV6="YES"
+
 # Eclipse builds forever on gcc5-built openjdk8
 
 USE_GCC=	NOT5

--- a/ports/java/openjdk8/dragonfly/patch-jdk_make_lib_networkinglibraries.gmk
+++ b/ports/java/openjdk8/dragonfly/patch-jdk_make_lib_networkinglibraries.gmk
@@ -1,0 +1,13 @@
+--- jdk/make/lib/NetworkingLibraries.gmk.orig
++++ jdk/make/lib/NetworkingLibraries.gmk
+@@ -58,6 +58,10 @@
+       NTLMAuthSequence.c NetworkInterface_winXP.c
+ endif
+
++ifneq ($(DONT_ENABLE_IPV6),)
++  LIBNET_CFLAGS += -DDONT_ENABLE_IPV6
++endif
++
+ $(eval $(call SetupNativeCompilation,BUILD_LIBNET, \
+     LIBRARY := net, \
+     OUTPUT_DIR := $(INSTALL_LIBRARIES_HERE), \


### PR DESCRIPTION
fix is slightly more complex than that for openjdk7 due to the jdk build
changes
  http://lists.dragonflybsd.org/pipermail/users/2015-January/207360.html

the change to the build file was taken from here:
  http://hg.openjdk.java.net/bsd-port/jdk8/jdk/rev/ffe5580b349c
so it will probably go away someday