### PR TITLE
sysutils/conky: initial port with intent to upstream it

### DIFF
--- a/ports/sysutils/conky/Makefile.DragonFly
+++ b/ports/sysutils/conky/Makefile.DragonFly
@@ -1,0 +1,6 @@
+USES+=  autoreconf:build libtool
+
+CFLAGS+= -Dstatfs64=statfs -Wno-maybe-uninitialized
+
+pre-configure:
+	cd ${WRKSRC} && ./autogen.sh

--- a/ports/sysutils/conky/dragonfly/patch-configure.ac.in
+++ b/ports/sysutils/conky/dragonfly/patch-configure.ac.in
@@ -1,0 +1,21 @@
+--- configure.ac.in.orig	2012-05-04 00:34:47.000000000 +0300
++++ configure.ac.in
+@@ -77,6 +77,10 @@ case $uname in
+ #    WANT_KSTAT=yes
+ #    ;;
+ 
++  DragonFly*)
++    WANT_KVM=yes
++    ;;
++
+   *)
+     echo "Your operating system $uname isn't supported"
+     echo "Feel free to help. :P"
+@@ -89,6 +93,7 @@ AM_CONDITIONAL(BUILD_LINUX, test x$uname
+ AM_CONDITIONAL(BUILD_FREEBSD, test x$uname = xFreeBSD -o x$uname = xGNU/kFreeBSD)
+ #AM_CONDITIONAL(BUILD_NETBSD, test x$uname = xNetBSD)
+ AM_CONDITIONAL(BUILD_OPENBSD, test x$uname = xOpenBSD)
++AM_CONDITIONAL(BUILD_DRAGONFLY, test x$uname = xDragonFly)
+ 
+ BUILD_DATE=$(LANG=en_US LC_ALL=en_US LOCALE=en_US date)
+ BUILD_ARCH="$(uname -sr) ($(uname -m))"

--- a/ports/sysutils/conky/dragonfly/patch-src_Makefile.am
+++ b/ports/sysutils/conky/dragonfly/patch-src_Makefile.am
@@ -1,0 +1,29 @@
+--- src/Makefile.am.orig	2012-05-04 00:08:27.000000000 +0300
++++ src/Makefile.am
+@@ -70,6 +70,7 @@ solaris = solaris.c
+ freebsd = freebsd.c freebsd.h
+ netbsd = netbsd.c netbsd.h
+ openbsd = openbsd.c openbsd.h
++dragonfly = dragonfly.c dragonfly.h
+ port_monitors = libtcp-portmon.c libtcp-portmon.h \
+                 tcp-portmon.c tcp-portmon.h
+ x11 = x11.c x11.h fonts.c fonts.h
+@@ -86,7 +87,7 @@ iconv = iconv_tools.c iconv_tools.h
+ 
+ # make sure the files from above are always included in the distfile
+ EXTRA_DIST = $(audacious) $(bmpx) $(ibm) $(mpd) $(moc) $(xmms2) $(linux) \
+-             $(solaris) $(freebsd) $(netbsd) $(openbsd) $(port_monitors) \
++             $(solaris) $(freebsd) $(netbsd) $(openbsd) $(dragonfly) $(port_monitors) \
+              $(x11) $(hddtemp) $(eve) $(ccurl_thread) $(rss) $(weather) \
+              $(lua) $(nvidia) $(imlib2) $(apcupsd)
+ 
+@@ -125,6 +126,9 @@ endif
+ if BUILD_OPENBSD
+ optional_sources += $(openbsd)
+ endif
++if BUILD_DRAGONFLY
++optional_sources += $(dragonfly)
++endif
+ if BUILD_PORT_MONITORS
+ optional_sources += $(port_monitors)
+ endif

--- a/ports/sysutils/conky/dragonfly/patch-src_Makefile.in
+++ b/ports/sysutils/conky/dragonfly/patch-src_Makefile.in
@@ -1,0 +1,83 @@
+--- src/Makefile.in.orig	2012-05-04 00:47:40.000000000 +0300
++++ src/Makefile.in
+@@ -94,6 +94,7 @@ bin_PROGRAMS = conky$(EXEEXT)
+ #optional_sources += $(netbsd)
+ #endif
+ @BUILD_OPENBSD_TRUE@am__append_9 = $(openbsd)
++@BUILD_DRAGONFLY_TRUE@am__append_99 = $(dragonfly)
+ @BUILD_PORT_MONITORS_TRUE@am__append_10 = $(port_monitors)
+ @BUILD_X11_TRUE@am__append_11 = $(x11)
+ @BUILD_HDDTEMP_TRUE@am__append_12 = $(hddtemp)
+@@ -126,7 +127,7 @@ am__conky_SOURCES_DIST = defconfig.h con
+ 	audacious.c audacious.h bmpx.c bmpx.h ibm.c ibm.h smapi.c \
+ 	smapi.h mpd.c mpd.h libmpdclient.c libmpdclient.h moc.c moc.h \
+ 	xmms2.c xmms2.h linux.c linux.h users.c sony.c sony.h i8k.c \
+-	i8k.h freebsd.c freebsd.h openbsd.c openbsd.h libtcp-portmon.c \
++	i8k.h freebsd.c freebsd.h openbsd.c openbsd.h dragonfly.c dragonfly.h libtcp-portmon.c \
+ 	libtcp-portmon.h tcp-portmon.c tcp-portmon.h x11.c x11.h \
+ 	fonts.c fonts.h hddtemp.c hddtemp.h eve.c eve.h ccurl_thread.c \
+ 	ccurl_thread.h rss.c rss.h prss.c prss.h weather.c weather.h \
+@@ -163,6 +164,8 @@ am__objects_19 = conky-openbsd.$(OBJEXT)
+ @BUILD_OPENBSD_TRUE@am__objects_20 = $(am__objects_19)
+ am__objects_21 = conky-libtcp-portmon.$(OBJEXT) \
+ 	conky-tcp-portmon.$(OBJEXT)
++am__objects_98 = conky-dragonfly.$(OBJEXT)
++@BUILD_DRAGONFLY_TRUE@am__objects_99 = $(am__objects_98)
+ @BUILD_PORT_MONITORS_TRUE@am__objects_22 = $(am__objects_21)
+ am__objects_23 = conky-x11.$(OBJEXT) conky-fonts.$(OBJEXT)
+ @BUILD_X11_TRUE@am__objects_24 = $(am__objects_23)
+@@ -429,6 +432,7 @@ solaris = solaris.c
+ freebsd = freebsd.c freebsd.h
+ netbsd = netbsd.c netbsd.h
+ openbsd = openbsd.c openbsd.h
++dragonfly = dragonfly.c dragonfly.h
+ port_monitors = libtcp-portmon.c libtcp-portmon.h \
+                 tcp-portmon.c tcp-portmon.h
+ 
+@@ -446,7 +450,7 @@ iconv = iconv_tools.c iconv_tools.h
+ 
+ # make sure the files from above are always included in the distfile
+ EXTRA_DIST = $(audacious) $(bmpx) $(ibm) $(mpd) $(moc) $(xmms2) $(linux) \
+-             $(solaris) $(freebsd) $(netbsd) $(openbsd) $(port_monitors) \
++             $(solaris) $(freebsd) $(netbsd) $(openbsd) $(dragonfly) $(port_monitors) \
+              $(x11) $(hddtemp) $(eve) $(ccurl_thread) $(rss) $(weather) \
+              $(lua) $(nvidia) $(imlib2) $(apcupsd)
+ 
+@@ -458,7 +462,7 @@ optional_sources = $(am__append_1) $(am_
+ 	$(am__append_10) $(am__append_11) $(am__append_12) \
+ 	$(am__append_13) $(am__append_14) $(am__append_15) \
+ 	$(am__append_16) $(am__append_17) $(am__append_18) \
+-	$(am__append_19) $(am__append_20) $(am__append_21)
++	$(am__append_19) $(am__append_20) $(am__append_21) $(am__append_98) $(am__append_99)
+ @BUILD_LINUX_FALSE@PTHREAD_LIBS = -pthread
+ 
+ # linux takes the standard to the max
+@@ -592,6 +596,7 @@ distclean-compile:
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/conky-exec.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/conky-fonts.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/conky-freebsd.Po@am__quote@
++@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/conky-dragonfly.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/conky-fs.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/conky-hddtemp.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/conky-i8k.Po@am__quote@
+@@ -849,6 +854,20 @@ conky-freebsd.obj: freebsd.c
+ @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+ @am__fastdepCC_FALSE@	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(conky_CFLAGS) $(CFLAGS) -c -o conky-freebsd.obj `if test -f 'freebsd.c'; then $(CYGPATH_W) 'freebsd.c'; else $(CYGPATH_W) '$(srcdir)/freebsd.c'; fi`
+ 
++conky-dragonfly.o: dragonfly.c
++@am__fastdepCC_TRUE@	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(conky_CFLAGS) $(CFLAGS) -MT conky-dragonfly.o -MD -MP -MF $(DEPDIR)/conky-dragonfly.Tpo -c -o conky-dragonfly.o `test -f 'dragonfly.c' || echo '$(srcdir)/'`dragonfly.c
++@am__fastdepCC_TRUE@	$(am__mv) $(DEPDIR)/conky-dragonfly.Tpo $(DEPDIR)/conky-dragonfly.Po
++@AMDEP_TRUE@@am__fastdepCC_FALSE@	source='dragonfly.c' object='conky-dragonfly.o' libtool=no @AMDEPBACKSLASH@
++@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
++@am__fastdepCC_FALSE@	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(conky_CFLAGS) $(CFLAGS) -c -o conky-dragonfly.o `test -f 'dragonfly.c' || echo '$(srcdir)/'`dragonfly.c
++
++conky-dragonfly.obj: dragonfly.c
++@am__fastdepCC_TRUE@	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(conky_CFLAGS) $(CFLAGS) -MT conky-dragonfly.obj -MD -MP -MF $(DEPDIR)/conky-dragonfly.Tpo -c -o conky-dragonfly.obj `if test -f 'dragonfly.c'; then $(CYGPATH_W) 'dragonfly.c'; else $(CYGPATH_W) '$(srcdir)/dragonfly.c'; fi`
++@am__fastdepCC_TRUE@	$(am__mv) $(DEPDIR)/conky-dragonfly.Tpo $(DEPDIR)/conky-dragonfly.Po
++@AMDEP_TRUE@@am__fastdepCC_FALSE@	source='dragonfly.c' object='conky-dragonfly.obj' libtool=no @AMDEPBACKSLASH@
++@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
++@am__fastdepCC_FALSE@	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(conky_CFLAGS) $(CFLAGS) -c -o conky-dragonfly.obj `if test -f 'dragonfly.c'; then $(CYGPATH_W) 'dragonfly.c'; else $(CYGPATH_W) '$(srcdir)/dragonfly.c'; fi`
++
+ conky-openbsd.o: openbsd.c
+ @am__fastdepCC_TRUE@	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(conky_CFLAGS) $(CFLAGS) -MT conky-openbsd.o -MD -MP -MF $(DEPDIR)/conky-openbsd.Tpo -c -o conky-openbsd.o `test -f 'openbsd.c' || echo '$(srcdir)/'`openbsd.c
+ @am__fastdepCC_TRUE@	$(am__mv) $(DEPDIR)/conky-openbsd.Tpo $(DEPDIR)/conky-openbsd.Po

--- a/ports/sysutils/conky/dragonfly/patch-src_common.c
+++ b/ports/sysutils/conky/dragonfly/patch-src_common.c
@@ -1,0 +1,11 @@
+--- src/common.c.orig	2012-05-04 00:08:27.000000000 +0300
++++ src/common.c
+@@ -54,6 +54,8 @@
+ #include "freebsd.h"
+ #elif defined(__OpenBSD__)
+ #include "openbsd.h"
++#elif defined(__DragonFly__)
++#include "dragonfly.h"
+ #endif
+ 
+ /* folds a string over top of itself, like so:

--- a/ports/sysutils/conky/dragonfly/patch-src_conky.h
+++ b/ports/sysutils/conky/dragonfly/patch-src_conky.h
@@ -1,0 +1,45 @@
+--- src/conky.c.orig	2012-05-04 00:22:21.000000000 +0300
++++ src/conky.c
+@@ -117,6 +117,8 @@
+ #include "freebsd.h"
+ #elif defined(__OpenBSD__)
+ #include "openbsd.h"
++#elif defined(__DragonFly__)
++#include "dragonfly.h"
+ #endif
+ 
+ #if defined(__FreeBSD_kernel__)
+@@ -1015,7 +1017,7 @@ void generate_text_internal(char *p, int
+ 				get_powerbook_batt_info(p, p_max_size, obj->data.i);
+ 			}
+ #endif /* __linux__ */
+-#if (defined(__FreeBSD__) || defined(__linux__))
++#if (defined(__FreeBSD__) || defined(__linux__) || defined(__DragonFly__))
+ 			OBJ(if_up) {
+ 				if (!interface_up(obj)) {
+ 					DO_JUMP;
+@@ -5667,13 +5669,13 @@ void initialisation(int argc, char **arg
+ 	/* handle other command line arguments */
+ 
+ #if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__OpenBSD__) \
+-		|| defined(__NetBSD__)
++		|| defined(__NetBSD__) || defined(__DragonFly__)
+ 	optind = optreset = 1;
+ #else
+ 	optind = 0;
+ #endif
+ 
+-#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
++#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__DragonFly__)
+ 	if ((kd = kvm_open("/dev/null", "/dev/null", "/dev/null", O_RDONLY,
+ 			"kvm_open")) == NULL) {
+ 		CRIT_ERR(NULL, NULL, "cannot read kvm");
+@@ -5960,7 +5962,7 @@ int main(int argc, char **argv)
+ 	curl_global_cleanup();
+ #endif
+ 
+-#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
++#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__DragonFly__)
+ 	kvm_close(kd);
+ 	pthread_mutex_destroy(&kvm_proc_mutex);
+ #endif

--- a/ports/sysutils/conky/dragonfly/patch-src_core.c
+++ b/ports/sysutils/conky/dragonfly/patch-src_core.c
@@ -1,0 +1,38 @@
+--- src/core.c.orig	2012-05-04 00:08:27.000000000 +0300
++++ src/core.c
+@@ -75,6 +75,8 @@
+ #include "freebsd.h"
+ #elif defined(__OpenBSD__)
+ #include "openbsd.h"
++#elif defined(__DragonFly__)
++#include "dragonfly.h"
+ #endif
+ 
+ #include <string.h>
+@@ -326,7 +328,7 @@ struct text_object *construct_text_objec
+ 			obj->data.i = PB_BATT_STATUS;
+ 		}
+ #endif /* __linux__ */
+-#if (defined(__FreeBSD__) || defined(__linux__))
++#if (defined(__FreeBSD__) || defined(__linux__) || defined(__DragonFly__))
+ 	END OBJ_IF_ARG(if_up, 0, "if_up needs an argument")
+ 		parse_if_up_arg(obj, arg);
+ #endif
+@@ -577,7 +579,7 @@ struct text_object *construct_text_objec
+ 		obj->data.s = strndup(arg, text_buffer_size);
+ 	END OBJ_IF_ARG(if_mounted, 0, "if_mounted needs an argument")
+ 		obj->data.s = strndup(arg, text_buffer_size);
+-#if defined(__linux__) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
++#if defined(__linux__) || defined(__DragonFly__) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
+ 	END OBJ_IF_ARG(if_running, &update_top, "if_running needs an argument")
+ 		top_running = 1;
+ 		obj->data.s = strndup(arg, text_buffer_size);
+@@ -1523,7 +1525,7 @@ void free_text_objects(struct text_objec
+ 					free(data.s);
+ 				break;
+ #endif
+-#if (defined(__FreeBSD__) || defined(__linux__))
++#if (defined(__FreeBSD__) || defined(__linux__)) || defined(__DragonFly__)
+ 			case OBJ_if_up:
+ 				free_if_up(obj);
+ 				break;

--- a/ports/sysutils/conky/dragonfly/patch-src_dragonfly.c
+++ b/ports/sysutils/conky/dragonfly/patch-src_dragonfly.c
@@ -1,0 +1,739 @@
+--- /dev/null	2015-09-11 11:21:55.750647684 +0300
++++ src/dragonfly.c
+@@ -0,0 +1,736 @@
++/* -*- mode: c; c-basic-offset: 4; tab-width: 4; indent-tabs-mode: t -*-
++ * vim: ts=4 sw=4 noet ai cindent syntax=c
++ *
++ * Conky, a system monitor, based on torsmo
++ *
++ * Any original torsmo code is licensed under the BSD license
++ *
++ * All code written since the fork of torsmo is licensed under the GPL
++ *
++ * Please see COPYING for details
++ *
++ * Copyright (c) 2005-2010 Brenden Matthews, Philip Kovacs, et. al.
++ *	(see AUTHORS)
++ * All rights reserved.
++ *
++ * This program is free software: you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation, either version 3 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ * You should have received a copy of the GNU General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ *
++ */
++
++#include <sys/ioctl.h>
++#include <sys/param.h>
++#include <sys/resource.h>
++#include <sys/socket.h>
++#include <sys/stat.h>
++#include <sys/sysctl.h>
++#include <sys/time.h>
++#include <sys/types.h>
++#include <sys/user.h>
++
++#include <net/if.h>
++#include <net/if_mib.h>
++#include <net/if_media.h>
++#include <net/if_var.h>
++
++#include <devstat.h>
++#include <ifaddrs.h>
++#include <limits.h>
++#include <unistd.h>
++
++//#include <dev/wi/if_wavelan_ieee.h>
++#include <dev/acpica/acpiio.h>
++
++#include "conky.h"
++#include "dragonfly.h"
++#include "logging.h"
++#include "net_stat.h"
++#include "top.h"
++#include "diskio.h"
++
++#define	GETSYSCTL(name, var)	getsysctl(name, &(var), sizeof(var))
++#define	KELVTOC(x)				((x - 2732) / 10.0)
++
++__attribute__((gnu_inline)) inline void
++proc_find_top(struct process **cpu, struct process **mem, struct process **time);
++
++static short cpu_setup = 0;
++
++static int getsysctl(const char *name, void *ptr, size_t len)
++{
++	size_t nlen = len;
++
++	if (sysctlbyname(name, ptr, &nlen, NULL, 0) == -1) {
++		return -1;
++	}
++
++	if (nlen != len && errno == ENOMEM) {
++		return -1;
++	}
++
++	return 0;
++}
++
++struct ifmibdata *data = NULL;
++size_t len = 0;
++
++static int swapmode(unsigned long *retavail, unsigned long *retfree)
++{
++	int n;
++	unsigned long pagesize = getpagesize();
++	struct kvm_swap swapary[1];
++
++	*retavail = 0;
++	*retfree = 0;
++
++#define	CONVERT(v)	((quad_t)(v) * (pagesize / 1024))
++
++	n = kvm_getswapinfo(kd, swapary, 1, 0);
++	if (n < 0 || swapary[0].ksw_total == 0) {
++		return 0;
++	}
++
++	*retavail = CONVERT(swapary[0].ksw_total);
++	*retfree = CONVERT(swapary[0].ksw_total - swapary[0].ksw_used);
++
++	n = (int) ((double) swapary[0].ksw_used * 100.0 /
++		(double) swapary[0].ksw_total);
++
++	return n;
++}
++
++void prepare_update(void)
++{
++}
++
++int update_uptime(void)
++{
++	int mib[2] = { CTL_KERN, KERN_BOOTTIME };
++	struct timeval boottime;
++	time_t now;
++	size_t size = sizeof(boottime);
++
++	if ((sysctl(mib, 2, &boottime, &size, NULL, 0) != -1)
++			&& (boottime.tv_sec != 0)) {
++		time(&now);
++		info.uptime = now - boottime.tv_sec;
++	} else {
++		fprintf(stderr, "Could not get uptime\n");
++		info.uptime = 0;
++	}
++
++	return 0;
++}
++
++int check_mount(char *s)
++{
++	struct statfs *mntbuf;
++	int i, mntsize;
++
++	mntsize = getmntinfo(&mntbuf, MNT_NOWAIT);
++	for (i = mntsize - 1; i >= 0; i--) {
++		if (strcmp(mntbuf[i].f_mntonname, s) == 0) {
++			return 1;
++		}
++	}
++
++	return 0;
++}
++
++int update_meminfo(void)
++{
++	u_int total_pages, inactive_pages, free_pages;
++	unsigned long swap_avail, swap_free;
++
++	int pagesize = getpagesize();
++
++	if (GETSYSCTL("vm.stats.vm.v_page_count", total_pages)) {
++		fprintf(stderr, "Cannot read sysctl \"vm.stats.vm.v_page_count\"\n");
++	}
++
++	if (GETSYSCTL("vm.stats.vm.v_free_count", free_pages)) {
++		fprintf(stderr, "Cannot read sysctl \"vm.stats.vm.v_free_count\"\n");
++	}
++
++	if (GETSYSCTL("vm.stats.vm.v_inactive_count", inactive_pages)) {
++		fprintf(stderr, "Cannot read sysctl \"vm.stats.vm.v_inactive_count\"\n");
++	}
++
++	info.memmax = total_pages * (pagesize >> 10);
++	info.mem = (total_pages - free_pages - inactive_pages) * (pagesize >> 10);
++	info.memeasyfree = info.memfree = info.memmax - info.mem;
++
++	if ((swapmode(&swap_avail, &swap_free)) >= 0) {
++		info.swapmax = swap_avail;
++		info.swap = (swap_avail - swap_free);
++		info.swapfree = swap_free;
++	} else {
++		info.swapmax = 0;
++		info.swap = 0;
++		info.swapfree = 0;
++	}
++
++	return 0;
++}
++
++int update_net_stats(void)
++{
++	struct net_stat *ns;
++	double delta;
++	long long r, t, last_recv, last_trans;
++	struct ifaddrs *ifap, *ifa;
++	struct if_data *ifd;
++
++	/* get delta */
++	delta = current_update_time - last_update_time;
++	if (delta <= 0.0001) {
++		return 0;
++	}
++
++	if (getifaddrs(&ifap) < 0) {
++		return 0;
++	}
++
++	for (ifa = ifap; ifa; ifa = ifa->ifa_next) {
++		ns = get_net_stat((const char *) ifa->ifa_name, NULL, NULL);
++
++		if (ifa->ifa_flags & IFF_UP) {
++			struct ifaddrs *iftmp;
++
++			ns->up = 1;
++			last_recv = ns->recv;
++			last_trans = ns->trans;
++
++			if (ifa->ifa_addr->sa_family != AF_LINK) {
++				continue;
++			}
++
++			for (iftmp = ifa->ifa_next;
++					iftmp != NULL && strcmp(ifa->ifa_name, iftmp->ifa_name) == 0;
++					iftmp = iftmp->ifa_next) {
++				if (iftmp->ifa_addr->sa_family == AF_INET) {
++					memcpy(&(ns->addr), iftmp->ifa_addr,
++						iftmp->ifa_addr->sa_len);
++				}
++			}
++
++			ifd = (struct if_data *) ifa->ifa_data;
++			r = ifd->ifi_ibytes;
++			t = ifd->ifi_obytes;
++
++			if (r < ns->last_read_recv) {
++				ns->recv += ((long long) 4294967295U - ns->last_read_recv) + r;
++			} else {
++				ns->recv += (r - ns->last_read_recv);
++			}
++
++			ns->last_read_recv = r;
++
++			if (t < ns->last_read_trans) {
++				ns->trans += ((long long) 4294967295U -
++					ns->last_read_trans) + t;
++			} else {
++				ns->trans += (t - ns->last_read_trans);
++			}
++
++			ns->last_read_trans = t;
++
++			/* calculate speeds */
++			ns->recv_speed = (ns->recv - last_recv) / delta;
++			ns->trans_speed = (ns->trans - last_trans) / delta;
++		} else {
++			ns->up = 0;
++		}
++	}
++
++	freeifaddrs(ifap);
++	return 0;
++}
++
++int update_total_processes(void)
++{
++	int n_processes;
++
++	pthread_mutex_lock(&kvm_proc_mutex);
++	kvm_getprocs(kd, KERN_PROC_ALL, 0, &n_processes);
++	pthread_mutex_unlock(&kvm_proc_mutex);
++
++	info.procs = n_processes;
++	return 0;
++}
++
++int update_running_processes(void)
++{
++	struct kinfo_proc *p;
++	int n_processes;
++	int i, cnt = 0;
++
++	pthread_mutex_lock(&kvm_proc_mutex);
++	p = kvm_getprocs(kd, KERN_PROC_ALL, 0, &n_processes);
++	for (i = 0; i < n_processes; i++) {
++		if ((p[i].kp_stat == SACTIVE) &&
++		    (p[i].kp_lwp.kl_stat == LSRUN)) {
++			cnt++;
++		}
++	}
++	pthread_mutex_unlock(&kvm_proc_mutex);
++
++	info.run_procs = cnt;
++	return 0;
++}
++
++void get_cpu_count(void)
++{
++	int cpu_count = 0;
++
++	if (GETSYSCTL("hw.ncpu", cpu_count) == 0) {
++		info.cpu_count = cpu_count;
++	} else {
++		fprintf(stderr, "Cannot get hw.ncpu\n");
++		info.cpu_count = 0;
++	}
++
++	info.cpu_usage = malloc((info.cpu_count + 1) * sizeof(float));
++	if (info.cpu_usage == NULL) {
++		CRIT_ERR(NULL, NULL, "malloc");
++	}
++}
++
++struct cpu_info {
++	long oldtotal;
++	long oldused;
++};
++
++int update_cpu_usage(void)
++{
++	int i, j = 0;
++	long used, total;
++	long *cp_time = NULL;
++	size_t cp_len;
++	static struct cpu_info *cpu = NULL;
++	unsigned int malloc_cpu_size = 0;
++	extern void* global_cpu;
++
++	/* add check for !info.cpu_usage since that mem is freed on a SIGUSR1 */
++	if ((cpu_setup == 0) || (!info.cpu_usage)) {
++		get_cpu_count();
++		cpu_setup = 1;
++	}
++
++	if (!global_cpu) {
++		malloc_cpu_size = (info.cpu_count + 1) * sizeof(struct cpu_info);
++		cpu = malloc(malloc_cpu_size);
++		memset(cpu, 0, malloc_cpu_size);
++		global_cpu = cpu;
++	}
++
++	/* cpu[0] is overall stats, get it from separate sysctl */
++	cp_len = CPUSTATES * sizeof(long);
++	cp_time = malloc(cp_len);
++
++	if (sysctlbyname("kern.cp_time", cp_time, &cp_len, NULL, 0) < 0) {
++		fprintf(stderr, "Cannot get kern.cp_time\n");
++	}
++
++	total = 0;
++	for (j = 0; j < CPUSTATES; j++)
++		total += cp_time[j];
++
++	used = total - cp_time[CP_IDLE];
++
++	if ((total - cpu[0].oldtotal) != 0) {
++		info.cpu_usage[0] = ((double) (used - cpu[0].oldused)) /
++		(double) (total - cpu[0].oldtotal);
++	} else {
++		info.cpu_usage[0] = 0;
++	}
++
++	cpu[0].oldused = used;
++	cpu[0].oldtotal = total;
++
++	free(cp_time);
++
++	/* per-core stats */
++	cp_len = CPUSTATES * sizeof(long) * info.cpu_count;
++	cp_time = malloc(cp_len);
++
++	for (i = 0; i < info.cpu_count; i++)
++	{
++		total = 0;
++		for (j = 0; j < CPUSTATES; j++)
++			total += cp_time[i*CPUSTATES + j];
++
++		used = total - cp_time[i*CPUSTATES + CP_IDLE];
++
++		if ((total - cpu[i+1].oldtotal) != 0) {
++			info.cpu_usage[i+1] = ((double) (used - cpu[i+1].oldused)) /
++			(double) (total - cpu[i+1].oldtotal);
++		} else {
++			info.cpu_usage[i+1] = 0;
++		}
++
++		cpu[i+1].oldused = used;
++		cpu[i+1].oldtotal = total;
++	}
++
++	free(cp_time);
++	return 0;
++}
++
++int update_load_average(void)
++{
++	double v[3];
++
++	getloadavg(v, 3);
++
++	info.loadavg[0] = (double) v[0];
++	info.loadavg[1] = (double) v[1];
++	info.loadavg[2] = (double) v[2];
++
++	return 0;
++}
++
++double get_acpi_temperature(int fd)
++{
++	int temp;
++	(void)fd;
++
++	if (GETSYSCTL("hw.acpi.thermal.tz0.temperature", temp)) {
++		fprintf(stderr,
++			"Cannot read sysctl \"hw.acpi.thermal.tz0.temperature\"\n");
++		return 0.0;
++	}
++
++	return KELVTOC(temp);
++}
++
++static void get_battery_stats(int *battime, int *batcapacity, int *batstate, int *ac) {
++	if (battime && GETSYSCTL("hw.acpi.battery.time", *battime)) {
++		fprintf(stderr, "Cannot read sysctl \"hw.acpi.battery.time\"\n");
++	}
++	if (batcapacity && GETSYSCTL("hw.acpi.battery.life", *batcapacity)) {
++		fprintf(stderr, "Cannot read sysctl \"hw.acpi.battery.life\"\n");
++	}
++	if (batstate && GETSYSCTL("hw.acpi.battery.state", *batstate)) {
++		fprintf(stderr, "Cannot read sysctl \"hw.acpi.battery.state\"\n");
++	}
++	if (ac && GETSYSCTL("hw.acpi.acline", *ac)) {
++		fprintf(stderr, "Cannot read sysctl \"hw.acpi.acline\"\n");
++	}
++}
++
++void get_battery_stuff(char *buf, unsigned int n, const char *bat, int item)
++{
++	int battime, batcapacity, batstate, ac;
++	(void)bat;
++
++	get_battery_stats(&battime, &batcapacity, &batstate, &ac);
++
++	if (batstate != 1 && batstate != 2 && batstate != 0 && batstate != 7)
++		fprintf(stderr, "Unknown battery state %d!\n", batstate);
++	else if (batstate != 1 && ac == 0)
++		fprintf(stderr, "Battery charging while not on AC!\n");
++	else if (batstate == 1 && ac == 1)
++		fprintf(stderr, "Battery discharing while on AC!\n");
++
++	switch (item) {
++		case BATTERY_TIME:
++			if (batstate == 1 && battime != -1)
++				snprintf(buf, n, "%d:%2.2d", battime / 60, battime % 60);
++			break;
++		case BATTERY_STATUS:
++			if (batstate == 1) // Discharging
++				snprintf(buf, n, "remaining %d%%", batcapacity);
++			else
++				snprintf(buf, n, batstate == 2 ? "charging (%d%%)" :
++						(batstate == 7 ? "absent/on AC" : "charged (%d%%)"),
++						batcapacity);
++			break;
++		default:
++			fprintf(stderr, "Unknown requested battery stat %d\n", item);
++	}
++}
++
++static int check_bat(const char *bat)
++{
++	int batnum, numbatts;
++	char *endptr;
++	if (GETSYSCTL("hw.acpi.battery.units", numbatts)) {
++		fprintf(stderr, "Cannot read sysctl \"hw.acpi.battery.units\"\n");
++		return -1;
++	}
++	if (numbatts <= 0) {
++		fprintf(stderr, "No battery unit detected\n");
++		return -1;
++	}
++	if (!bat || (batnum = strtol(bat, &endptr, 10)) < 0 ||
++			bat == endptr || batnum > numbatts) {
++		fprintf(stderr, "Wrong battery unit %s requested\n", bat ? bat : "");
++		return -1;
++	}
++	return batnum;
++}
++
++int get_battery_perct(const char *bat)
++{
++	union acpi_battery_ioctl_arg battio;
++	int batnum, acpifd;
++	int designcap, lastfulcap, batperct;
++
++	if ((battio.unit = batnum = check_bat(bat)) < 0)
++		return 0;
++	if ((acpifd = open("/dev/acpi", O_RDONLY)) < 0) {
++		fprintf(stderr, "Can't open ACPI device\n");
++		return 0;
++	}
++	if (ioctl(acpifd, ACPIIO_BATT_GET_BIF, &battio) == -1) {
++		fprintf(stderr, "Unable to get info for battery unit %d\n", batnum);
++		return 0;
++	}
++	close(acpifd);
++	designcap = battio.bif.dcap;
++	lastfulcap = battio.bif.lfcap;
++	batperct = (designcap > 0 && lastfulcap > 0) ?
++		(int) (((float) lastfulcap / designcap) * 100) : 0;
++	return batperct > 100 ? 100 : batperct;
++}
++
++int get_battery_perct_bar(const char *bar)
++{
++	int batperct = get_battery_perct(bar);
++	return (int)(batperct * 2.56 - 1);
++}
++
++int open_acpi_temperature(const char *name)
++{
++	(void)name;
++	/* Not applicable for DragonFly. */
++	return 0;
++}
++
++void get_acpi_ac_adapter(char *p_client_buffer, size_t client_buffer_size, const char *adapter)
++{
++	int state;
++
++	(void) adapter; // only linux uses this
++
++	if (!p_client_buffer || client_buffer_size <= 0) {
++		return;
++	}
++
++	if (GETSYSCTL("hw.acpi.acline", state)) {
++		fprintf(stderr, "Cannot read sysctl \"hw.acpi.acline\"\n");
++		return;
++	}
++
++	if (state) {
++		strncpy(p_client_buffer, "Running on AC Power", client_buffer_size);
++	} else {
++		strncpy(p_client_buffer, "Running on battery", client_buffer_size);
++	}
++}
++
++void get_acpi_fan(char *p_client_buffer, size_t client_buffer_size)
++{
++	/* not implemented */
++	if (p_client_buffer && client_buffer_size > 0) {
++		memset(p_client_buffer, 0, client_buffer_size);
++	}
++}
++
++/* void */
++char get_freq(char *p_client_buffer, size_t client_buffer_size, const char *p_format,
++		int divisor, unsigned int cpu)
++{
++	int freq;
++	char *freq_sysctl;
++
++	freq_sysctl = (char *) calloc(16, sizeof(char));
++	if (freq_sysctl == NULL) {
++		exit(-1);
++	}
++
++	snprintf(freq_sysctl, 16, "hw.clockrate", (cpu - 1));
++
++	if (!p_client_buffer || client_buffer_size <= 0 || !p_format
++			|| divisor <= 0) {
++		return 0;
++	}
++
++	if (GETSYSCTL(freq_sysctl, freq) == 0) {
++		snprintf(p_client_buffer, client_buffer_size, p_format,
++			(float) freq / divisor);
++	} else {
++		snprintf(p_client_buffer, client_buffer_size, p_format, 0.0f);
++	}
++
++	free(freq_sysctl);
++	return 1;
++}
++
++int update_top(void)
++{
++	proc_find_top(info.cpu, info.memu, info.time);
++	return 0;
++}
++
++int update_diskio(void)
++{
++	/* XXX TODO */
++	return 0;
++}
++
++/* While topless is obviously better, top is also not bad. */
++
++int comparecpu(const void *a, const void *b)
++{
++	if (((const struct process *)a)->amount > ((const struct process *)b)->amount) {
++		return -1;
++	} else if (((const struct process *)a)->amount < ((const struct process *)b)->amount) {
++		return 1;
++	} else {
++		return 0;
++	}
++}
++
++int comparemem(const void *a, const void *b)
++{
++	if (((const struct process *)a)->rss > ((const struct process *)b)->rss) {
++		return -1;
++	} else if (((const struct process *)a)->rss < ((const struct process *)b)->rss) {
++		return 1;
++	} else {
++		return 0;
++	}
++}
++
++int comparetime(const void *va, const void *vb)
++{
++	struct process *a = (struct process *)va, *b = (struct process *)vb;
++
++	return b->total_cpu_time - a->total_cpu_time;
++}
++
++__attribute__((gnu_inline)) inline void
++proc_find_top(struct process **cpu, struct process **mem, struct process **time)
++{
++	struct kinfo_proc *p;
++	int n_processes;
++	int i, j = 0;
++	struct process *processes;
++
++	int total_pages;
++
++	/* we get total pages count again to be sure it is up to date */
++	if (GETSYSCTL("vm.stats.vm.v_page_count", total_pages) != 0) {
++		CRIT_ERR(NULL, NULL, "Cannot read sysctl \"vm.stats.vm.v_page_count\"");
++	}
++
++	pthread_mutex_lock(&kvm_proc_mutex);
++	p = kvm_getprocs(kd, KERN_PROC_ALL, 0, &n_processes);
++	processes = malloc(n_processes * sizeof(struct process));
++
++	for (i = 0; i < n_processes; i++) {
++		if (!((p[i].kp_flags & P_SYSTEM)) && p[i].kp_comm != NULL) {
++			processes[j].pid = p[i].kp_pid;
++			processes[j].name = strndup(p[i].kp_comm, text_buffer_size);
++			processes[j].amount = 100 * (float)(p[i].kp_lwp.kl_pctcpu) / FSCALE;
++			processes[j].vsize = p[i].kp_vm_map_size;
++			processes[j].rss = (p[i].kp_vm_rssize * getpagesize());
++			/* XXX for now show percentage of cpu time */
++			processes[j].total_cpu_time = p[i].kp_lwp.kl_pctcpu / 10000 * FSCALE;
++			j++;
++		}
++	}
++	pthread_mutex_unlock(&kvm_proc_mutex);
++
++	qsort(processes, j - 1, sizeof(struct process), comparemem);
++	for (i = 0; i < 10 && i < n_processes; i++) {
++		struct process *tmp, *ttmp;
++
++		tmp = malloc(sizeof(struct process));
++		memcpy(tmp, &processes[i], sizeof(struct process));
++		tmp->name = strndup(processes[i].name, text_buffer_size);
++
++		ttmp = mem[i];
++		mem[i] = tmp;
++		if (ttmp != NULL) {
++			free(ttmp->name);
++			free(ttmp);
++		}
++	}
++
++	qsort(processes, j - 1, sizeof(struct process), comparecpu);
++	for (i = 0; i < 10 && i < n_processes; i++) {
++		struct process *tmp, *ttmp;
++
++		tmp = malloc(sizeof(struct process));
++		memcpy(tmp, &processes[i], sizeof(struct process));
++		tmp->name = strndup(processes[i].name, text_buffer_size);
++
++		ttmp = cpu[i];
++		cpu[i] = tmp;
++		if (ttmp != NULL) {
++			free(ttmp->name);
++			free(ttmp);
++		}
++	}
++
++	qsort(processes, j - 1, sizeof(struct process), comparetime);
++	for (i = 0; i < 10 && i < n_processes; i++) {
++		struct process *tmp, *ttmp;
++
++		tmp = malloc(sizeof(struct process));
++		memcpy(tmp, &processes[i], sizeof(struct process));
++		tmp->name = strndup(processes[i].name, text_buffer_size);
++
++		ttmp = time[i];
++		time[i] = tmp;
++		if (ttmp != NULL) {
++			free(ttmp->name);
++			free(ttmp);
++		}
++	}
++
++	for (i = 0; i < j; i++) {
++		free(processes[i].name);
++	}
++	free(processes);
++}
++
++void get_battery_short_status(char *buffer, unsigned int n, const char *bat)
++{
++	get_battery_stuff(buffer, n, bat, BATTERY_STATUS);
++	if (0 == strncmp("charging", buffer, 8)) {
++		buffer[0] = 'C';
++		memmove(buffer + 1, buffer + 8, n - 8);
++	} else if (0 == strncmp("discharging", buffer, 11)) {
++		buffer[0] = 'D';
++		memmove(buffer + 1, buffer + 11, n - 11);
++	} else if (0 == strncmp("absent/on AC", buffer, 12)) {
++		buffer[0] = 'A';
++		memmove(buffer + 1, buffer + 12, n - 12);
++	}
++}
++
++/* dummies */
++int get_entropy_avail(unsigned int *val)
++{
++	(void)val;
++	return 1;
++}
++
++int get_entropy_poolsize(unsigned int *val)
++{
++	(void)val;
++	return 1;
++}

--- a/ports/sysutils/conky/dragonfly/patch-src_dragonfly.h
+++ b/ports/sysutils/conky/dragonfly/patch-src_dragonfly.h
@@ -1,0 +1,24 @@
+--- src/dragonfly.h.orig	2015-09-11 10:52:16.572726119 +0300
++++ src/dragonfly.h
+@@ -0,0 +1,21 @@
++/* -*- mode: c; c-basic-offset: 4; tab-width: 4; indent-tabs-mode: t -*- */
++
++#ifndef DRAGONFLY_H_
++#define DRAGONFLY_H_
++
++#include "common.h"
++#include <sys/param.h>
++#include <sys/mount.h>
++#include <sys/ucred.h>
++#include <fcntl.h>
++#include <kvm.h>
++#include <pthread.h>
++#include <stdbool.h>
++
++kvm_t *kd;
++pthread_mutex_t kvm_proc_mutex;
++
++int get_entropy_avail(unsigned int *);
++int get_entropy_poolsize(unsigned int *);
++
++#endif /*DRAGONFLY_H_*/

--- a/ports/sysutils/conky/dragonfly/patch-src_entropy.c
+++ b/ports/sysutils/conky/dragonfly/patch-src_entropy.c
@@ -1,0 +1,11 @@
+--- src/entropy.c.orig	2012-05-04 00:08:27.000000000 +0300
++++ src/entropy.c
+@@ -39,6 +39,8 @@
+ #include "freebsd.h"
+ #elif defined(__OpenBSD__)
+ #include "openbsd.h"
++#elif defined(__DragonFly__)
++#include "dragonfly.h"
+ #endif
+ 
+ static struct {

--- a/ports/sysutils/conky/dragonfly/patch-src_fs.c
+++ b/ports/sysutils/conky/dragonfly/patch-src_fs.c
@@ -1,0 +1,20 @@
+--- src/fs.c.orig	2012-05-04 00:08:27.000000000 +0300
++++ src/fs.c
+@@ -52,7 +52,7 @@
+ #include <sys/mount.h>
+ #endif
+ 
+-#if !defined(HAVE_STRUCT_STATFS_F_FSTYPENAME) && !defined (__OpenBSD__) && !defined(__FreeBSD__)
++#if !defined(HAVE_STRUCT_STATFS_F_FSTYPENAME) && !defined (__OpenBSD__) && !defined(__FreeBSD__) && !defined(__DragonFly__)
+ #include <mntent.h>
+ #endif
+ 
+@@ -138,7 +138,7 @@ static void update_fs_stat(struct fs_sta
+ void get_fs_type(const char *path, char *result)
+ {
+ 
+-#if defined(HAVE_STRUCT_STATFS_F_FSTYPENAME) || defined(__FreeBSD__) || defined (__OpenBSD__)
++#if defined(HAVE_STRUCT_STATFS_F_FSTYPENAME) || defined(__FreeBSD__) || defined (__OpenBSD__) || defined(__DragonFly__)
+ 
+ 	struct statfs s;
+ 	if (statfs(path, &s) == 0) {

--- a/ports/sysutils/conky/dragonfly/patch-src_iconv_tools.c
+++ b/ports/sysutils/conky/dragonfly/patch-src_iconv_tools.c
@@ -1,0 +1,11 @@
+--- src/iconv_tools.c.orig	2012-05-04 00:08:27.000000000 +0300
++++ src/iconv_tools.c
+@@ -81,7 +81,7 @@ void iconv_convert(size_t *a, char *buff
+ 			&& (iconv_cd[iconv_selected - 1] != (iconv_t) (-1))) {
+ 		int bytes;
+ 		size_t dummy1, dummy2;
+-#ifdef __FreeBSD__
++#if defined(__FreeBSD__) || defined(__DragonFly__)
+ 		const char *ptr = buff_in;
+ #else
+ 		char *ptr = buff_in;

--- a/ports/sysutils/conky/dragonfly/patch-src_text_object.h
+++ b/ports/sysutils/conky/dragonfly/patch-src_text_object.h
@@ -1,0 +1,11 @@
+--- srv/text_object.h.orig	2012-05-04 00:08:27.000000000 +0300
++++ src/text_object.h
+@@ -166,7 +166,7 @@ enum text_object_type {
+ 	OBJ_wireless_link_qual_perc,
+ 	OBJ_wireless_link_bar,
+ #endif /* __linux__ */
+-#if defined(__FreeBSD__) || defined(__linux__)
++#if defined(__FreeBSD__) || defined(__linux__) || defined(__DragonFly__)
+ 	OBJ_if_up,
+ #endif
+ 	OBJ_if_empty,


### PR DESCRIPTION
Default .conkyrc config is working.
Currently:
  no disk I/O (devstat fun);
  running proc count stays at 0;
  six digit pid numbers get truncated to just 5 ones.

Port is very complicated due to FreeBSD patches that prevents applying few changes now.
Once those files/* get settled-in (or dropped) and if there would be interest from users
planing to submit dragonfly/* patches upstream for official support.

Would be very glad for patches and feature testing.
Happy ~/.conkyrc pimping!

p.s. port is explicitly made to be upstream-happy(note autogen.sh)