### PR TITLE
D1509 add openimageio

### DIFF
--- a/ports/graphics/luxrender/Makefile.DragonFly
+++ b/ports/graphics/luxrender/Makefile.DragonFly
@@ -1,0 +1,1 @@
+USES+= alias:11

--- a/ports/graphics/openimageio/Makefile.DragonFly
+++ b/ports/graphics/openimageio/Makefile.DragonFly
@@ -1,0 +1,5 @@
+USES+= alias:11
+
+CXXFLAGS+= -D__FreeBSD_version=1300000 -std=gnu++11
+
+CMAKE_ARGS+= -DUSE_CPP11:BOOL=ON

--- a/ports/graphics/openimageio/dragonfly/patch-src_libOpenImageIO_imagebufalgo_draw.cpp
+++ b/ports/graphics/openimageio/dragonfly/patch-src_libOpenImageIO_imagebufalgo_draw.cpp
@@ -1,0 +1,11 @@
+        Patch to allow automatic font search on BSDs
+--- src/libOpenImageIO/imagebufalgo_draw.cpp.orig	2015-06-11 20:25:58.000000000 +0300
++++ src/libOpenImageIO/imagebufalgo_draw.cpp
+@@ -110,6 +110,7 @@ ImageBufAlgo::render_text (ImageBuf &R,
+         search_dirs.push_back (sysroot + "/Fonts");
+     }
+     search_dirs.push_back ("/usr/share/fonts");
++    search_dirs.push_back ("/usr/local/share/fonts");
+     search_dirs.push_back ("/Library/Fonts");
+     search_dirs.push_back ("C:/Windows/Fonts");
+     search_dirs.push_back ("/opt/local/share/fonts");

--- a/ports/graphics/openimageio/dragonfly/patch-src_libutil_ustring.cpp
+++ b/ports/graphics/openimageio/dragonfly/patch-src_libutil_ustring.cpp
@@ -1,0 +1,12 @@
+  XXX yup _GLIBCXX_USE_CXX11_ABI change, pending upstream proper fix
+--- src/libutil/ustring.cpp.orig	2014-11-25 07:10:44.000000000 +0200
++++ src/libutil/ustring.cpp
+@@ -183,7 +183,7 @@ ustring::TableRep::TableRep (string_view
+     // the std::string to make it point to our chars!  In such a case, the
+     // destructor will be careful not to allow a deallocation.
+ 
+-#if defined(__GNUC__) && !defined(_LIBCPP_VERSION)
++#if defined(__GNUC__) && !defined(_LIBCPP_VERSION) && !defined(__DragonFly__)
+     // It turns out that the first field of a gcc std::string is a pointer
+     // to the characters within the basic_string::_Rep.  We merely redirect
+     // that pointer, though for std::string to function properly, the chars

--- a/ports/graphics/openimageio/dragonfly/patch-src_make_detectplatform.mk
+++ b/ports/graphics/openimageio/dragonfly/patch-src_make_detectplatform.mk
@@ -1,0 +1,14 @@
+--- src/make/detectplatform.mk.orig	2014-11-25 07:10:44.000000000 +0200
++++ src/make/detectplatform.mk
+@@ -59,6 +59,11 @@ ifeq (${platform},unknown)
+     platform := macosx
+   endif
+ 
++  # DragonFly BSD
++  ifeq (${uname},dragonfly)
++    platform := dragonfly
++  endif
++
+   # If we haven't been able to determine the platform from uname, use
+   # whatever is in $ARCH, if it's set.
+   ifeq (${platform},unknown)


### PR DESCRIPTION
This hopefully brings one step closer to building graphics/blender and LuxMark (OpenCL benchmark) on DragonFly.
Includes font directory search patch in /usr/local/share/fonts.