### PR TITLE
D1509 fix ti group

### DIFF
--- a/ports/comms/libticables2/Makefile.DragonFly
+++ b/ports/comms/libticables2/Makefile.DragonFly
@@ -1,0 +1,5 @@
+
+dfly-patch:
+# this one to avoid adding "x86_64" directly to CFLAGS (instead of -D__BSD__)
+	${REINPLACE_CMD} -e 's@\(\*-\*-\*bsd\*\))@\1|*-*-dragonfly*)@g'	\
+		${WRKSRC}/configure

--- a/ports/comms/libticalcs2/Makefile.DragonFly
+++ b/ports/comms/libticalcs2/Makefile.DragonFly
@@ -1,0 +1,5 @@
+
+dfly-patch:
+# this one to avoid adding "x86_64" directly to CFLAGS (instead of -D__BSD__)
+	${REINPLACE_CMD} -e 's@\(\*-\*-\*bsd\*\))@\1|*-*-dragonfly*)@g'	\
+		${WRKSRC}/configure

--- a/ports/comms/tilp2/Makefile.DragonFly
+++ b/ports/comms/tilp2/Makefile.DragonFly
@@ -1,0 +1,5 @@
+
+dfly-patch:
+# this one to avoid adding "x86_64" directly to CFLAGS (instead of -D__BSD__)
+	${REINPLACE_CMD} -e 's@\(\*-\*-\*bsd\*\))@\1|*-*-dragonfly*)@g'	\
+		${WRKSRC}/configure

--- a/ports/devel/libtifiles2/Makefile.DragonFly
+++ b/ports/devel/libtifiles2/Makefile.DragonFly
@@ -1,0 +1,5 @@
+
+dfly-patch:
+# this one to avoid adding "x86_64" directly to CFLAGS (instead of -D__BSD__)
+	${REINPLACE_CMD} -e 's@\(\*-\*-\*bsd\*\))@\1|*-*-dragonfly*)@g'	\
+		${WRKSRC}/configure

--- a/ports/emulators/tiemu3/Makefile.DragonFly
+++ b/ports/emulators/tiemu3/Makefile.DragonFly
@@ -1,0 +1,5 @@
+
+dfly-patch:
+# this one to avoid adding "x86_64" directly to CFLAGS (instead of -D__BSD__)
+	${REINPLACE_CMD} -e 's@\(\*-\*-\*bsd\*\))@\1|*-*-dragonfly*)@g'	\
+		${WRKSRC}/configure


### PR DESCRIPTION
Simple fix with regex, hard with patches.
Idea is to include dragonfly ARCH under \*-\*-\*bsd\* group.
This changes -D__LINUX__ --> -D__BSD__ (for now mostly was cosmetic).
Also prevents wrongly dumping x86_64 directly to CFLAGS (libticables2).