### PR TITLE
sysutils/freeipmi: add alias

### DIFF
--- a/ports/sysutils/freeipmi/Makefile.DragonFly
+++ b/ports/sysutils/freeipmi/Makefile.DragonFly
@@ -1,0 +1,1 @@
+USES+= alias:11


### PR DESCRIPTION
Sadly cannot test actual connection to bmc, network separation issue.
Still looks promising.