### PR TITLE
x11-fm/xplore: disable build

### DIFF
--- a/ports/x11-fm/xplore/Makefile.DragonFly
+++ b/ports/x11-fm/xplore/Makefile.DragonFly
@@ -1,0 +1,1 @@
+BROKEN= segfaults on widgets in libXt.so


### PR DESCRIPTION
While it can compile and run
it segfaults in libXt.so when changing shelfs.
Also there are better alternatives anyway.