### PR TITLE
sysutils/pax-utils: add few extra __DragonFly__

### DIFF
--- a/ports/sysutils/pax-utils/dragonfly/patch-porting.h
+++ b/ports/sysutils/pax-utils/dragonfly/patch-porting.h
@@ -1,0 +1,18 @@
+--- porting.h.orig	2013-04-08 00:01:36.000000000 +0300
++++ porting.h
+@@ -36,13 +36,13 @@
+ #include <sys/stat.h>
+ #include <sys/types.h>
+ #include "elf.h"
+-#if !defined(__FreeBSD__) && !defined(__OpenBSD__)
++#if !defined(__FreeBSD__) && !defined(__DragonFly__) && !defined(__OpenBSD__)
+ # include <alloca.h>
+ #endif
+ #if defined(__GLIBC__) || defined(__UCLIBC__)
+ # include <byteswap.h>
+ # include <endian.h>
+-#elif defined(__FreeBSD__)
++#elif defined(__FreeBSD__) || defined(__DragonFly__)
+ # include <sys/endian.h>
+ #elif defined(__sun__)
+ # include <sys/isa_defs.h>


### PR DESCRIPTION
gmake test: (port needs bash shebangfix and gsed) for now only manual
  PASS: scanelf.simple
  PASS: lddtree.sh.smoke
  PASS: src.typos
  PASS: src.obsolete.funcs
  PASS: src.bad.constants
  PASS: src.obsolete.headers
  PASS: src.use.xfuncs
  PASS: src.style
  PASS: src.space