### PR TITLE
x11-themes/qtcurve-qt45: fix std::isnan issue

### DIFF
--- a/ports/x11-themes/qtcurve/Makefile.DragonFly
+++ b/ports/x11-themes/qtcurve/Makefile.DragonFly
@@ -1,0 +1,5 @@
+
+dfly-patch:
+	-${REINPLACE_CMD} -e 's/[[:<:]]isinf[[:>:]]/std::isinf/g'	\
+			  -e 's/[[:<:]]isnan[[:>:]]/std::isnan/g'	\
+		${WRKSRC}/lib/utils/color.h


### PR DESCRIPTION
Nothing better came in mind.

First rebuild:
x11-themes/qtcurve (to fetch Makefile.DragonFly)

Only then try:
x11-themes/qtcurve-qt4
x11-themes/qtcurve-qt5