### PR TITLE
games/openspades: cmath fix

### DIFF
--- a/ports/games/openspades/Makefile.DragonFly
+++ b/ports/games/openspades/Makefile.DragonFly
@@ -1,0 +1,12 @@
+
+dfly-patch:
+	${REINPLACE_CMD} -e 's/[[:<:]]isinf[[:>:]]/std::isinf/g'	\
+			 -e 's/[[:<:]]isnan[[:>:]]/std::isnan/g'	\
+		${WRKSRC}/Sources/Client/Client_Input.cpp		\
+		${WRKSRC}/Sources/Client/Client_Scene.cpp		\
+		${WRKSRC}/Sources/Client/Corpse.cpp			\
+		${WRKSRC}/Sources/Client/GameMap.cpp			\
+		${WRKSRC}/Sources/Client/NetClient.cpp			\
+		${WRKSRC}/Sources/Draw/GLRadiosityRenderer.cpp		\
+		${WRKSRC}/Sources/Draw/GLWaterRenderer.cpp		\
+		${WRKSRC}/Sources/Draw/SWMapRenderer.cpp

--- a/ports/games/openspades/dragonfly/patch-Sources_AngelScript_source_as_memory.cpp
+++ b/ports/games/openspades/dragonfly/patch-Sources_AngelScript_source_as_memory.cpp
@@ -1,0 +1,11 @@
+--- Sources/AngelScript/source/as_memory.cpp.orig	2014-06-23 14:55:03.000000000 +0300
++++ Sources/AngelScript/source/as_memory.cpp
+@@ -38,7 +38,7 @@
+ 
+ #include <stdlib.h>
+ 
+-#if !defined(__APPLE__) && !defined( __SNC__ ) && !defined( __ghs__ ) && !defined(__FreeBSD__)
++#if !defined(__APPLE__) && !defined( __SNC__ ) && !defined( __ghs__ ) && !defined(__FreeBSD__) && !defined(__DragonFly__)
+ #include <malloc.h>
+ #endif
+ 

--- a/ports/games/openspades/dragonfly/patch-Sources_ENet_unix.c
+++ b/ports/games/openspades/dragonfly/patch-Sources_ENet_unix.c
@@ -1,0 +1,20 @@
+--- Sources/ENet/unix.c.orig	2014-06-23 14:55:03.000000000 +0300
++++ Sources/ENet/unix.c
+@@ -80,7 +80,7 @@ enet_address_set_host (ENetAddress * add
+     char buffer [2048];
+     int errnum;
+ 
+-#if defined(linux) || defined(__linux) || defined(__linux__) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
++#if defined(linux) || defined(__linux) || defined(__linux__) || defined(__DragonFly__) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
+     gethostbyname_r (name, & hostData, buffer, sizeof (buffer), & hostEntry, & errnum);
+ #else
+     hostEntry = gethostbyname_r (name, & hostData, buffer, sizeof (buffer), & errnum);
+@@ -133,7 +133,7 @@ enet_address_get_host (const ENetAddress
+ 
+     in.s_addr = address -> host;
+ 
+-#if defined(linux) || defined(__linux) || defined(__linux__) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
++#if defined(linux) || defined(__linux) || defined(__linux__) || defined(__DragonFly__) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
+     gethostbyaddr_r ((char *) & in, sizeof (struct in_addr), AF_INET, & hostData, buffer, sizeof (buffer), & hostEntry, & errnum);
+ #else
+     hostEntry = gethostbyaddr_r ((char *) & in, sizeof (struct in_addr), AF_INET, & hostData, buffer, sizeof (buffer), & errnum);


### PR DESCRIPTION
USES+= alias behaves strangely in build system thus patches