### PR TITLE
benchmarks/fio: initial port

### DIFF
--- a/ports/benchmarks/fio/dragonfly/patch-Makefile
+++ b/ports/benchmarks/fio/dragonfly/patch-Makefile
@@ -1,0 +1,13 @@
+--- Makefile.orig	2014-05-13 02:18:13.000000000 +0300
++++ Makefile
+@@ -119,6 +119,10 @@ ifeq ($(CONFIG_TARGET_OS), NetBSD)
+   LIBS	 += -lpthread -lrt
+   LDFLAGS += -rdynamic
+ endif
++ifeq ($(CONFIG_TARGET_OS), DragonFly)
++  LIBS	 += -lpthread -lrt
++  LDFLAGS += -rdynamic
++endif
+ ifeq ($(CONFIG_TARGET_OS), AIX)
+   LIBS	 += -lpthread -ldl -lrt
+   CPPFLAGS += -D_LARGE_FILES -D__ppc__

--- a/ports/benchmarks/fio/dragonfly/patch-libfio.c
+++ b/ports/benchmarks/fio/dragonfly/patch-libfio.c
@@ -1,0 +1,10 @@
+--- libfio.c.orig	2014-05-13 02:18:13.000000000 +0300
++++ libfio.c
+@@ -55,6 +55,7 @@ static const char *fio_os_strings[os_nr]
+ 	"OSX",
+ 	"NetBSD",
+ 	"OpenBSD",
++	"DragonFly",
+ 	"Solaris",
+ 	"Windows",
+ 	"Android",

--- a/ports/benchmarks/fio/dragonfly/patch-os_os-dragonfly.h
+++ b/ports/benchmarks/fio/dragonfly/patch-os_os-dragonfly.h
@@ -1,0 +1,58 @@
+--- /dev/null
++++ os/os-dragonfly.h
+@@ -0,0 +1,55 @@
++#ifndef FIO_OS_DRAGONFLY_H
++#define FIO_OS_DRAGONFLY_H
++
++#define	FIO_OS	os_dragonfly
++
++#include <errno.h>
++#include <sys/sysctl.h>
++#include <sys/param.h>
++
++#include "../file.h"
++
++#define FIO_HAVE_ODIRECT
++#define FIO_USE_GENERIC_BDEV_SIZE
++#define FIO_USE_GENERIC_RAND
++#define FIO_USE_GENERIC_INIT_RANDOM_STATE
++#define FIO_HAVE_GETTID
++#undef FIO_HAVE_CPU_AFFINITY	/* XXX notyet */
++
++#define OS_MAP_ANON		MAP_ANON
++
++#ifndef PTHREAD_STACK_MIN
++#define PTHREAD_STACK_MIN 4096
++#endif
++
++#define fio_swap16(x)	bswap16(x)
++#define fio_swap32(x)	bswap32(x)
++#define fio_swap64(x)	bswap64(x)
++
++typedef off_t off64_t;
++
++static inline int blockdev_invalidate_cache(struct fio_file *f)
++{
++	return EINVAL;
++}
++
++static inline unsigned long long os_phys_mem(void)
++{
++	int mib[2] = { CTL_HW, HW_PHYSMEM };
++	unsigned long long mem;
++	size_t len = sizeof(mem);
++
++	sysctl(mib, 2, &mem, &len, NULL, 0);
++	return mem;
++}
++
++static inline int gettid(void)
++{
++	return lwp_gettid();
++}
++
++#ifdef MADV_FREE
++#define FIO_MADV_FREE	MADV_FREE
++#endif
++
++#endif

--- a/ports/benchmarks/fio/dragonfly/patch-os_os.h
+++ b/ports/benchmarks/fio/dragonfly/patch-os_os.h
@@ -1,0 +1,19 @@
+--- os/os.h.orig	2014-05-13 02:18:13.000000000 +0300
++++ os/os.h
+@@ -18,6 +18,7 @@ enum {
+ 	os_mac,
+ 	os_netbsd,
+ 	os_openbsd,
++	os_dragonfly,
+ 	os_solaris,
+ 	os_windows,
+ 	os_android,
+@@ -35,6 +36,8 @@ enum {
+ #include "os-openbsd.h"
+ #elif defined(__NetBSD__)
+ #include "os-netbsd.h"
++#elif defined(__DragonFly__)
++#include "os-dragonfly.h"
+ #elif defined(__sun__)
+ #include "os-solaris.h"
+ #elif defined(__APPLE__)


### PR DESCRIPTION
WARNING: and you thought dd was dangerous ;)

Adapted from os-openbsd.h, basic functionality seems to be working:

$ cat random-read-test.fio
; radon read test on ufs mount
[random-read]
rw=randread
size=2g
directory=/zzz/zrj

$ fio random-read-test.fio
fio: this platform does not support process shared mutexes, forcing use of threads. Use the 'thread' option to get rid of this warning.
random-read: (g=0): rw=randread, bs=4K-4K/4K-4K/4K-4K, ioengine=sync, iodepth=1
fio-2.1.9
Starting 1 thread
random-read: Laying out IO file(s) (1 file(s) / 2048MB)
Jobs: 1 (f=1): [r] [92.3% done] [182.5MB/0KB/0KB /s] [46.7K/0/0 iops] [eta 00m:01s]
random-read: (groupid=0, jobs=1): err= 0: pid=2: Sun Sep 20 11:20:29 2015
  read : io=2048.0MB, bw=179628KB/s, iops=44906, runt= 11675msec
    clat (usec): min=1, max=782, avg=21.34, stdev=12.57
     lat (usec): min=1, max=782, avg=21.39, stdev=12.57
    clat percentiles (usec):
     |  1.00th=[    2],  5.00th=[    2], 10.00th=[    2], 20.00th=[   11],
     | 30.00th=[   21], 40.00th=[   27], 50.00th=[   27], 60.00th=[   27],
     | 70.00th=[   27], 80.00th=[   27], 90.00th=[   28], 95.00th=[   28],
     | 99.00th=[   28], 99.50th=[   28], 99.90th=[   39], 99.95th=[   63],
     | 99.99th=[  580]
    bw (KB  /s): min=152072, max=309008, per=98.18%, avg=176351.65, stdev=39786.99
    lat (usec) : 2=0.57%, 4=12.05%, 10=0.02%, 20=16.95%, 50=70.36%
    lat (usec) : 100=0.01%, 250=0.03%, 500=0.01%, 750=0.02%, 1000=0.01%
  cpu          : usr=12.57%, sys=87.53%, ctx=1209, majf=0, minf=10
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued    : total=r=524288/w=0/d=0, short=r=0/w=0/d=0
     latency   : target=0, window=0, percentile=100.00%, depth=1

Run status group 0 (all jobs):
   READ: io=2048.0MB, aggrb=179627KB/s, minb=179627KB/s, maxb=179627KB/s, mint=11675msec, maxt=11675msec