### PR TITLE
benchmarks/iorate: add alias

### DIFF
--- a/ports/benchmarks/iorate/Makefile.DragonFly
+++ b/ports/benchmarks/iorate/Makefile.DragonFly
@@ -1,0 +1,1 @@
+USES+= alias


### PR DESCRIPTION
$ iorate # on simple config int tmpfs
iorate: Starting IORATE (iorate) version 3.05

 - - - - - - Log of Devices Data from 'devices.ior'- - - - - -

 Device 1 = "/tmp/zrj/trash1.dat"  offset 8KB capacity 2.10GB  block size 512B ;

 - - - - - - End of Devices Data - - - - - -

$ cat iorate.perf
test_number     test_name       device_num      device_name     total_sec       measured_sec    reads   KB_read read_resp       writes  KB_written      write_resp      total_I/Os      total_KB        total_resp      I/Os_per_sec    KB_per_sec      dev_copy
1        2k Bus Test    1       /tmp/zrj/trash1.dat     130     100     34540422        69080844        0.001   0       0       0.000   34540422        69080844        0.001   345404  690808  1
2        8k Bus Test    1       /tmp/zrj/trash1.dat     130     100     28928511        231428088       0.001   0       0       0.000   28928511        231428088       0.001   289285  2314280 1