### PR TITLE
benchmarks/libmicro: add it or not?

### DIFF
--- a/ports/benchmarks/libmicro/Makefile.DragonFly
+++ b/ports/benchmarks/libmicro/Makefile.DragonFly
@@ -1,0 +1,18 @@
+USES+= alias
+
+# zrj disable some tests for now in bench.sh
+dfly-patch:
+	${LN} -sv ${WRKSRC}/Makefile.FreeBSD ${WRKSRC}/Makefile.DragonFly
+	${REINPLACE_CMD} -e 's@\(\[ F"\`uname -s\`" = F"FreeBSD" \]\)@\1 \|\| \[ F"\`uname -s\`" = F"DragonFly" \]@g'	\
+			 -e '/c_lockf_10/s@cascade_lockf@#cascade_lockf@g'	\
+			 -e '/c_lockf_200/s@cascade_lockf@#cascade_lockf@g'	\
+			 -e '/c_flock_10/s@cascade_flock@#cascade_flock@g'	\
+			 -e '/c_flock_200/s@cascade_flock@#cascade_flock@g'	\
+			 -e '/c_fcntl_10/s@cascade_fcntl@#cascade_fcntl@g'	\
+			 -e '/c_fcntl_200/s@cascade_fcntl@#cascade_fcntl@g'	\
+			 -e '/fork_10/s@fork@#fork@g'				\
+			 -e '/exit_10/s@exit@#exit@g'				\
+			 -e '/close_tcp/s@close_tcp@#close_tcp@g'		\
+		${WRKSRC}/bench.sh
+	${REINPLACE_CMD} -e 's@jmp_buf@sigjmp_buf@g'			\
+		${WRKSRC}/siglongjmp.c


### PR DESCRIPTION
Not sure if working correctly. Had to disable few tests.
libmicro_bench output: http://sprunge.us/LTPc