### PR TITLE
japanese/Wnn6-lib: add .so.2.0 to list too

### DIFF
--- a/ports/japanese/Wnn6-lib/diffs/pkg-plist.diff
+++ b/ports/japanese/Wnn6-lib/diffs/pkg-plist.diff
@@ -1,0 +1,7 @@
+--- pkg-plist.orig	2015-08-28 12:02:27.000000000 +0300
++++ pkg-plist
+@@ -24,3 +24,4 @@ lib/libwnn6_fromsrc.a
+ lib/libwnn6.a
+ lib/libwnn6.so
+ lib/libwnn6.so.2
++lib/libwnn6.so.2.0


### PR DESCRIPTION
Avoids installing libs with broken symlinks.
Also satisfies LIB_DEPEND for japanese/esecanna-module-wnn6