### PR TITLE
x11-themes/qtcurve: prune isnan patch

### DIFF
--- a/ports/x11-themes/qtcurve/Makefile.DragonFly
+++ b/ports/x11-themes/qtcurve/Makefile.DragonFly
@@ -1,5 +1,0 @@
-
-dfly-patch:
-	-${REINPLACE_CMD} -e 's/[[:<:]]isinf[[:>:]]/std::isinf/g'	\
-			  -e 's/[[:<:]]isnan[[:>:]]/std::isnan/g'	\
-		${WRKSRC}/lib/utils/color.h


### PR DESCRIPTION
Untested.
Seems no longer needed, should unbreak qtcurve-gtk2/qtcurve-kde4 builds.