### PR TITLE
multimedia/mpv: add options by default

### DIFF
--- a/ports/multimedia/mpv/Makefile.DragonFly
+++ b/ports/multimedia/mpv/Makefile.DragonFly
@@ -1,0 +1,5 @@
+OPTIONS_DEFAULT+= VAAPI VDPAU OPENGL
+
+dfly-patch:
+	${REINPLACE_CMD} -e 's@\(\.stop_screensaver = \)1@\10@g'	\
+		${WRKSRC}/options/options.c


### PR DESCRIPTION
While there disable stop_screensaver by default for now.
It causes problems with i915kms driver.