### PR TITLE
x11/nxcomp: add alias

### DIFF
--- a/ports/x11/nxcomp/Makefile.DragonFly
+++ b/ports/x11/nxcomp/Makefile.DragonFly
@@ -1,0 +1,3 @@
+USES+= alias
+
+CONFIGURE_ARGS+= nxconf_cv_freebsd=yes


### PR DESCRIPTION
Doesn't crash, should allow to build Skipped ports