### PR TITLE
net/netwib: alias to FreeBSD sys-platform

### DIFF
--- a/ports/net/netwib/Makefile.DragonFly
+++ b/ports/net/netwib/Makefile.DragonFly
@@ -1,0 +1,4 @@
+
+dfly-patch:
+	${REINPLACE_CMD} -e 's@\("FreeBSD" )\)@"DragonFly"|\1@g'	\
+		${WRKSRC}/genemake


### PR DESCRIPTION
Builds, tools run, but couldn't figure out how to get /dev/bpf0.