### PR TITLE
lang/nx: tcl fix

### DIFF
--- a/ports/lang/nx/Makefile.DragonFly
+++ b/ports/lang/nx/Makefile.DragonFly
@@ -1,0 +1,5 @@
+
+# must be invoked after autotools but before configure step
+run-autotools-fixup:
+	${REINPLACE_CMD} -e 's@\(FreeBSD-\*\)@\1|DragonFly-*@g'		\
+		${WRKSRC}/configure


### PR DESCRIPTION
  Regression Test Summary:
        Environment: Tcl 8.6.4, OS DragonFly 4.3-DEVELOPMENT machine x86_64 threaded 1.
        NSF performed 4844 tests in 45 files, success 4844, failures 0 in 10.229 seconds
        Congratulations, NSF 2.0b5, NX 2.0b5, and XOTcl 2.0b5 work fine in your environment.