### PR TITLE
databases/grass: try compile

### DIFF
--- a/ports/databases/grass/Makefile.DragonFly
+++ b/ports/databases/grass/Makefile.DragonFly
@@ -1,0 +1,5 @@
+USES+= alias
+
+dfly-patch:
+	${REINPLACE_CMD} -e 's@\(FreeBSD-\*\))@\1|DragonFly-*)@g'	\
+		${WRKSRC}/configure


### PR DESCRIPTION
Very Very strange port, requires half of python ports.
At least it installed and grass64 launched graphical GUI.