### PR TITLE
net/xisp: predefine USE_OPENSSL

### DIFF
--- a/ports/net/xisp/Makefile.DragonFly
+++ b/ports/net/xisp/Makefile.DragonFly
@@ -1,0 +1,3 @@
+USES+= alias
+
+CFLAGS+= -DUSE_OPENSSL


### PR DESCRIPTION
Requires users in dialer group.
Graphical interface(xisp) starts up