### PR TITLE
mesa/vdpau: try quick fix

### DIFF
--- a/ports/graphics/libGL/diffs/Makefile.common.diff
+++ b/ports/graphics/libGL/diffs/Makefile.common.diff
@@ -8,7 +8,7 @@
  WRKSRC=			${WRKDIR}/mesa-${MESADISTVERSION}
  DESCR=			${.CURDIR}/pkg-descr
  PLIST=			${.CURDIR}/pkg-plist
-@@ -134,8 +135,7 @@ CONFIGURE_ARGS+=--disable-vdpau
+@@ -134,11 +135,12 @@ CONFIGURE_ARGS+=--disable-vdpau
  PLIST_SUB+=     VDPAU="@comment "
  .endif
  
@@ -18,3 +18,8 @@
  CONFIGURE_ARGS+=--disable-vdpau
  .else
  CONFIGURE_ARGS+=--enable-vdpau
++LIB_DEPENDS+=   libvdpau.so:${PORTSDIR}/multimedia/libvdpau
++PLIST_SUB+=     VDPAU=""
+ .endif
+ 
+ ALL_DRI_DRIVERS=I915 I965 R200 RADEON SWRAST


### PR DESCRIPTION
Should be enough to build all meta ports
and don't complicate them.
(untested, nuked /usr instead of /usr/obj *FACEPALM*)