### PR TITLE
mesa/vdpau: package radeon vdpau libs in dri

### DIFF
--- a/ports/graphics/libGL/diffs/Makefile.common.diff
+++ b/ports/graphics/libGL/diffs/Makefile.common.diff
@@ -8,7 +8,13 @@
  WRKSRC=			${WRKDIR}/mesa-${MESADISTVERSION}
  DESCR=			${.CURDIR}/pkg-descr
  PLIST=			${.CURDIR}/pkg-plist
-@@ -134,11 +135,12 @@ CONFIGURE_ARGS+=--disable-vdpau
+@@ -129,21 +130,22 @@ IGNORE= VDPAU option requires GALLIUM su
+ CONFIGURE_ARGS+=--enable-vdpau
+ LIB_DEPENDS+=   libvdpau.so:${PORTSDIR}/multimedia/libvdpau
+ PLIST_SUB+=     VDPAU=""
+-.else
++# see bellow .else
+ CONFIGURE_ARGS+=--disable-vdpau
  PLIST_SUB+=     VDPAU="@comment "
  .endif
  

--- a/ports/graphics/libGL/diffs/Makefile.common.diff
+++ b/ports/graphics/libGL/diffs/Makefile.common.diff
@@ -13,7 +13,7 @@
  LIB_DEPENDS+=   libvdpau.so:${PORTSDIR}/multimedia/libvdpau
  PLIST_SUB+=     VDPAU=""
 -.else
-+# see bellow .else
++# for now disable too .else
  CONFIGURE_ARGS+=--disable-vdpau
  PLIST_SUB+=     VDPAU="@comment "
  .endif


### PR DESCRIPTION
Missed this hunk, vdpau libs were compiled but
VDPAU="@comment" took precedence against VDPAU="" in PLIST_SUB
thus radeon vdpau libs were not packaged.