### PR TITLE
devel/libosmo-sccp: fix libosmo endian.h

### DIFF
--- a/ports/devel/libosmocore/dragonfly/patch-include_osmocom_core_endian.h
+++ b/ports/devel/libosmocore/dragonfly/patch-include_osmocom_core_endian.h
@@ -1,0 +1,11 @@
+--- include/osmocom/core/endian.h.orig	2015-08-23 18:39:14.000000000 +0300
++++ include/osmocom/core/endian.h
+@@ -12,7 +12,7 @@
+  *
+  */
+ 
+-#if defined(__FreeBSD__)
++#if defined(__FreeBSD__) || defined(__DragonFly__)
+ #include <sys/endian.h>
+         #if BYTE_ORDER == LITTLE_ENDIAN
+                 #define OSMO_IS_LITTLE_ENDIAN           1


### PR DESCRIPTION
Since osmocom/core/endian.h is installed into local
USES+= alias doesn't help and actual patch is needed.