### PR TITLE
www/dfileserver: add with simple fix for sort

### DIFF
--- a/ports/www/dfileserver/dragonfly/patch-src_DirectoryIndexing.cxx
+++ b/ports/www/dfileserver/dragonfly/patch-src_DirectoryIndexing.cxx
@@ -1,0 +1,11 @@
+--- src/DirectoryIndexing.cxx.orig	2005-10-04 10:45:52.000000000 +0300
++++ src/DirectoryIndexing.cxx
+@@ -46,6 +46,8 @@
+ #include <fstream>
+ #include <vector>
+ #include <set>
++// for sort()
++#include <algorithm>
+ 
+ #include "Version.hxx"
+ 


### PR DESCRIPTION
Missing algorithm include for sort().

Running gives:
  Listening on port: 2000