### PR TITLE
sysutils/bacula: just a compile fix

### DIFF
--- a/ports/sysutils/bacula-server/Makefile.DragonFly
+++ b/ports/sysutils/bacula-server/Makefile.DragonFly
@@ -1,3 +1,6 @@
 USES+=			readline
-CONFIGURE_ARGS+= 	--with-readline=${LOCALBASE}/include/readline
 CONFIGURE_ENV+=		ac_cv_header_regex_h=no
+
+CONFIGURE_ARGS+=	--disable-xattr
+CPPFLAGS:=		-I${LOCALBASE}/include/readline ${CPPFLAGS}
+CFLAGS:=		-I${LOCALBASE}/include/readline ${CFLAGS}

--- a/ports/sysutils/bacula-server/dragonfly/patch-configure
+++ b/ports/sysutils/bacula-server/dragonfly/patch-configure
@@ -1,0 +1,14 @@
+
+Piggy back on OpenBSD
+
+--- configure.orig	2015-08-13 16:52:24.000000000 +0300
++++ configure
+@@ -16948,7 +16948,7 @@ else
+ fi
+ fi
+ 
+-if test $HAVE_UNAME=yes -a x`uname -s` = xOpenBSD
++if test $HAVE_UNAME=yes && [ x`uname -s` = xOpenBSD -o x`uname -s` = xDragonFly ]
+ then
+ 
+ 


### PR DESCRIPTION
Play dirty with CPPFLAGS, CFLAGS and piggy back on OpenBSD.
As for XATTR support have no idea (simply not familiar),
port should have a proper DragonFly support (if useful)