### PR TITLE
Build wayland-egl support into libEGL

### DIFF
--- a/ports/devel/libdevq/dragonfly/patch-include_libdevq.h
+++ b/ports/devel/libdevq/dragonfly/patch-include_libdevq.h
@@ -1,0 +1,11 @@
+--- include/libdevq.h.orig	2015-10-17 14:25:05 +0200
++++ include/libdevq.h
+@@ -41,6 +41,8 @@
+ 
+ int	devq_device_get_devpath_from_fd(int fd,
+ 	    char *path, size_t *path_len);
++int	devq_device_get_name_from_fd(int fd,
++	    char *name, size_t *name_len);
+ int	devq_device_get_pciid_from_fd(int fd,
+ 	    int *vendor_id, int *device_id);
+ 

--- a/ports/devel/libdevq/dragonfly/patch-src_device.c
+++ b/ports/devel/libdevq/dragonfly/patch-src_device.c
@@ -1,0 +1,90 @@
+--- src/device.c.orig	2015-10-17 14:32:38 +0200
++++ src/device.c
+@@ -187,6 +187,87 @@
+ #endif /* defined(HAVE_LIBPROCSTAT_H) */
+ }
+ 
++int
++devq_device_get_name_from_fd(int fd,
++    char *name, size_t *name_len)
++{
++#if !defined(HAVE_LIBPROCSTAT_H)
++	int ret, found;
++	DIR *dir;
++	struct stat st;
++	struct dirent *dp;
++	char tmp_path[256];
++	size_t tmp_path_len;
++
++	/*
++	 * FIXME: This function is specific to DRM devices.
++	 */
++#define DEVQ_DRIDEV_DIR "/dev/dri"
++
++	ret = fstat(fd, &st);
++	if (ret != 0)
++		return (-1);
++	if (!S_ISCHR(st.st_mode)) {
++		errno = EBADF;
++		return (-1);
++	}
++
++	dir = opendir(DEVQ_DRIDEV_DIR);
++	if (dir == NULL)
++		return (-1);
++
++	found = 0;
++	while ((dp = readdir(dir)) != NULL) {
++		struct stat tmp_st;
++
++		if (dp->d_name[0] == '.')
++			continue;
++
++		tmp_path_len = strlen(DEVQ_DRIDEV_DIR);
++		strcpy(tmp_path, DEVQ_DRIDEV_DIR);
++		tmp_path[tmp_path_len++] = '/';
++		tmp_path[tmp_path_len] = '\0';
++
++		strcpy(tmp_path + tmp_path_len, dp->d_name);
++		tmp_path_len += dp->d_namlen;
++		tmp_path[tmp_path_len] = '\0';
++
++		ret = stat(tmp_path, &tmp_st);
++		if (ret != 0)
++			continue;
++
++		if (st.st_dev  == tmp_st.st_dev &&
++		    st.st_ino  == tmp_st.st_ino) {
++			found = 1;
++			break;
++		}
++	}
++
++	closedir(dir);
++
++	if (!found) {
++		errno = EBADF;
++		return -(1);
++	}
++
++	if (name) {
++		if (*name_len < tmp_path_len) {
++			*name_len = tmp_path_len;
++			errno = ENOMEM;
++			return (-1);
++		}
++
++		/* Cut off the initial "/dev/" part */
++		memcpy(name, tmp_path+5, tmp_path_len-5);
++	}
++	/* Ignore the initial "/dev/" part */
++	if (name_len)
++		*name_len = tmp_path_len-5;
++
++	return (0);
++#endif /* !defined(HAVE_LIBPROCSTAT_H) */
++}
++
+ static int
+ devq_compare_vgapci_busaddr(int i, int *domain, int *bus, int *slot,
+     int *function)

--- a/ports/graphics/dri/diffs/Makefile.diff
+++ b/ports/graphics/dri/diffs/Makefile.diff
@@ -1,0 +1,13 @@
+--- Makefile.orig	2015-10-18 12:53:31 +0200
++++ Makefile
+@@ -15,8 +15,8 @@
+ USE_XORG=	glproto x11 xext xxf86vm xdamage xfixes dri2proto \
+ 		presentproto xvmc xshmfence
+ 
+-OPTIONS_DEFINE=	TEXTURE
+-OPTIONS_DEFAULT=TEXTURE
++OPTIONS_DEFINE=	TEXTURE WAYLAND
++OPTIONS_DEFAULT=TEXTURE WAYLAND
+ 
+ TEXTURE_DESC=	Enable texture-float support (patent encumbered)
+ VDPAU_DESC=	VDPAU (GPU video acceleration) support (needs Gallium)

--- a/ports/graphics/gbm/diffs/Makefile.diff
+++ b/ports/graphics/gbm/diffs/Makefile.diff
@@ -1,0 +1,20 @@
+--- Makefile.orig	2015-10-18 13:32:24 +0200
++++ Makefile
+@@ -19,10 +19,16 @@
+ USE_XORG+=	glproto dri2proto xext xdamage xfixes presentproto \
+ 		xshmfence
+ 
++OPTIONS_DEFINE=		WAYLAND
++OPTIONS_DEFAULT=	WAYLAND
++
+ .include <bsd.port.options.mk>
+ .include "${.CURDIR}/../../graphics/libGL/Makefile.common"
+ 
+-MESA_BUILD_WRKSRC=	src/mapi src/gbm
++.if ${PORT_OPTIONS:MWAYLAND}
++MESA_BUILD_WRKSRC=	src/egl/wayland/wayland-drm
++.endif
++MESA_BUILD_WRKSRC+=	src/mapi src/gbm
+ MESA_INSTALL_WRKSRC=	src/gbm
+ 
+ .include "${.CURDIR}/../../graphics/libGL/Makefile.targets"

--- a/ports/graphics/libEGL/diffs/Makefile.diff
+++ b/ports/graphics/libEGL/diffs/Makefile.diff
@@ -1,27 +1,24 @@
---- Makefile.orig	2015-10-05 22:48:07 +0200
+--- Makefile.orig	2015-10-18 13:47:05 +0200
 +++ Makefile
-@@ -11,7 +11,9 @@
- LIB_DEPENDS+=	libpthread-stubs.so:${PORTSDIR}/devel/libpthread-stubs \
- 		libexpat.so:${PORTSDIR}/textproc/expat2 \
- 		libdevq.so:${PORTSDIR}/devel/libdevq \
--		libdrm.so:${PORTSDIR}/graphics/libdrm
-+		libdrm.so:${PORTSDIR}/graphics/libdrm \
-+		libwayland-client.so:${PORTSDIR}/graphics/wayland \
-+		libwayland-server.so:${PORTSDIR}/graphics/wayland
+@@ -20,11 +20,19 @@
+ USE_XORG+=	glproto dri2proto xext xdamage xfixes presentproto \
+ 		xshmfence
  
- USE_GL=		gbm
- USE_XORG=	x11 xau xcb xdmcp
-@@ -23,8 +25,11 @@
++OPTIONS_DEFINE=		WAYLAND
++OPTIONS_DEFAULT=	WAYLAND
++
  .include <bsd.port.options.mk>
  .include "${.CURDIR}/../../graphics/libGL/Makefile.common"
  
 -MESA_BUILD_WRKSRC=	src/mapi src/gbm src/egl/drivers/dri2 src/egl/main
 -MESA_INSTALL_WRKSRC=	src/egl/drivers/dri2 src/egl/main
++.if ${PORT_OPTIONS:MWAYLAND}
 +MESA_BUILD_WRKSRC=	src/egl/wayland/wayland-drm \
-+			src/egl/wayland/wayland-egl \
-+			src/mapi src/gbm src/egl/drivers/dri2 src/egl/main
-+MESA_INSTALL_WRKSRC=	src/egl/wayland/wayland-egl src/egl/drivers/dri2 \
-+			src/egl/main
++			src/egl/wayland/wayland-egl
++MESA_INSTALL_WRKSRC=	src/egl/wayland/wayland-egl
++.endif
++MESA_BUILD_WRKSRC+=	src/mapi src/gbm src/egl/drivers/dri2 src/egl/main
++MESA_INSTALL_WRKSRC+=	src/egl/drivers/dri2 src/egl/main
  
  .include "${.CURDIR}/../../graphics/libGL/Makefile.targets"
  

--- a/ports/graphics/libEGL/diffs/Makefile.diff
+++ b/ports/graphics/libEGL/diffs/Makefile.diff
@@ -1,0 +1,27 @@
+--- Makefile.orig	2015-10-05 22:48:07 +0200
++++ Makefile
+@@ -11,7 +11,9 @@
+ LIB_DEPENDS+=	libpthread-stubs.so:${PORTSDIR}/devel/libpthread-stubs \
+ 		libexpat.so:${PORTSDIR}/textproc/expat2 \
+ 		libdevq.so:${PORTSDIR}/devel/libdevq \
+-		libdrm.so:${PORTSDIR}/graphics/libdrm
++		libdrm.so:${PORTSDIR}/graphics/libdrm \
++		libwayland-client.so:${PORTSDIR}/graphics/wayland \
++		libwayland-server.so:${PORTSDIR}/graphics/wayland
+ 
+ USE_GL=		gbm
+ USE_XORG=	x11 xau xcb xdmcp
+@@ -23,8 +25,11 @@
+ .include <bsd.port.options.mk>
+ .include "${.CURDIR}/../../graphics/libGL/Makefile.common"
+ 
+-MESA_BUILD_WRKSRC=	src/mapi src/gbm src/egl/drivers/dri2 src/egl/main
+-MESA_INSTALL_WRKSRC=	src/egl/drivers/dri2 src/egl/main
++MESA_BUILD_WRKSRC=	src/egl/wayland/wayland-drm \
++			src/egl/wayland/wayland-egl \
++			src/mapi src/gbm src/egl/drivers/dri2 src/egl/main
++MESA_INSTALL_WRKSRC=	src/egl/wayland/wayland-egl src/egl/drivers/dri2 \
++			src/egl/main
+ 
+ .include "${.CURDIR}/../../graphics/libGL/Makefile.targets"
+ 

--- a/ports/graphics/libEGL/diffs/Makefile.diff
+++ b/ports/graphics/libEGL/diffs/Makefile.diff
@@ -1,11 +1,12 @@
 --- Makefile.orig	2015-10-18 13:47:05 +0200
 +++ Makefile
-@@ -20,11 +20,19 @@
+@@ -20,11 +20,20 @@
  USE_XORG+=	glproto dri2proto xext xdamage xfixes presentproto \
  		xshmfence
  
 +OPTIONS_DEFINE=		WAYLAND
 +OPTIONS_DEFAULT=	WAYLAND
++OPTIONS_SUB=		yes
 +
  .include <bsd.port.options.mk>
  .include "${.CURDIR}/../../graphics/libGL/Makefile.common"

--- a/ports/graphics/libEGL/diffs/pkg-plist.diff
+++ b/ports/graphics/libEGL/diffs/pkg-plist.diff
@@ -1,0 +1,11 @@
+--- pkg-plist.orig	2015-10-05 22:48:07 +0200
++++ pkg-plist
+@@ -7,4 +7,8 @@
+ lib/.mesa/libEGL.so
+ lib/.mesa/libEGL.so.1
+ lib/.mesa/libEGL.so.1.0.0
++lib/libwayland-egl.so
++lib/libwayland-egl.so.1
++lib/libwayland-egl.so.1.0.0
+ libdata/pkgconfig/egl.pc
++libdata/pkgconfig/wayland-egl.pc

--- a/ports/graphics/libEGL/diffs/pkg-plist.diff
+++ b/ports/graphics/libEGL/diffs/pkg-plist.diff
@@ -4,8 +4,8 @@
  lib/.mesa/libEGL.so
  lib/.mesa/libEGL.so.1
  lib/.mesa/libEGL.so.1.0.0
-+lib/libwayland-egl.so
-+lib/libwayland-egl.so.1
-+lib/libwayland-egl.so.1.0.0
++%%WAYLAND%%lib/libwayland-egl.so
++%%WAYLAND%%lib/libwayland-egl.so.1
++%%WAYLAND%%lib/libwayland-egl.so.1.0.0
  libdata/pkgconfig/egl.pc
-+libdata/pkgconfig/wayland-egl.pc
++%%WAYLAND%%libdata/pkgconfig/wayland-egl.pc

--- a/ports/graphics/libGL/diffs/Makefile.common.diff
+++ b/ports/graphics/libGL/diffs/Makefile.common.diff
@@ -1,6 +1,6 @@
---- Makefile.common.orig	2015-10-13 19:54:53 UTC
+--- Makefile.common.orig	2015-10-17 16:01:48 +0200
 +++ Makefile.common
-@@ -60,6 +60,7 @@ SHEBANG_FILES+=	src/mapi/mapi_abi.py
+@@ -60,6 +60,7 @@
  
  MASTERDIR=		${.CURDIR}/../../graphics/libGL
  PATCHDIR=		${MASTERDIR}/files
@@ -8,7 +8,17 @@
  WRKSRC=			${WRKDIR}/mesa-${MESADISTVERSION}
  DESCR=			${.CURDIR}/pkg-descr
  PLIST=			${.CURDIR}/pkg-plist
-@@ -129,21 +130,22 @@ IGNORE= VDPAU option requires GALLIUM su
+@@ -75,8 +76,7 @@
+ CONFIGURE_ARGS+=	--enable-gbm
+ 
+ # libEGL, dri and clover need gallium enabled.
+-# the third option in --with-egl-platforms is wayland.
+-CONFIGURE_ARGS+=	--enable-egl --with-egl-platforms=x11,drm
++CONFIGURE_ARGS+=	--enable-egl --with-egl-platforms=x11,drm,wayland
+ 
+ CONFIGURE_ARGS+=	--enable-gles2
+ 
+@@ -129,16 +129,17 @@
  CONFIGURE_ARGS+=--enable-vdpau
  LIB_DEPENDS+=   libvdpau.so:${PORTSDIR}/multimedia/libvdpau
  PLIST_SUB+=     VDPAU=""

--- a/ports/graphics/libGL/diffs/Makefile.common.diff
+++ b/ports/graphics/libGL/diffs/Makefile.common.diff
@@ -1,4 +1,4 @@
---- Makefile.common.orig	2015-10-17 16:01:48 +0200
+--- Makefile.common.orig	2015-10-18 13:38:09 +0200
 +++ Makefile.common
 @@ -60,6 +60,7 @@
  
@@ -8,17 +8,27 @@
  WRKSRC=			${WRKDIR}/mesa-${MESADISTVERSION}
  DESCR=			${.CURDIR}/pkg-descr
  PLIST=			${.CURDIR}/pkg-plist
-@@ -75,8 +76,7 @@
+@@ -75,11 +76,18 @@
  CONFIGURE_ARGS+=	--enable-gbm
  
  # libEGL, dri and clover need gallium enabled.
 -# the third option in --with-egl-platforms is wayland.
--CONFIGURE_ARGS+=	--enable-egl --with-egl-platforms=x11,drm
++.if ${PORT_OPTIONS:MWAYLAND}
 +CONFIGURE_ARGS+=	--enable-egl --with-egl-platforms=x11,drm,wayland
++LIB_DEPENDS+=		libwayland-client.so:${PORTSDIR}/graphics/wayland
++LIB_DEPENDS+=		libwayland-server.so:${PORTSDIR}/graphics/wayland
++.else
+ CONFIGURE_ARGS+=	--enable-egl --with-egl-platforms=x11,drm
++.endif
  
  CONFIGURE_ARGS+=	--enable-gles2
  
-@@ -129,16 +129,17 @@
++WAYLAND_DESC=		Wayland display server support
++
+ # Clover (OpenCL).
+ .if ${OPSYS} == DragonFly || \
+ 	(${OPSYS} == FreeBSD && ${OSVERSION} >= 1000000 && \
+@@ -129,16 +137,17 @@
  CONFIGURE_ARGS+=--enable-vdpau
  LIB_DEPENDS+=   libvdpau.so:${PORTSDIR}/multimedia/libvdpau
  PLIST_SUB+=     VDPAU=""

--- a/ports/graphics/libGL/diffs/Makefile.diff
+++ b/ports/graphics/libGL/diffs/Makefile.diff
@@ -1,0 +1,12 @@
+--- Makefile.orig	2015-10-18 13:35:02 +0200
++++ Makefile
+@@ -15,6 +15,9 @@
+ USE_XORG=	glproto x11 xext xxf86vm xdamage xfixes dri2proto:both \
+ 		presentproto xshmfence
+ 
++OPTIONS_DEFINE=		WAYLAND
++OPTIONS_DEFAULT=	WAYLAND
++
+ .include <bsd.port.options.mk>
+ .include "${.CURDIR}/Makefile.common"
+ 

--- a/ports/graphics/libGL/dragonfly/patch-src_loader_loader.c
+++ b/ports/graphics/libGL/dragonfly/patch-src_loader_loader.c
@@ -1,0 +1,41 @@
+--- src/loader/loader.c.orig	2015-10-17 15:07:35 +0200
++++ src/loader/loader.c
+@@ -546,6 +546,24 @@
+    return (*chip_id >= 0);
+ }
+ 
++static char *
++devq_get_device_name_for_fd(int fd)
++{
++   size_t len;
++   char buf[0x40];
++   char *device_name = NULL;
++   DEVQ_SYMBOL(int, devq_device_get_name_from_fd,
++               (int fd, char *name, size_t *name_len));
++
++   len = sizeof(buf) - 1;
++   memset(buf, 0, sizeof(buf));
++   if (devq_device_get_name_from_fd(fd, buf, &len) == 0) {
++      if (len < sizeof(buf))
++         device_name = strdup(buf);
++   }
++   return device_name;
++}
++
+ #endif
+ 
+ #if !defined(__NOT_HAVE_DRM_H)
+@@ -733,12 +751,9 @@
+       return result;
+ #endif
+ #if HAVE_LIBDEVQ
+-#if 0
+-/* XXX implement this function in libdevq */
+-   if ((result = devq_device_get_name_for_fd(fd)))
++   if ((result = devq_get_device_name_for_fd(fd)))
+       return result;
+ #endif
+-#endif
+    return result;
+ }
+ 

--- a/ports/graphics/weston/newport/Makefile
+++ b/ports/graphics/weston/newport/Makefile
@@ -25,6 +25,7 @@ LIB_DEPENDS=	libxkbcommon.so:${PORTSDIR}/x11/libxkbcommon		\
 		libwayland-server.so:${PORTSDIR}/graphics/wayland	\
 		libwayland-client.so:${PORTSDIR}/graphics/wayland	\
 		libwayland-cursor.so:${PORTSDIR}/graphics/wayland	\
+		libwayland-egl.so:${PORTSDIR}/graphics/libEGL		\
 		libevent.so:${PORTSDIR}/devel/libevent2			\
 		libdrm.so:${PORTSDIR}/graphics/libdrm			\
 		libpng.so:${PORTSDIR}/graphics/png			\
@@ -40,7 +41,7 @@ RUN_DEPENDS=	${LOCALBASE}/lib/libglapi.so.0:${PORTSDIR}/graphics/libglapi
 GNU_CONFIGURE=	YES
 
 CONFIGURE_ARGS+=	--with-libevent=${PREFIX}
-CONFIGURE_ARGS+=	--disable-egl --enable-weston-launch
+CONFIGURE_ARGS+=	--enable-egl --enable-weston-launch
 CONFIGURE_ARGS+=	--enable-drm-compositor --disable-rpi-compositor
 CONFIGURE_ARGS+=	--disable-fbdev-compositor --disable-vaapi-recorder
 CONFIGURE_ARGS+=	--disable-dbus --enable-setuid-install

--- a/ports/graphics/weston/newport/pkg-plist
+++ b/ports/graphics/weston/newport/pkg-plist
@@ -15,9 +15,11 @@ lib/weston/cms-static.so
 lib/weston/desktop-shell.so
 lib/weston/drm-backend.so
 lib/weston/fullscreen-shell.so
+lib/weston/gl-renderer.so
 lib/weston/headless-backend.so
 lib/weston/hmi-controller.so
 lib/weston/ivi-shell.so
+lib/weston/wayland-backend.so
 lib/weston/x11-backend.so
 lib/weston/xwayland.so
 libdata/pkgconfig/weston.pc


### PR DESCRIPTION
gl-renderer stuff can best be tested, by running the nested commpositor. That will use the llvmpipe software gl-renderer from mesa, which is fine for testing. Trying to use hardware acceleration just gives a stuck render ring (on i915kms); or a somewhat working desktop with lots of corruption which causes a hard freeze after a couple of seconds (on radeonkms).