### PR TITLE
devel/libdevq: fix PCI detection for radeon cards

### DIFF
--- a/ports/devel/libdevq/Makefile.DragonFly
+++ b/ports/devel/libdevq/Makefile.DragonFly
@@ -1,0 +1,7 @@
+OPTIONS_DEFAULT=	PROGRAMS
+
+# zrj: fix devq-lsdri on radeons
+dfly-patch:
+	${REINPLACE_CMD} -e 's@busid_format = "pci:%d:%d:%d.%d";@busid_format = "pci:%x:%x:%x.%d";@g'   \
+		${WRKSRC}/src/device.c
+


### PR DESCRIPTION
This 2nd part of patch to correctly get CARD_ID in mesa.
radeonkms before Nov 1 and i915kms are unaffected.
For now use sed to do a substitution to help
with upcoming libEGL devq additions.

While there for now activate PROGRAMS option,
to aid with debugging process (devq_lsdri).