### PR TITLE
graphics/dri: add missing getprogname definition

### DIFF
--- a/ports/graphics/libGL/dragonfly/patch-src_mesa_drivers_dri_common_xmlconfig.c
+++ b/ports/graphics/libGL/dragonfly/patch-src_mesa_drivers_dri_common_xmlconfig.c
@@ -1,0 +1,12 @@
+--- src/mesa/drivers/dri/common/xmlconfig.c.orig	2015-10-03 14:30:41.000000000 +0300
++++ src/mesa/drivers/dri/common/xmlconfig.c
+@@ -59,6 +59,9 @@ extern char *program_invocation_name, *p
+ #elif defined(__NetBSD__) && defined(__NetBSD_Version__) && (__NetBSD_Version__ >= 106000100)
+ #    include <stdlib.h>
+ #    define GET_PROGRAM_NAME() getprogname()
++#elif defined(__DragonFly__)
++#    include <stdlib.h>
++#    define GET_PROGRAM_NAME() getprogname()
+ #elif defined(__APPLE__)
+ #    include <stdlib.h>
+ #    define GET_PROGRAM_NAME() getprogname()


### PR DESCRIPTION
This allows to use per application xml configs
from /usr/local/etc/drirc on DragonFly.