### PR TITLE
security/bro: does something

### DIFF
--- a/ports/security/bro/Makefile.DragonFly
+++ b/ports/security/bro/Makefile.DragonFly
@@ -1,0 +1,7 @@
+
+# zrj: gcc5 w/ -pedantic doesn't pass while leaky clang++36 does
+# DebugCmdInfoConstants.cc:14:7: error: zero-size array 'names'
+CXXFLAGS:= ${CXXFLAGS:N-pedantic}
+
+# zrj: there are few things that need runtime dfly-patch:
+# but gives warnings on nested make[1]

--- a/ports/security/bro/dragonfly/patch-aux_broctl_bin_helpers_top
+++ b/ports/security/bro/dragonfly/patch-aux_broctl_bin_helpers_top
@@ -1,0 +1,10 @@
+--- aux/broctl/bin/helpers/top.orig	2015-09-06 22:43:34.000000000 +0300
++++ aux/broctl/bin/helpers/top
+@@ -9,6 +9,7 @@
+ . `dirname $0`/../broctl-config.sh
+ 
+ cmd_linux='top -b -n 1 | awk "/^ *[0-9]+ /{printf(\"%d %s %s %d %s\\n\", \$1, \$5, \$6, \$9, \$12)}"'
++cmd_dragonfly='top -u -b all | tail -n +5 | awk "/^ *[0-9]+ /{printf(\"%d %s %s %d %s\\n\", \$1, \$4, \$5, \$10, \$11)}"'
+ cmd_freebsd='top -u -b all | tail -n +5 | awk "/^ *[0-9]+ /{printf(\"%d %s %s %d %s\\n\", \$1, \$6, \$7, \$11, \$12)}"'
+ cmd_freebsd_nonsmp='top -u -b all | tail -n +5 | awk "/^ *[0-9]+ /{printf(\"%d %s %s %d %s\\n\", \$1, \$6, \$7, \$10, \$11)}"'
+ cmd_openbsd='top -u -b all | tail -n +5 | awk "/^ *[0-9]+ /{printf(\"%d %s %s %d %s\\n\", \$1, \$5, \$6, \$10, \$11)}"'

--- a/ports/security/bro/dragonfly/patch-src_threading_BasicThread.cc
+++ b/ports/security/bro/dragonfly/patch-src_threading_BasicThread.cc
@@ -1,0 +1,11 @@
+--- src/threading/BasicThread.cc.orig	2015-09-06 22:43:16.000000000 +0300
++++ src/threading/BasicThread.cc
+@@ -59,7 +59,7 @@ void BasicThread::SetOSName(const char*
+ 	pthread_setname_np(arg_name);
+ #endif
+ 
+-#ifdef FREEBSD
++#if defined(FREEBSD) || defined(DRAGONFLY)
+ 	pthread_set_name_np(pthread_self(), arg_name, arg_name);
+ #endif
+ 	}


### PR DESCRIPTION
dumb cmake + dumb cxx

For now do not include -pedantic in CXXFLAGS,
looks like devs use smth to create runtime exception at runtime.

While there fix top(1) wrapper for DragonFly.

Since it is cmake:outsource not tested.
When running configure manually:
_# make test
[ 62%] plugins.bifs-and-scripts ... failed
[ 62%] plugins.hooks ... failed
[ 62%] plugins.api-version-mismatch ... failed
[ 62%] plugins.bifs-and-scripts-install ... failed
[ 62%] plugins.file ... failed
[ 63%] plugins.pktdumper ... failed
[ 63%] plugins.pktsrc ... failed
[ 63%] plugins.init-plugin ... failed
[ 63%] plugins.reader ... failed
[ 64%] plugins.writer ... failed
[ 65%] plugins.protocol ... failed
[ 70%] scripts.base.frameworks.input.raw.stderr ... failed
[ 70%] istate.pybroccoli ... failed
13 of 802 tests failed, 63 skipped
*** Error code 1

Stop.
make[2]: stopped in /usr/obj/dports/security/bro/work/bro-2.4.1/testing/btest
Coverage for 'btest' dir:
2216/3279 (67.6%) Bro script statements covered.
Coverage for 'external' dir:
Complete test suite code coverage:
2216/3279 (67.6%) Bro script statements covered.