### PR TITLE
devel/sdl2pp: fix Werror+pedantic

### DIFF
--- a/ports/devel/sdl2pp/Makefile.DragonFly
+++ b/ports/devel/sdl2pp/Makefile.DragonFly
@@ -1,0 +1,7 @@
+# don't cripple "special" languages on non-crippled systems
+CXXFLAGS:= ${CXXFLAGS:N-D_GLIBCXX_USE_C99}
+
+# since Werror and pedantic don't use non standard extensions [c++14 feauture]
+dfly-patch:
+	${REINPLACE_CMD} -e 's@\[deprecated\]@[gnu::deprecated]@g'	\
+		${WRKSRC}/SDL2pp/Config.hh.in


### PR DESCRIPTION
_# make test
Running tests...
Test project /usr/obj/dports/devel/sdl2pp/work/libSDL2pp-0.10.0
    Start 1: test_pointrect
1/5 Test #1: test_pointrect ...................   Passed    0.01 sec
    Start 2: test_pointrect_constexpr
2/5 Test #2: test_pointrect_constexpr .........   Passed    0.01 sec
    Start 3: test_rwops
3/5 Test #3: test_rwops .......................   Passed    0.01 sec
    Start 4: test_optional
4/5 Test #4: test_optional ....................   Passed    0.01 sec
    Start 5: test_error
5/5 Test #5: test_error .......................   Passed    0.01 sec

100% tests passed, 0 tests failed out of 5

Total Test time (real) =   0.05 sec