### PR TITLE
devel/libdap: remove crippling

### DIFF
--- a/ports/devel/libdap/Makefile.DragonFly
+++ b/ports/devel/libdap/Makefile.DragonFly
@@ -1,0 +1,2 @@
+# zrj: is "${OSVERSION} >= 1100000" on-purpose?
+OSVERSION:=	1


### PR DESCRIPTION
Disable EXTRA_PATCHES+=extra-patch-dds.yy

gmake check:
All 40 tests were successful.
All 29 tests were successful.
All 118 tests were successful.
All 170 tests behaved as expected.
  1: getdap -d http://test.opendap.org/dap/data/nc/fnoc1.nc getdap-testsuite/fnoc1.nc.dds (pass) ok