### PR TITLE
lang/nim: fix build on dragonfly

### DIFF
--- a/ports/lang/nim/Makefile.DragonFly
+++ b/ports/lang/nim/Makefile.DragonFly
@@ -1,0 +1,5 @@
+
+# enforce gcc on myos=freebsd
+dfly-patch:
+	${REINPLACE_CMD} -e '/cc = clang/d' -e '/tlsEmulation:on/d'	\
+		${WRKSRC}/config/nim.cfg


### PR DESCRIPTION
Use gcc on myos=freebsd.
Still full support would be better.