### PR TITLE
Fix build of sysutils/logrotate on DragonFly.

### DIFF
--- a/ports/sysutils/logrotate/Makefile.DragonFly
+++ b/ports/sysutils/logrotate/Makefile.DragonFly
@@ -1,0 +1,4 @@
+USES+=		autoreconf
+GNU_CONFIGURE=	yes
+CPPFLAGS+=	-I${LOCALBASE}/include
+LDFLAGS+=	-L${LOCALBASE}/lib


### PR DESCRIPTION
Use autoreconf and configure to "properly" build this port on DragonFly.

Upstream (FreeBSD ports) uses Makefile from tarball that's marked as "deprecated". And even files/patch-Makefile is partly obsolete, as it duplicates "ifeq" block for FreeBSD.