### PR TITLE
benchmarks/interbench: add DragonFly swap handling

### DIFF
--- a/ports/benchmarks/interbench/dragonfly/patch-interbench.c
+++ b/ports/benchmarks/interbench/dragonfly/patch-interbench.c
@@ -1,0 +1,30 @@
+--- interbench.c.bak	2015-11-30 11:33:37.000000000 +0200
++++ interbench.c
+@@ -46,7 +46,7 @@
+ #include <sys/stat.h>
+ #include <sys/mman.h>
+ #include <sys/wait.h>
+-#ifdef __FreeBSD__
++#if defined(__FreeBSD__) || defined(__DragonFly__)
+ #include <sys/sysctl.h>
+ #endif
+ #include "interbench.h"
+@@ -1160,6 +1160,18 @@ void get_ram(void)
+ 
+ 	ud.ram = pagesize / 1024 * numpages;
+ 	ud.swap = swap / 1024;
++#elif defined(__DragonFly__)
++	long pagesize, numpages;
++	long swap;
++	size_t len = sizeof(swap);
++
++	pagesize = sysconf(_SC_PAGESIZE);
++	numpages = sysconf(_SC_PHYS_PAGES);
++	if (sysctlbyname("vm.swap_size", &swap, &len, NULL, 0) == -1)
++		swap = 0;
++
++	ud.ram = pagesize / 1024 * numpages;
++	ud.swap = swap / 1024 * pagesize;
+ #else
+ #error unsupported operating system
+ #endif


### PR DESCRIPTION
While it looks to be correct, haven't tested swap part
don't have swab enabled systems.

Everything else seems to be correct, if i load system externally
deviations start to be registered.