### PR TITLE
net-im/gloox: fix string > cstring

### DIFF
--- a/ports/net-im/gloox/Makefile.DragonFly
+++ b/ports/net-im/gloox/Makefile.DragonFly
@@ -1,0 +1,4 @@
+
+dfly-patch:
+	${REINPLACE_CMD} -e 's@\<string\>@<cstring>@g'		\
+		${WRKSRC}/src/dns.h


### PR DESCRIPTION
tests:
  tlsgnutls_test fails
GnuTLS error: Insufficient credentials for that request.
test 'anon client/server handshake test' failed
GnuTLS error: The specified session has been invalidated for some reason.