### PR TITLE
Fix multimedia/mplayer with gold linker.

### DIFF
--- a/ports/multimedia/mplayer/Makefile.DragonFly
+++ b/ports/multimedia/mplayer/Makefile.DragonFly
@@ -1,0 +1,2 @@
+dfly-patch:
+	${REINPLACE_CMD} -e 's|binary.ver|disable|' ${WRKSRC}/configure


### PR DESCRIPTION
Apply the same tweak as done for mencoder in commit 3afd9f760+.
Without it, mplayer compiles fine but fails to run with error
'/lib/libc.so.8: Undefined symbol "__progname"'.