### PR TITLE
Fix build of x11-fm/qtfm on DragonFly.

### DIFF
--- a/ports/x11-fm/qtfm/Makefile.DragonFly
+++ b/ports/x11-fm/qtfm/Makefile.DragonFly
@@ -1,0 +1,1 @@
+USES += alias

--- a/ports/x11-fm/qtfm/dragonfly/patch-src_bookmarks.cpp
+++ b/ports/x11-fm/qtfm/dragonfly/patch-src_bookmarks.cpp
@@ -1,0 +1,12 @@
+--- src/bookmarks.cpp.orig	2015-12-03 09:40:56.777665000 +0100
++++ src/bookmarks.cpp	2015-12-03 09:43:44.277709000 +0100
+@@ -96,7 +96,9 @@ void MainWindow::MountWorker::run()
+     struct kevent ki[1];
+     struct timespec to[1] = {{ 0, 100000 }};
+ 
++#ifdef EVFILT_FS
+     EV_SET(ki, 0, EVFILT_FS, EV_ADD, VQ_MOUNT | VQ_UNMOUNT, 0, 0);
++#endif
+     kevent(kq, ki, 1, NULL, 0, NULL);
+ 
+     while (ahead) {


### PR DESCRIPTION
DragonFly is missing EVFILT_FS implementation in kqueue(2). So rather than
checking for mount events inefficiently (for example via getmntinfo(3)),
disable autoBookmarkMounts() feature for now (until there is EVFILT_FS).