### PR TITLE
graphics/devil: fix gcc50 build

### DIFF
--- a/ports/graphics/devil/Makefile.DragonFly
+++ b/ports/graphics/devil/Makefile.DragonFly
@@ -1,3 +1,2 @@
-# does not build with gcc50
-
-USE_GCC=	NOT5
+# needed for my work
+OPTIONS_DEFAULT+= EXR

--- a/ports/graphics/devil/dragonfly/patch-fix-gcc50-build
+++ b/ports/graphics/devil/dragonfly/patch-fix-gcc50-build
@@ -1,0 +1,48 @@
+
+Obtained-from: https://aur.archlinux.org
+
+diff -ru devil-1.7.8/src-IL/src/il_exr.cpp devil-1.7.8a/src-IL/src/il_exr.cpp
+--- src-IL/src/il_exr.cpp	2009-03-08 08:10:09.000000000 +0100
++++ src-IL/src/il_exr.cpp	2015-05-15 18:50:35.700339353 +0200
+@@ -11,6 +11,7 @@
+ //-----------------------------------------------------------------------------
+ 
+ 
++#include "il.h"
+ #include "il_internal.h"
+ #ifndef IL_NO_EXR
+ 
+diff -ru devil-1.7.8/src-IL/src/il_nvidia.cpp devil-1.7.8a/src-IL/src/il_nvidia.cpp
+--- src-IL/src/il_nvidia.cpp	2009-03-08 08:10:09.000000000 +0100
++++ src-IL/src/il_nvidia.cpp	2015-05-15 18:50:46.490308339 +0200
+@@ -11,6 +11,7 @@
+ //-----------------------------------------------------------------------------
+ 
+ 
++#include "il.h"
+ #include "il_internal.h"
+ #include "il_dds.h"
+ #include "il_manip.h"
+diff -ru devil-1.7.8/src-IL/src/il_squish.cpp devil-1.7.8a/src-IL/src/il_squish.cpp
+--- src-IL/src/il_squish.cpp	2009-03-08 08:10:09.000000000 +0100
++++ src-IL/src/il_squish.cpp	2015-05-15 18:56:13.935820622 +0200
+@@ -11,6 +11,7 @@
+ //-----------------------------------------------------------------------------
+ 
+ 
++#include "il.h"
+ #include "il_internal.h"
+ /*#include "il_dds.h"
+ #include "il_manip.h"
+diff -ru devil-1.7.8/src-IL/src/il_utx.cpp devil-1.7.8a/src-IL/src/il_utx.cpp
+--- src-IL/src/il_utx.cpp	2009-03-08 08:10:09.000000000 +0100
++++ src-IL/src/il_utx.cpp	2015-05-15 18:56:33.572405684 +0200
+@@ -12,6 +12,8 @@
+ //
+ //-----------------------------------------------------------------------------
+ 
++
++#include "il.h"
+ #include "il_internal.h"
+ #ifndef IL_NO_UTX
+ #include "il_utx.h"


### PR DESCRIPTION
While there, enable EXR format, needed for my work and it works:
$ ilur -l GrayRampsDiagonal.exr -s result.jpg -a 'iluBlurAvg(6)'

make check:
Formats that were OK: BMP DDS EXR HDR JP2 JPG PCX PNG PPM SGI TGA TIF
Failed formats:  ICO PSD