### PR TITLE
Stabilize x11-fm/qtfm.

### DIFF
--- a/ports/x11-fm/qtfm/dragonfly/patch-src_bookmarks.cpp
+++ b/ports/x11-fm/qtfm/dragonfly/patch-src_bookmarks.cpp
@@ -1,9 +1,10 @@
 --- src/bookmarks.cpp.orig	2015-12-03 09:40:56.777665000 +0100
 +++ src/bookmarks.cpp	2015-12-03 09:43:44.277709000 +0100
-@@ -96,7 +96,9 @@ void MainWindow::MountWorker::run()
+@@ -96,7 +96,10 @@ void MainWindow::MountWorker::run()
      struct kevent ki[1];
      struct timespec to[1] = {{ 0, 100000 }};
  
++    bzero(ki, sizeof(struct kevent));
 +#ifdef EVFILT_FS
      EV_SET(ki, 0, EVFILT_FS, EV_ADD, VQ_MOUNT | VQ_UNMOUNT, 0, 0);
 +#endif


### PR DESCRIPTION
Don't pass uninitialized variable to kevent().

Suggested by: ivadasz