### PR TITLE
graphics/cegui: fix build

### DIFF
--- a/ports/graphics/cegui/Makefile.DragonFly
+++ b/ports/graphics/cegui/Makefile.DragonFly
@@ -1,0 +1,9 @@
+USES+= alias
+
+#CMAKE_ARGS+= -DCEGUI_BUILD_RENDERER_NULL=ON -DCEGUI_BUILD_TESTS=ON
+
+CXXFLAGS+= -I${LOCALBASE}/include
+
+dfly-patch:
+	${REINPLACE_CMD} -e 's@"\(FreeBSD\)"@"\1|DragonFly"@g'		\
+		${WRKSRC}/cegui/src/CMakeLists.txt

--- a/ports/graphics/cegui/dragonfly/patch-cegui_src_System.cpp
+++ b/ports/graphics/cegui/dragonfly/patch-cegui_src_System.cpp
@@ -1,0 +1,11 @@
+--- cegui/src/System.cpp.orig	2014-07-07 10:06:18.000000000 +0300
++++ cegui/src/System.cpp
+@@ -356,6 +356,8 @@ const String& System::getVerboseVersion(
+ 
+ #if defined(__linux__)
+         ret += " GNU/Linux";
++#elif defined(__DragonFly__)
++        ret += " DragonFly";
+ #elif defined (__FreeBSD__)
+         ret += " FreeBSD";
+ #elif defined (__APPLE__)


### PR DESCRIPTION
tests(with null renderer and tests on):
Running tests...
Test project /usr/obj/dports/graphics/cegui/cegui-0.8.4
    Start 1: CEGUITests
1/1 Test #1: CEGUITests .......................   Passed    0.10 sec

100% tests passed, 0 tests failed out of 1