### PR TITLE
benchmarks/interbench: fix swap type on DragonFly

### DIFF
--- a/ports/benchmarks/interbench/dragonfly/patch-interbench.c
+++ b/ports/benchmarks/interbench/dragonfly/patch-interbench.c
@@ -15,7 +15,7 @@
  	ud.swap = swap / 1024;
 +#elif defined(__DragonFly__)
 +	long pagesize, numpages;
-+	long swap;
++	int swap;
 +	size_t len = sizeof(swap);
 +
 +	pagesize = sysconf(_SC_PAGESIZE);


### PR DESCRIPTION
vm.swap_size returns int

Thanks ivadasz!