### PR TITLE
devel/godot: add alias

### DIFF
--- a/ports/devel/godot/Makefile.DragonFly
+++ b/ports/devel/godot/Makefile.DragonFly
@@ -1,0 +1,1 @@
+USES+= alias


### PR DESCRIPTION
Window working but on i915 same intel_uncore stuff
failed wait in intel_do_flush_locked()

Also depends on substitution of ${ARCH}==amd64 => x86_64