### PR TITLE
games/enigma: mark as broken

### DIFF
--- a/ports/games/enigma/Makefile.DragonFly
+++ b/ports/games/enigma/Makefile.DragonFly
@@ -1,0 +1,9 @@
+USE_CXXSTD= c++11
+CXXFLAGS+= -Wno-deprecated-declarations
+
+BROKEN= segfaults: png images need to be recoded for use with png >= 1.6
+
+dfly-patch:
+	${REINPLACE_CMD} -e 's@\(defined (__FreeBSD__)\)@(\1 || defined(__DragonFly__))@g'	\
+		${WRKSRC}/lib-src/zipios++/src/directory.h		\
+		${WRKSRC}/lib-src/zipios++/src/directory.cpp

--- a/ports/games/enigma/dragonfly/patch-lib-src__enigma-core__ecl_util.hh
+++ b/ports/games/enigma/dragonfly/patch-lib-src__enigma-core__ecl_util.hh
@@ -1,0 +1,10 @@
+--- lib-src/enigma-core/ecl_util.hh.orig	2007-09-08 15:20:05.000000000 +0300
++++ lib-src/enigma-core/ecl_util.hh
+@@ -20,6 +20,7 @@
+ #define ECL_UTIL_HH_INCLUDED
+ 
+ #include <string>
++#include <algorithm>
+ 
+ /* hide GNU extensions for non-gnu compilers: */
+ #ifndef __GNU__

--- a/ports/games/enigma/dragonfly/patch-src__Utf8ToXML.hh
+++ b/ports/games/enigma/dragonfly/patch-src__Utf8ToXML.hh
@@ -1,0 +1,10 @@
+--- src/Utf8ToXML.hh.orig	2007-09-08 15:20:02.000000000 +0300
++++ src/Utf8ToXML.hh
+@@ -21,6 +21,7 @@
+ #define ENIGMA_UTF8TOXML_HH
+ 
+ #include <iostream>
++#include <cstring>
+ #include <xercesc/util/XMLString.hpp>
+ 
+ 

--- a/ports/games/enigma/dragonfly/patch-src__file.hh
+++ b/ports/games/enigma/dragonfly/patch-src__file.hh
@@ -1,0 +1,10 @@
+--- src/file.hh.orig	2007-09-08 15:20:02.000000000 +0300
++++ src/file.hh
+@@ -21,6 +21,7 @@
+ 
+ #include <iosfwd>
+ #include <vector>
++#include <memory>
+ #include <list>
+ #include "ecl_error.hh"
+ 


### PR DESCRIPTION
segfaults with png > v1.5 + name conflict with /usr/bin/enigma cypher
libpng error: error message "IDAT: invalid distance too far back" is shown