### PR TITLE
games/cleanq3: mark as broken

### DIFF
--- a/ports/games/cleanq3/Makefile.DragonFly
+++ b/ports/games/cleanq3/Makefile.DragonFly
@@ -1,0 +1,1 @@
+BROKEN= segfaults with bus error


### PR DESCRIPTION
While it could compile, segfaults hard at runtime