### PR TITLE
Add DragonFly support to sysutils/monit.

### DIFF
--- a/ports/sysutils/monit/Makefile.DragonFly
+++ b/ports/sysutils/monit/Makefile.DragonFly
@@ -1,0 +1,1 @@
+USES += autoreconf libtool

--- a/ports/sysutils/monit/dragonfly/patch-configure.ac
+++ b/ports/sysutils/monit/dragonfly/patch-configure.ac
@@ -1,0 +1,32 @@
+--- configure.ac.orig	2015-10-22 15:44:25.000000000 +0200
++++ configure.ac	2015-12-06 11:16:05.510574000 +0100
+@@ -118,6 +118,7 @@ AC_CHECK_HEADERS([ \
+ 	glob.h \
+ 	grp.h \
+ 	ifaddrs.h \
++	kinfo.h \
+ 	kvm.h \
+ 	paths.h \
+ 	kstat.h \
+@@ -375,6 +376,9 @@ AC_CHECK_TYPES([boolean_t], [], [],
+          #ifdef HAVE_VM_VM_H
+          #include <vm/vm.h>
+          #endif
++         #ifdef HAVE_KINFO_H
++         #include <kinfo.h>
++         #endif
+         ])
+ 
+ AC_TYPE_MODE_T
+@@ -571,6 +575,11 @@ then
+    ARCH="NETBSD"
+    CFLAGS="$CFLAGS -D _REENTRANT"
+    test_kvm="true"
++elif test "$architecture" = "DragonFly"
++then
++   ARCH="DRAGONFLY"
++   CFLAGS="$CFLAGS -D _REENTRANT"
++   test_kvm="true"
+ elif test "$architecture" = "Darwin"
+ then
+    ARCH="DARWIN"

--- a/ports/sysutils/monit/dragonfly/patch-libmonit-configure.ac
+++ b/ports/sysutils/monit/dragonfly/patch-libmonit-configure.ac
@@ -1,0 +1,13 @@
+--- libmonit/configure.ac.orig	2015-10-22 15:44:32.000000000 +0200
++++ libmonit/configure.ac	2015-12-05 20:45:08.520394000 +0100
+@@ -192,6 +192,10 @@ elif test "$architecture" = "OpenBSD"
+ then
+    CFLAGS="$CFLAGS -D _REENTRANT"
+    AC_DEFINE([OPENBSD], 1, [Define to 1 if the system is OpenBSD])
++elif test "$architecture" = "DragonFly"
++then
++   CFLAGS="$CFLAGS -D _REENTRANT"
++   AC_DEFINE([DRAGONFLY], 1, [Define to 1 if the system is DragonFly])
+ elif test "$architecture" = "Darwin"
+ then
+    CFLAGS="$CFLAGS -DREENTRANT"

--- a/ports/sysutils/monit/dragonfly/patch-libmonit-src-system-dragonfly-Link.inc
+++ b/ports/sysutils/monit/dragonfly/patch-libmonit-src-system-dragonfly-Link.inc
@@ -1,0 +1,80 @@
+--- libmonit/src/system/os/dragonfly/Link.inc.orig	1970-01-01 01:00:00.000000000 +0100
++++ libmonit/src/system/os/dragonfly/Link.inc	2015-12-05 21:22:04.400620000 +0100
+@@ -0,0 +1,77 @@
++/*
++ * Copyright (C) Tildeslash Ltd. All rights reserved.
++ *
++ * This program is free software: you can redistribute it and/or modify
++ * it under the terms of the GNU Affero General Public License version 3.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU Affero General Public License for more details.
++ *
++ * You should have received a copy of the GNU Affero General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ *
++ * In addition, as a special exception, the copyright holders give
++ * permission to link the code of portions of this program with the
++ * OpenSSL library under certain conditions as described in each
++ * individual source file, and distribute linked combinations
++ * including the two.
++ *
++ * You must obey the GNU Affero General Public License in all respects
++ * for all of the code used other than OpenSSL.  
++ */
++
++
++/**
++ * Implementation of the Network Statistics for DragonFly.
++ *
++ * @author http://www.tildeslash.com/
++ * @see http://www.mmonit.com/
++ * @file
++ */
++
++
++static boolean_t _update(T L, const char *interface) {
++        for (struct ifaddrs *a = _stats.addrs; a != NULL; a = a->ifa_next) {
++                if (a->ifa_addr == NULL)
++                        continue;
++                if (Str_isEqual(interface, a->ifa_name) && a->ifa_addr->sa_family == AF_LINK) {
++                        int s = socket(AF_INET, SOCK_DGRAM, 0);
++                        if (s > 0) {
++                                struct ifmediareq ifmr;
++                                memset(&ifmr, 0, sizeof(ifmr));
++                                strncpy(ifmr.ifm_name, interface, sizeof(ifmr.ifm_name));
++                                // try SIOCGIFMEDIA - if not supported, assume the interface is UP (loopback or other virtual interface)
++                                if (ioctl(s, SIOCGIFMEDIA, (caddr_t)&ifmr) >= 0) {
++                                        if (ifmr.ifm_status & IFM_AVALID && ifmr.ifm_status & IFM_ACTIVE) {
++                                                L->state = 1LL;
++                                                L->duplex = ifmr.ifm_active & 0x00100000 ? 1LL : 0LL;
++                                        } else {
++                                                L->state = 0LL;
++                                                L->duplex = -1LL;
++                                        }
++                                } else {
++                                        L->state = 1LL;
++                                }
++                                close(s);
++                        } else {
++                                L->state = -1LL;
++                                L->duplex = -1LL;
++                        }
++                        struct if_data *data = (struct if_data *)a->ifa_data;
++                        L->timestamp.last = L->timestamp.now;
++                        L->timestamp.now = Time_milli();
++                        L->speed = data->ifi_baudrate;
++                        _updateValue(&(L->ibytes), data->ifi_ibytes);
++                        _updateValue(&(L->ipackets), data->ifi_ipackets);
++                        _updateValue(&(L->ierrors), data->ifi_ierrors);
++                        _updateValue(&(L->obytes), data->ifi_obytes);
++                        _updateValue(&(L->opackets), data->ifi_opackets);
++                        _updateValue(&(L->oerrors), data->ifi_oerrors);
++                        return true;
++                }
++        }
++        return false;
++}
++

--- a/ports/sysutils/monit/dragonfly/patch-src-device-sysdep_DRAGONFLY.c
+++ b/ports/sysutils/monit/dragonfly/patch-src-device-sysdep_DRAGONFLY.c
@@ -1,0 +1,107 @@
+--- src/device/sysdep_DRAGONFLY.c.orig	1970-01-01 01:00:00.000000000 +0100
++++ src/device/sysdep_DRAGONFLY.c	2015-12-05 20:44:45.940189000 +0100
+@@ -0,0 +1,104 @@
++/*
++ * Copyright (C) Tildeslash Ltd. All rights reserved.
++ *
++ * This program is free software: you can redistribute it and/or modify
++ * it under the terms of the GNU Affero General Public License version 3.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU Affero General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ *
++ * In addition, as a special exception, the copyright holders give
++ * permission to link the code of portions of this program with the
++ * OpenSSL library under certain conditions as described in each
++ * individual source file, and distribute linked combinations
++ * including the two.
++ *
++ * You must obey the GNU Affero General Public License in all respects
++ * for all of the code used other than OpenSSL.
++ */
++
++/**
++ *  System dependent filesystem methods.
++ *
++ *  @file
++ */
++
++#include "config.h"
++
++#ifdef HAVE_STDIO_H
++#include <stdio.h>
++#endif
++
++#ifdef HAVE_ERRNO_H
++#include <errno.h>
++#endif
++
++#ifdef HAVE_STRING_H
++#include <string.h>
++#endif
++
++#ifdef HAVE_SYS_PARAM_H
++#include <sys/param.h>
++#endif
++
++#if defined HAVE_SYS_UCRED_H
++#include <sys/ucred.h>
++#endif
++
++#ifdef HAVE_SYS_MOUNT_H
++#include <sys/mount.h>
++#endif
++
++#include "monit.h"
++#include "device_sysdep.h"
++
++char *device_mountpoint_sysdep(char *dev, char *buf, int buflen) {
++        int countfs;
++
++        ASSERT(dev);
++
++        if ((countfs = getfsstat(NULL, 0, MNT_NOWAIT)) != -1) {
++                struct statfs *statfs = CALLOC(countfs, sizeof(struct statfs));
++                if ((countfs = getfsstat(statfs, countfs * sizeof(struct statfs), MNT_NOWAIT)) != -1) {
++                        for (int i = 0; i < countfs; i++) {
++                                struct statfs *sfs = statfs + i;
++                                if (IS(sfs->f_mntfromname, dev)) {
++                                        snprintf(buf, buflen, "%s", sfs->f_mntonname);
++                                        FREE(statfs);
++                                        return buf;
++                                }
++                        }
++                }
++                FREE(statfs);
++        }
++        LogError("Error getting mountpoint for filesystem '%s' -- %s\n", dev, STRERROR);
++        return NULL;
++}
++
++
++boolean_t filesystem_usage_sysdep(char *mntpoint, Info_T inf) {
++        struct statfs usage;
++
++        ASSERT(inf);
++
++        if (statfs(mntpoint, &usage) != 0) {
++                LogError("Error getting usage statistics for filesystem '%s' -- %s\n", mntpoint, STRERROR);
++                return false;
++        }
++        inf->priv.filesystem.f_bsize =           usage.f_bsize;
++        inf->priv.filesystem.f_blocks =          usage.f_blocks;
++        inf->priv.filesystem.f_blocksfree =      usage.f_bavail;
++        inf->priv.filesystem.f_blocksfreetotal = usage.f_bfree;
++        inf->priv.filesystem.f_files =           usage.f_files;
++        inf->priv.filesystem.f_filesfree =       usage.f_ffree;
++        inf->priv.filesystem._flags =            inf->priv.filesystem.flags;
++        inf->priv.filesystem.flags =             usage.f_flags;
++        return true;
++
++}
++

--- a/ports/sysutils/monit/dragonfly/patch-src-monit.h
+++ b/ports/sysutils/monit/dragonfly/patch-src-monit.h
@@ -1,0 +1,13 @@
+--- src/monit.h.orig	2015-10-22 15:44:25.000000000 +0200
++++ src/monit.h	2015-12-06 11:11:15.855663000 +0100
+@@ -29,6 +29,10 @@
+ #include "config.h"
+ #include <assert.h>
+ 
++#ifdef HAVE_KINFO_H
++#include <kinfo.h>
++#endif
++
+ #ifdef HAVE_SYS_TYPES_H
+ #include <sys/types.h>
+ #endif

--- a/ports/sysutils/monit/dragonfly/patch-src-process-sysdep_DRAGONFLY.c
+++ b/ports/sysutils/monit/dragonfly/patch-src-process-sysdep_DRAGONFLY.c
@@ -1,0 +1,308 @@
+--- src/process/sysdep_DRAGONFLY.c.orig	2015-12-06 13:09:49.299501858 +0100
++++ src/process/sysdep_DRAGONFLY.c	2015-12-06 13:09:48.212634000 +0100
+@@ -0,0 +1,305 @@
++/*
++ * Copyright (C) Tildeslash Ltd. All rights reserved.
++ *
++ * This program is free software: you can redistribute it and/or modify
++ * it under the terms of the GNU Affero General Public License version 3.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU Affero General Public License
++ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
++ *
++ * In addition, as a special exception, the copyright holders give
++ * permission to link the code of portions of this program with the
++ * OpenSSL library under certain conditions as described in each
++ * individual source file, and distribute linked combinations
++ * including the two.
++ *
++ * You must obey the GNU Affero General Public License in all respects
++ * for all of the code used other than OpenSSL.
++ */
++
++
++#include "config.h"
++
++#ifdef HAVE_ERRNO_H
++#include <errno.h>
++#endif
++
++#ifdef HAVE_STRING_H
++#include <string.h>
++#endif
++
++#ifdef HAVE_FCNTL_H
++#include <fcntl.h>
++#endif
++
++#ifdef HAVE_KVM_H
++#include <kinfo.h>
++#endif
++
++#ifdef HAVE_KVM_H
++#include <kvm.h>
++#endif
++
++#ifdef HAVE_PATHS_H
++#include <paths.h>
++#endif
++
++#ifdef HAVE_SYS_PARAM_H
++#include <sys/param.h>
++#endif
++
++#ifdef HAVE_SYS_PROC_H
++#include <sys/proc.h>
++#endif
++
++#ifdef HAVE_SYS_USER_H
++#include <sys/user.h>
++#endif
++
++#ifdef HAVE_SYS_VMMETER_H
++#include <sys/vmmeter.h>
++#endif
++
++#ifdef HAVE_SYS_SYSCTL_H
++#include <sys/sysctl.h>
++#endif
++
++#ifdef HAVE_SYS_DKSTAT_H
++#include <sys/dkstat.h>
++#endif
++
++#include "monit.h"
++#include "process.h"
++#include "process_sysdep.h"
++
++
++/**
++ *  System dependent resource gathering code for DragonFly.
++ *
++ *  @file
++ */
++
++
++/* ----------------------------------------------------------------- Private */
++
++
++static int  hz;
++static int  pagesize_kbyte;
++static long total_old    = 0;
++static long cpu_user_old = 0;
++static long cpu_syst_old = 0;
++
++
++/* ------------------------------------------------------------------ Public */
++
++
++boolean_t init_process_info_sysdep(void) {
++        int              mib[2];
++        size_t           len;
++        struct clockinfo clock;
++
++        mib[0] = CTL_KERN;
++        mib[1] = KERN_CLOCKRATE;
++        len    = sizeof(clock);
++        if (sysctl(mib, 2, &clock, &len, NULL, 0) == -1) {
++                DEBUG("system statistic error -- cannot get clock rate: %s\n", STRERROR);
++                return false;
++        }
++        hz     = clock.hz;
++
++        mib[0] = CTL_HW;
++        mib[1] = HW_NCPU;
++        len    = sizeof(systeminfo.cpus);
++        if (sysctl(mib, 2, &systeminfo.cpus, &len, NULL, 0) == -1) {
++                DEBUG("system statistic error -- cannot get cpu count: %s\n", STRERROR);
++                return false;
++        }
++
++        mib[1] = HW_PHYSMEM;
++        len    = sizeof(systeminfo.mem_kbyte_max);
++        if (sysctl(mib, 2, &systeminfo.mem_kbyte_max, &len, NULL, 0) == -1) {
++                DEBUG("system statistic error -- cannot get real memory amount: %s\n", STRERROR);
++                return false;
++        }
++        systeminfo.mem_kbyte_max /= 1024;
++
++        mib[1] = HW_PAGESIZE;
++        len    = sizeof(pagesize_kbyte);
++        if (sysctl(mib, 2, &pagesize_kbyte, &len, NULL, 0) == -1) {
++                DEBUG("system statistic error -- cannot get memory page size: %s\n", STRERROR);
++                return false;
++        }
++        pagesize_kbyte /= 1024;
++
++        return true;
++}
++
++
++/**
++ * Read all processes to initialize the information tree.
++ * @param reference  reference of ProcessTree
++ * @return treesize>0 if succeeded otherwise =0.
++ */
++int initprocesstree_sysdep(ProcessTree_T **reference) {
++        int                treesize;
++        static kvm_t      *kvm_handle;
++        ProcessTree_T     *pt;
++        struct kinfo_proc *pinfo;
++
++        if (! (kvm_handle = kvm_open(NULL, _PATH_DEVNULL, NULL, O_RDONLY, prog))) {
++                LogError("system statistic error -- cannot initialize kvm interface\n");
++                return 0;
++        }
++
++        pinfo = kvm_getprocs(kvm_handle, KERN_PROC_ALL, 0, &treesize);
++        if (! pinfo || (treesize < 1)) {
++                LogError("system statistic error -- cannot get process tree\n");
++                kvm_close(kvm_handle);
++                return 0;
++        }
++
++        pt = CALLOC(sizeof(ProcessTree_T), treesize);
++
++        for (int i = 0; i < treesize; i++) {
++                StringBuffer_T cmdline = StringBuffer_create(64);
++                pt[i].pid       = pinfo[i].kp_pid;
++                pt[i].ppid      = pinfo[i].kp_ppid;
++                pt[i].uid       = pinfo[i].kp_ruid;
++                pt[i].euid      = pinfo[i].kp_uid;
++                pt[i].gid       = pinfo[i].kp_rgid;
++                pt[i].starttime = pinfo[i].kp_start.tv_sec;
++                pt[i].cputime   = (long)((pinfo[i].kp_lwp.kl_uticks + pinfo[i].kp_lwp.kl_sticks + pinfo[i].kp_lwp.kl_iticks) / 1000000);
++                pt[i].mem_kbyte = (unsigned long)(pinfo[i].kp_vm_rssize * pagesize_kbyte);
++                int flags       = pinfo[i].kp_stat;
++                char * procname = pinfo[i].kp_comm;
++                if (flags == SZOMB)
++                        pt[i].zombie = true;
++                pt[i].cpu_percent = 0;
++                pt[i].time = get_float_time();
++                char **args;
++                if ((args = kvm_getargv(kvm_handle, &pinfo[i], 0))) {
++                        for (int j = 0; args[j]; j++)
++                                StringBuffer_append(cmdline, args[j + 1] ? "%s " : "%s", args[j]);
++                        pt[i].cmdline = Str_dup(StringBuffer_toString(StringBuffer_trim(cmdline)));
++                }
++                StringBuffer_free(&cmdline);
++                if (! pt[i].cmdline || ! *pt[i].cmdline) {
++                        FREE(pt[i].cmdline);
++                        pt[i].cmdline = Str_dup(procname);
++                }
++        }
++
++        *reference = pt;
++        kvm_close(kvm_handle);
++
++        return treesize;
++}
++
++
++/**
++ * This routine returns 'nelem' double precision floats containing
++ * the load averages in 'loadv'; at most 3 values will be returned.
++ * @param loadv destination of the load averages
++ * @param nelem number of averages
++ * @return: 0 if successful, -1 if failed (and all load averages are 0).
++ */
++int getloadavg_sysdep(double *loadv, int nelem) {
++        return getloadavg(loadv, nelem);
++}
++
++
++/**
++ * This routine returns kbyte of real memory in use.
++ * @return: true if successful, false if failed (or not available)
++ */
++boolean_t used_system_memory_sysdep(SystemInfo_T *si) {
++        /* Memory */
++        size_t len = sizeof(unsigned int);
++        unsigned int active;
++        if (sysctlbyname("vm.stats.vm.v_active_count", &active, &len, NULL, 0) == -1) {
++                LogError("system statistic error -- cannot get for active memory usage: %s\n", STRERROR);
++                return false;
++        }
++        if (len != sizeof(unsigned int)) {
++                LogError("system statistic error -- active memory usage statics error\n");
++                return false;
++        }
++        unsigned int wired;
++        if (sysctlbyname("vm.stats.vm.v_wire_count", &wired, &len, NULL, 0) == -1) {
++                LogError("system statistic error -- cannot get for wired memory usage: %s\n", STRERROR);
++                return false;
++        }
++        if (len != sizeof(unsigned int)) {
++                LogError("system statistic error -- wired memory usage statics error\n");
++                return false;
++        }
++        si->total_mem_kbyte = (active + wired) * pagesize_kbyte;
++
++        /* Swap */
++        unsigned int used;
++        if (sysctlbyname("vm.swap_anon_use", &used, &len, NULL, 0) == -1) {
++                LogError("system statistic error -- cannot get swap usage: %s\n", STRERROR);
++                si->swap_kbyte_max = 0;
++                return false;
++        }
++        si->total_swap_kbyte = used * pagesize_kbyte;
++        if (sysctlbyname("vm.swap_cache_use", &used, &len, NULL, 0) == -1) {
++                LogError("system statistic error -- cannot get swap usage: %s\n", STRERROR);
++                si->swap_kbyte_max = 0;
++                return false;
++        }
++        si->total_swap_kbyte += used * pagesize_kbyte;
++        unsigned int free;
++        if (sysctlbyname("vm.swap_size", &free, &len, NULL, 0) == -1) {
++                LogError("system statistic error -- cannot get swap usage: %s\n", STRERROR);
++                si->swap_kbyte_max = 0;
++                return false;
++        }
++        si->swap_kbyte_max = free * pagesize_kbyte + si->total_swap_kbyte;
++        return true;
++}
++
++
++/**
++ * This routine returns system/user CPU time in use.
++ * @return: true if successful, false if failed
++ */
++boolean_t used_system_cpu_sysdep(SystemInfo_T *si) {
++        int    mib[2];
++        long   cp_time[CPUSTATES];
++        long   total_new = 0;
++        long   total;
++        size_t len;
++
++        len = sizeof(mib);
++        if (sysctlnametomib("kern.cp_time", mib, &len) == -1) {
++                LogError("system statistic error -- cannot get cpu time handler: %s\n", STRERROR);
++                return false;
++        }
++
++        len = sizeof(cp_time);
++        if (sysctl(mib, 2, &cp_time, &len, NULL, 0) == -1) {
++                LogError("system statistic error -- cannot get cpu time: %s\n", STRERROR);
++                return false;
++        }
++
++        for (int i = 0; i < CPUSTATES; i++)
++                total_new += cp_time[i];
++
++        total     = total_new - total_old;
++        total_old = total_new;
++
++        si->total_cpu_user_percent = (total > 0) ? (int)(1000 * (double)(cp_time[CP_USER] - cpu_user_old) / total) : -10;
++        si->total_cpu_syst_percent = (total > 0) ? (int)(1000 * (double)(cp_time[CP_SYS] - cpu_syst_old) / total) : -10;
++        si->total_cpu_wait_percent = 0; /* there is no wait statistic available */
++
++        cpu_user_old = cp_time[CP_USER];
++        cpu_syst_old = cp_time[CP_SYS];
++
++        return true;
++}

--- a/ports/sysutils/monit/dragonfly/patch-src-process.c
+++ b/ports/sysutils/monit/dragonfly/patch-src-process.c
@@ -1,0 +1,14 @@
+--- src/process.c.orig	2015-10-22 15:44:25.000000000 +0200
++++ src/process.c	2015-12-06 11:51:52.076604000 +0100
+@@ -268,9 +268,10 @@ int initprocesstree(ProcessTree_T **pt_r
+         }
+ 
+         /* The main process in Solaris zones and FreeBSD host doesn't have pid 1, so try to find process which is parent of itself */
++        /* Note: on DragonFly, main process is swapper with pid 0 and ppid -1, so take also this case into consideration */
+         int root = -1;
+         for (int i = 0; i < *size_r; i++) {
+-                if (pt[i].pid == pt[i].ppid) {
++                if ((pt[i].pid == pt[i].ppid) || (pt[i].ppid == -1)) {
+                         root = i;
+                         break;
+                 }

--- a/ports/sysutils/monit/dragonfly/patch-src-system-Link.c
+++ b/ports/sysutils/monit/dragonfly/patch-src-system-Link.c
@@ -1,0 +1,11 @@
+--- libmonit/src/system/Link.c.orig	2015-10-22 15:44:32.000000000 +0200
++++ libmonit/src/system/Link.c	2015-12-05 21:27:14.873455000 +0100
+@@ -153,6 +153,8 @@ static void _updateValue(LinkData_T *dat
+ #include "os/openbsd/Link.inc"
+ #elif defined NETBSD
+ #include "os/netbsd/Link.inc"
++#elif defined DRAGONFLY
++#include "os/dragonfly/Link.inc"
+ #elif defined LINUX
+ #include "os/linux/Link.inc"
+ #elif defined SOLARIS


### PR DESCRIPTION
Take these FreeBSD support files as a reference...

libmonit/src/system/os/freebsd/Link.inc
src/device/sysdep_FREEBSD.c
src/process/sysdep_FREEBSD.c

... copy them to DragonFly counterparts and adapt initprocesstree_sysdep()
and used_system_memory_sysdep() in the latter.

Note: optimally, we should get this included in Monit source, however DPorts
is an ideal place to test and polish it before pushing to upstream.