### PR TITLE
games/nexuiz: fix port

### DIFF
--- a/ports/games/nexuiz/diffs/Makefile.diff
+++ b/ports/games/nexuiz/diffs/Makefile.diff
@@ -1,0 +1,11 @@
+--- Makefile.orig	2015-10-18 16:28:38.000000000 +0300
++++ Makefile
+@@ -91,7 +91,7 @@ PLIST_FILES+=	bin/${PORTNAME}-dedicated
+ .endif
+ 
+ post-extract:
+-	@${EXTRACT_CMD} -qo \
++	@${UNZIP_CMD} -qo \
+ 		${WRKDIR}/Nexuiz/sources/enginesource20091001.zip \
+ 		-d ${WRKDIR}/Nexuiz/sources
+ 

--- a/ports/games/nexuiz/dragonfly/patch-sources__darkplaces__BSDmakefile
+++ b/ports/games/nexuiz/dragonfly/patch-sources__darkplaces__BSDmakefile
@@ -1,0 +1,11 @@
+--- sources/darkplaces/BSDmakefile.bak	2015-12-07 08:40:01.000000000 +0200
++++ sources/darkplaces/BSDmakefile
+@@ -18,6 +18,8 @@ UNIX_X11LIBPATH=/usr/local/lib
+ # FreeBSD uses OSS
+ .if $(DP_ARCH) == "FreeBSD"
+ DEFAULT_SNDAPI=OSS
++.elif $(DP_ARCH) == "DragonFly"
++DEFAULT_SNDAPI=OSS
+ .else
+ DEFAULT_SNDAPI=BSD
+ .endif

--- a/ports/games/nexuiz/dragonfly/patch-sources__darkplaces__cd_bsd.c
+++ b/ports/games/nexuiz/dragonfly/patch-sources__darkplaces__cd_bsd.c
@@ -1,0 +1,28 @@
+--- sources/darkplaces/cd_bsd.c.orig	2009-01-19 17:14:26.000000000 +0200
++++ sources/darkplaces/cd_bsd.c
+@@ -29,14 +29,14 @@ Foundation, Inc., 59 Temple Place - Suit
+ #include <paths.h>
+ #include <unistd.h>
+ #include <time.h>
+-#ifndef __FreeBSD__
++#if !defined(__FreeBSD__) && !defined(__DragonFly__)
+ # include <util.h>
+ #endif
+ 
+ #include "cdaudio.h"
+ 
+ 
+-#ifndef __FreeBSD__
++#if !defined(__FreeBSD__) && !defined(__DragonFly__)
+ # define DEFAULT_CD_DEVICE _PATH_DEV "cd0"
+ #else
+ # define DEFAULT_CD_DEVICE "/dev/acd0c"
+@@ -259,7 +259,7 @@ void CDAudio_SysInit (void)
+ 
+ int CDAudio_SysStartup (void)
+ {
+-#ifndef __FreeBSD__
++#if !defined(__FreeBSD__) && !defined(__DragonFly__)
+ 	char buff [80];
+ 
+ 	if ((cdfile = opendisk(cd_dev, O_RDONLY, buff, sizeof(buff), 0)) == -1)

--- a/ports/games/nexuiz/dragonfly/patch-sources__darkplaces__common.h
+++ b/ports/games/nexuiz/dragonfly/patch-sources__darkplaces__common.h
@@ -1,0 +1,11 @@
+--- sources/darkplaces/common.h.orig	2009-07-08 11:32:32.000000000 +0300
++++ sources/darkplaces/common.h
+@@ -349,7 +349,7 @@ void InfoString_Print(char *buffer);
+ 
+ // strlcat and strlcpy, from OpenBSD
+ // Most (all?) BSDs already have them
+-#if defined(__OpenBSD__) || defined(__NetBSD__) || defined(__FreeBSD__) || defined(MACOSX)
++#if defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || defined(__FreeBSD__) || defined(MACOSX)
+ # define HAVE_STRLCAT 1
+ # define HAVE_STRLCPY 1
+ #endif

--- a/ports/games/nexuiz/dragonfly/patch-sources__darkplaces__makefile
+++ b/ports/games/nexuiz/dragonfly/patch-sources__darkplaces__makefile
@@ -1,0 +1,23 @@
+--- sources/darkplaces/makefile.orig	2009-07-20 11:30:38.000000000 +0300
++++ sources/darkplaces/makefile
+@@ -26,6 +26,10 @@ endif  # ifneq ($(filter %BSD,$(DP_ARCH)
+ endif  # ifdef windir
+ endif  # ifndef DP_MAKE_TARGET
+ 
++ifeq ($(DP_ARCH), DragonFly)
++	DP_MAKE_TARGET=bsd
++endif
++
+ # If we're not on compiling for Win32, we need additional information
+ ifneq ($(DP_MAKE_TARGET), mingw)
+ 	DP_ARCH:=$(shell uname)
+@@ -136,6 +140,9 @@ ifeq ($(DP_ARCH),FreeBSD)
+ else
+ 	DEFAULT_SNDAPI=BSD
+ endif
++ifeq ($(DP_ARCH),DragonFly)
++	DEFAULT_SNDAPI=OSS
++endif
+ 	OBJ_CD=$(OBJ_BSDCD)
+ 
+ 	OBJ_CL=$(OBJ_GLX)

--- a/ports/games/nexuiz/dragonfly/patch-sources__darkplaces__quakedef.h
+++ b/ports/games/nexuiz/dragonfly/patch-sources__darkplaces__quakedef.h
@@ -1,0 +1,12 @@
+--- sources/darkplaces/quakedef.h.orig	2009-09-18 03:24:40.000000000 +0300
++++ sources/darkplaces/quakedef.h
+@@ -294,6 +294,9 @@ extern cvar_t developer_loading;
+ #elif defined(WIN32)
+ # define DP_OS_NAME		"Windows"
+ # define DP_OS_STR		"win32"
++#elif defined(__DragonFly__)
++# define DP_OS_NAME		"DragonFly"
++# define DP_OS_STR		"dragonfly"
+ #elif defined(__FreeBSD__)
+ # define DP_OS_NAME		"FreeBSD"
+ # define DP_OS_STR		"freebsd"

--- a/ports/games/nexuiz/dragonfly/patch-sources__darkplaces__sys_shared.c
+++ b/ports/games/nexuiz/dragonfly/patch-sources__darkplaces__sys_shared.c
@@ -1,0 +1,20 @@
+--- sources/darkplaces/sys_shared.c.orig	2009-01-28 08:41:40.000000000 +0200
++++ sources/darkplaces/sys_shared.c
+@@ -31,7 +31,7 @@ void Sys_Quit (int returnvalue)
+ 	exit(returnvalue);
+ }
+ 
+-#if defined(__linux__) || defined(__FreeBSD__)
++#if defined(__linux__) || defined(__DragonFly__) || defined(__FreeBSD__)
+ #ifdef __cplusplus
+ extern "C"
+ #endif
+@@ -40,7 +40,7 @@ int moncontrol(int);
+ 
+ void Sys_AllowProfiling(qboolean enable)
+ {
+-#if defined(__linux__) || defined(__FreeBSD__)
++#if defined(__linux__) || defined(__DragonFly__) || defined(__FreeBSD__)
+ 	moncontrol(enable);
+ #endif
+ }


### PR DESCRIPTION
Darkplaces mod plays awesomelly! Both glx and sdl backends
on both radeonsi and haswell.

WARNING: size..
distfiles - single engine+data(888M) + optional(ON) map pack(108M)
package - .txz 879M
installed - 963M