### PR TITLE
games/wizznic: fix build

### DIFF
--- a/ports/games/wizznic/Makefile.DragonFly
+++ b/ports/games/wizznic/Makefile.DragonFly
@@ -1,0 +1,18 @@
+
+# zrj: fix build w/ gcc50, upstream commit 977b5dcc
+dfly-patch:
+	${REINPLACE_CMD} -e 's@^inline @@g'	\
+		${WRKSRC}/board.c		\
+		${WRKSRC}/board.h		\
+		${WRKSRC}/input.c		\
+		${WRKSRC}/input.h		\
+		${WRKSRC}/mbrowse.c		\
+		${WRKSRC}/particle.c		\
+		${WRKSRC}/particles.h		\
+		${WRKSRC}/pixel.c		\
+		${WRKSRC}/pixel.h		\
+		${WRKSRC}/settings.c		\
+		${WRKSRC}/settings.h		\
+		${WRKSRC}/stats.c		\
+		${WRKSRC}/ticks.c		\
+		${WRKSRC}/ticks.h


### PR DESCRIPTION
remove 'inline' to build w/ gcc50 (from upstream)
https://github.com/DusteDdk/Wizznic/commit/977b5ddc46dddb7955ca471daf29b5ae360c1d3d

Puzzle game works