### PR TITLE
graphics/cimg: fix build, by renaming CCVER

### DIFF
--- a/ports/graphics/cimg/Makefile.DragonFly
+++ b/ports/graphics/cimg/Makefile.DragonFly
@@ -1,0 +1,4 @@
+
+dfly-patch:
+	${REINPLACE_CMD} -e 's@CCVER@CxxVER@g'				\
+		${WRKSRC}/examples/Makefile


### PR DESCRIPTION
This one took some time to figure out.
Some examples work, others give:
X Error of failed request:  BadLength (poly request too large or internal Xlib length error)
Looks to be xorg+mesa issue, also some missing demo images.