### PR TITLE
math/eigen3: use posix_memalign

### DIFF
--- a/ports/math/eigen3/dragonfly/patch-src_Core_util_Memory.h
+++ b/ports/math/eigen3/dragonfly/patch-src_Core_util_Memory.h
@@ -1,0 +1,17 @@
+
+malloc(3) on DragonFly does not guarantee 16-bit alignment.
+But posix_memalign(ptr, 16, size) does.
+
+--- Eigen/src/Core/util/Memory.h.orig	2015-11-05 16:56:09.000000000 +0200
++++ Eigen/src/Core/util/Memory.h
+@@ -56,6 +56,10 @@
+   #define EIGEN_MALLOC_ALREADY_ALIGNED 0
+ #endif
+ 
++#if defined(__DragonFly__)
++#define EIGEN_HAS_POSIX_MEMALIGN 1
++#endif
++
+ #endif
+ 
+ // See bug 554 (http://eigen.tuxfamily.org/bz/show_bug.cgi?id=554)


### PR DESCRIPTION
This one biten me on blender (eigen3 redist).

Tests: (looks like there are still problems in libm)

99% tests passed, 8 tests failed out of 644

Label Time Summary:
Official       = 203.77 sec
Unsupported    =  21.29 sec

Total Test time (real) = 225.54 sec

The following tests FAILED:
        552 - sparselu_3 (OTHER_FAULT)
        571 - matrix_exponential_8 (OTHER_FAULT)
        577 - matrix_exponential_9 (OTHER_FAULT)
        579 - matrix_function_2 (OTHER_FAULT)
        580 - matrix_function_3 (OTHER_FAULT)
        587 - matrix_power_9 (OTHER_FAULT)
        605 - openglsupport (OTHER_FAULT)
        630 - levenberg_marquardt (OTHER_FAULT)