### PR TITLE
devel/p5-BSD-devstat: mark as ignored

### DIFF
--- a/ports/devel/p5-BSD-devstat/Makefile.DragonFly
+++ b/ports/devel/p5-BSD-devstat/Makefile.DragonFly
@@ -1,0 +1,1 @@
+IGNORE= only for freebsd (kvm_t)


### PR DESCRIPTION
Only for freebsd