### PR TITLE
sysutils/p5-BSD-Jail-Object: mark as ignored

### DIFF
--- a/ports/sysutils/p5-BSD-Jail-Object/Makefile.DragonFly
+++ b/ports/sysutils/p5-BSD-Jail-Object/Makefile.DragonFly
@@ -1,0 +1,1 @@
+IGNORE= JAIL v2 only


### PR DESCRIPTION
No security.jail.list sysctl