### PR TITLE
textproc/ctpp2: fix build

### DIFF
--- a/ports/textproc/ctpp2/dragonfly/patch-include_CTPP2SysTypes.h
+++ b/ports/textproc/ctpp2/dragonfly/patch-include_CTPP2SysTypes.h
@@ -1,0 +1,11 @@
+--- include/CTPP2SysTypes.h.orig	2012-08-02 10:22:44.000000000 +0300
++++ include/CTPP2SysTypes.h
+@@ -134,7 +134,7 @@ typedef CCHAR_8                   * CCHA
+ typedef UCCHAR_8                  * UCCHAR_P;
+ 
+ 
+-#elif defined(__FreeBSD__) || defined(__APPLE__) /* Linux End, start of FreeBSD / Mac OS declarations */
++#elif defined(__FreeBSD__) || defined(__APPLE__) || defined(__DragonFly__) /* Linux End, start of FreeBSD / Mac OS declarations */
+ 
+ /**
+   @var typedef int16_t    INT_16

--- a/ports/textproc/ctpp2/dragonfly/patch-src_functions_FnRandom.cpp
+++ b/ports/textproc/ctpp2/dragonfly/patch-src_functions_FnRandom.cpp
@@ -1,0 +1,11 @@
+--- src/functions/FnRandom.cpp.orig	2012-11-10 22:36:30.000000000 +0200
++++ src/functions/FnRandom.cpp
+@@ -51,7 +51,7 @@ namespace CTPP // C++ Template Engine
+ //
+ FnRandom::FnRandom()
+ {
+-#if defined(__FreeBSD__) || defined(_MSC_VER)
++#if defined(__FreeBSD__) || defined(__DragonFly__) || defined(_MSC_VER)
+ 	srandomdev();
+ #else
+ 	srandom(time(NULL));


### PR DESCRIPTION
Tests: (diffs in version: v2.8.2 vs v2.8.3)
98% tests passed, 1 tests failed out of 57

Total Test time (real) =   1.30 sec

The following tests FAILED:
         26 - Functions_D (Failed