### PR TITLE
emulators/qemu-devel: Work around makecontext behaviour on DragonFly.

### DIFF
--- a/ports/emulators/qemu-devel/dragonfly/patch-coroutine-ucontext.c
+++ b/ports/emulators/qemu-devel/dragonfly/patch-coroutine-ucontext.c
@@ -1,0 +1,19 @@
+--- coroutine-ucontext.c.orig	2015-12-15 23:02:28 +0100
++++ coroutine-ucontext.c
+@@ -122,7 +122,15 @@
+                 2, arg.i[0], arg.i[1]);
+ 
+     /* swapcontext() in, siglongjmp() back out */
+-    if (!sigsetjmp(old_env, 0)) {
++    /* Save signal mask in this sigsetjmp, because makecontext on DragonFly
++     * leaves all signals blocked when entering the new context with
++     * swapcontext.
++     * Workaround this, by just having the signal mask restored by the
++     * siglongjmp that brings us back from qemu_coroutine_new().
++     * XXX Remove this workaround when the makecontext behaviour is fixed
++     *     on DragonFly.
++     */
++    if (!sigsetjmp(old_env, 1)) {
+         swapcontext(&old_uc, &uc);
+     }
+     return &co->base;


### PR DESCRIPTION
On DragonFly, when using swapcontext to enter a new context initialized
with makecontext all signals are left blocked in the new context. Since
qemu then uses siglongjmp (without a previously saved signal mask) to
continue in the original context, all signals are still blocked.

The most simple workaround is to just save the signal mask in the sigsetjmp
before using swapcontext to enter the new ucontext.

Without this workaround the virtual-machine isn't getting interrupted
(e.g. by the timer-interrupt) when it is running in a busy loop
(like "while true; do echo a > /dev/null; done" in the shell),
because SIGUSR1 is blocked.