### PR TITLE
audio/cmus: fix build after new defaults

### DIFF
--- a/ports/audio/cmus/dragonfly/patch-scripts-checks.sh
+++ b/ports/audio/cmus/dragonfly/patch-scripts-checks.sh
@@ -1,0 +1,11 @@
+--- scripts/checks.sh.intermediate	2015-12-17 17:25:50.000000000 +0200
++++ scripts/checks.sh
+@@ -124,7 +124,7 @@ cc_cxx_common()
+ 	common_lf=
+ 
+ 	case `uname -s` in
+-	*BSD)
++	*BSD|DragonFly)
+ 		common_cf="$common_cf -I/usr/local/include"
+ 		common_lf="$common_lf -L/usr/local/lib"
+ 		;;


### PR DESCRIPTION
This fixes mp4v2/mp4v2.h header detection.

TUI player starts, seems to be working