### PR TITLE
D1512 tweak gstreamer

### DIFF
--- a/ports/graphics/gstreamer-plugins-gl/Makefile.DragonFly
+++ b/ports/graphics/gstreamer-plugins-gl/Makefile.DragonFly
@@ -1,0 +1,7 @@
+
+# just for the noise
+CFLAGS+= -Wno-deprecated-declarations
+
+dfly-patch:
+	${REINPLACE_CMD} -e 's@dragonflybsd@dragonfly@g'		\
+		${WRKSRC}/configure

--- a/ports/multimedia/gstreamer-plugins-good/dragonfly/patch-configure
+++ b/ports/multimedia/gstreamer-plugins-good/dragonfly/patch-configure
@@ -1,0 +1,13 @@
+--- configure.intermediate	2015-12-18 09:37:29.000000000 +0200
++++ configure
+@@ -28876,9 +28876,7 @@ $as_echo_n "checking Checking for up to
+ #ifdef __sun /* Solaris */
+ #include <sys/types.h>
+ #include <sys/videodev2.h>
+-#elif __FreeBSD__
+-#include <linux/videodev2.h>
+-#elif __FreeBSD__
++#elif defined(__FreeBSD__) || defined(__DragonFly__)
+ #include <linux/videodev2.h>
+ #else /* Linux */
+ #include <linux/types.h>

--- a/ports/multimedia/gstreamer-plugins-good/dragonfly/patch-sys_v4l2_gstv4l2object.h
+++ b/ports/multimedia/gstreamer-plugins-good/dragonfly/patch-sys_v4l2_gstv4l2object.h
@@ -1,0 +1,11 @@
+--- sys/v4l2/gstv4l2object.h.intermediate	2015-12-18 09:37:28.000000000 +0200
++++ sys/v4l2/gstv4l2object.h
+@@ -40,7 +40,7 @@
+ #include <sys/types.h>
+ #ifdef __sun
+ #include <sys/videodev2.h>
+-#elif defined(__FreeBSD__)
++#elif defined(__FreeBSD__) || defined(__DragonFly__)
+ #include <linux/videodev2.h>
+ #else /* linux */
+ #include <linux/types.h>

--- a/ports/multimedia/gstreamer-plugins/Makefile.DragonFly
+++ b/ports/multimedia/gstreamer-plugins/Makefile.DragonFly
@@ -1,0 +1,9 @@
+
+# warning: -Wformat-nonliteral ignored without -Wformat [-Wformat-nonliteral]
+CFLAGS+= -Wformat
+
+# just for the noise
+CFLAGS+= -Wno-deprecated-declarations
+
+# for all -base -bad -good and the -ugly separate
+DFLY_PATCHDIR=	${PATCHDIR:S@/files$$@/dragonfly@}

--- a/ports/multimedia/gstreamer/Makefile.DragonFly
+++ b/ports/multimedia/gstreamer/Makefile.DragonFly
@@ -1,0 +1,6 @@
+
+# warning: -Wformat-nonliteral ignored without -Wformat [-Wformat-nonliteral]
+CFLAGS+= -Wformat
+
+# just for the noise
+CFLAGS+= -Wno-deprecated-declarations


### PR DESCRIPTION
This one is a complicated one and long I wanted to fix these properly.
Build order: (depends on master Makefiles thus has to build in separate poudriere builds)
1) multimedia/gstreamer
then
2) multimedia/gstreamer-plugins
then
3) (these can be build together)
multimedia/gstreamer-plugins-{all,annodex,bad,buzztard,bz2,core}
multimedia/gstreamer-plugins-{dts,dv,dvd,fluendo-mpegdemux,gnonlin,good}
multimedia/gstreamer-plugins-{mpeg2dec,mpeg2enc,resindvd,schrodinger}
multimedia/gstreamer-plugins-{theora,ugly,v4l2,vdpau,vp8,x264,xvid}
graphics/gstreamer-plugins-gl

This way all patching will get in order and build properly :)