### PR TITLE
multimedia/mkvalidator: add alias

### DIFF
--- a/ports/multimedia/mkvalidator/Makefile.DragonFly
+++ b/ports/multimedia/mkvalidator/Makefile.DragonFly
@@ -1,0 +1,1 @@
+USES+= alias


### PR DESCRIPTION
Tested, reports correct mkv files and bad ones:
ERR201: Invalid 'EncryptedBlock' for profile 'matroska v4' in Cluster at 20207
ERR201: Invalid 'EncryptedBlock' for profile 'matroska v4' in Cluster at 20207
ERR200: Missing element 'Block' in BlockGroup at 45212
ERR0C3: Unknown track #12 in Cluster at 20207 in SimpleBlock at 36152
ERR0B2: Block at 36152 is using an unknown track #12
ERR0A1: The Cluster PrevSize 12783829 at 45115 should be 14123
WRN0D0: There are 5271 bytes of void data..
So good!