### PR TITLE
multimedia/avidemux: retweek ffmpeg inlining in cxx

### DIFF
--- a/ports/multimedia/avidemux/Makefile.DragonFly
+++ b/ports/multimedia/avidemux/Makefile.DragonFly
@@ -1,5 +1,3 @@
-# has a bug, ffmpeg is C so should not be treated as non C
-CFLAGS+=	-D__STDC_CONSTANT_MACROS
 USES+=	alias execinfo
 
 #CMAKE_ARGS+=   -DLIBEXECINFO_INCLUDE_DIR=/usr/local/include

--- a/ports/multimedia/avidemux/dragonfly/patch-avidemux_core__ADM_core__include__ADM_default.h
+++ b/ports/multimedia/avidemux/dragonfly/patch-avidemux_core__ADM_core__include__ADM_default.h
@@ -1,0 +1,16 @@
+
+Needed for C code in CXX
+
+--- avidemux_core/ADM_core/include/ADM_default.h.orig	2015-06-10 08:42:47.000000000 +0300
++++ avidemux_core/ADM_core/include/ADM_default.h
+@@ -38,6 +38,10 @@
+ #include "ADM_misc.h"
+ #endif
+ 
++#ifdef __DragonFly__
++#include <machine/int_const.h>
++#endif
++
+ #ifdef __cplusplus
+ extern "C" 
+ {


### PR DESCRIPTION
This one is complicated too.

Rebuild just multimedia/avidemux first.
Then in separate run rest avidemux-{cli,plugins,qt4}

Tested, plugins now work.