### PR TITLE
x11/decurs: fix va_start/va_end w/ stdarg.h

### DIFF
--- a/ports/x11/decurs/dragonfly/patch-src_cppstring.cc
+++ b/ports/x11/decurs/dragonfly/patch-src_cppstring.cc
@@ -1,0 +1,10 @@
+--- src/cppstring.cc.orig	2014-12-03 09:48:01.000000000 +0200
++++ src/cppstring.cc
+@@ -1,6 +1,7 @@
+ 
+ #include <ctype.h>	// tolower()
+ #include <stdio.h>
++#include <stdarg.h>
+ #include "cppstring.hh"
+ #include "idefs.h"
+ #include <iostream>


### PR DESCRIPTION
I can draw my own cursors.