### PR TITLE
devel/fpc-bfd: redirect dep to binutils

### DIFF
--- a/ports/lang/fpc/Makefile.DragonFly
+++ b/ports/lang/fpc/Makefile.DragonFly
@@ -1,0 +1,4 @@
+
+.if defined(LIBBFD_RUN_DEPENDS)
+LIBBFD_RUN_DEPENDS:= ${LIBBFD_RUN_DEPENDS:S@devel/libbfd$$@devel/binutils@}
+.endif


### PR DESCRIPTION
devel/libbfd is build from an old binutils tarball.
It does have dragonfly target in config.bfd.
Also conflicts if any ports depend on devel/binutils (libbfd.a).

Thus on DragonFly it useful to avoid port conflicts.