### PR TITLE
emulators/qemu-devel: Add vknet network backend for DragonFly's vknetd(1)

### DIFF
--- a/ports/emulators/qemu-devel/diffs/Makefile.diff
+++ b/ports/emulators/qemu-devel/diffs/Makefile.diff
@@ -1,0 +1,47 @@
+--- Makefile.orig
++++ Makefile
+@@ -24,7 +24,7 @@ ONLY_FOR_ARCHS=	amd64 i386 powerpc powerpc64 # XXX someone wants to debug sparc6
+ 
+ OPTIONS_DEFINE=	SAMBA X11 GTK2 OPENGL GNUTLS SASL JPEG PNG CURL \
+ 		CDROM_DMA PCAP USBREDIR GNS3 X86_TARGETS \
+-		STATIC_LINK DOCS
++		STATIC_LINK DOCS VKNET
+ SAMBA_DESC=		samba dependency (for -smb)
+ GNUTLS_DESC=		gnutls dependency (vnc encryption)
+ SASL_DESC=		cyrus-sasl dependency (vnc encryption)
+@@ -32,12 +32,13 @@ JPEG_DESC=		jpeg dependency (vnc lossy compression)
+ PNG_DESC=		png dependency (vnc compression)
+ CDROM_DMA_DESC=		IDE CDROM DMA
+ PCAP_DESC=		pcap dependency (networking with bpf)
++VKNET_DESC=		vknet network backend for simple userspace bridge
+ USBREDIR_DESC=		usb device network redirection (experimental!)
+ GNS3_DESC=		gns3 patches (promiscuous multicast)
+ X86_TARGETS_DESC=	Don't build non-x86 system targets
+ BSD_USER_DESC=		Also build bsd-user targets (for testing)
+ STATIC_LINK_DESC=	Statically link the executables
+-OPTIONS_DEFAULT=X11 GTK2 OPENGL GNUTLS SASL JPEG PNG CDROM_DMA CURL PCAP
++OPTIONS_DEFAULT=X11 GTK2 OPENGL GNUTLS SASL JPEG PNG CDROM_DMA CURL PCAP VKNET
+ 
+ .if !defined(QEMU_USER_STATIC)
+ CONFLICTS_INSTALL=	qemu-[0-9]* qemu-sbruno-[0-9]*
+@@ -183,6 +184,10 @@ RUN_DEPENDS+=	usbredir>=0.6:${PORTSDIR}/net/usbredir
+ CONFIGURE_ARGS+=	--enable-pcap
+ .endif
+ 
++.if ${PORT_OPTIONS:MVKNET}
++CONFIGURE_ARGS+=	--enable-vknet
++.endif
++
+ .if ${PORT_OPTIONS:MSTATIC_LINK}
+ .if ${PORT_OPTIONS:MGTK2} || ${PORT_OPTIONS:MX11}
+ IGNORE=		X11 ui cannot be built static
+@@ -232,6 +237,9 @@ post-patch:
+ .if ${PORT_OPTIONS:MPCAP}
+ 	@cd ${WRKSRC} && ${PATCH} --quiet < ${FILESDIR}/pcap-patch
+ .endif
++.if ${PORT_OPTIONS:MVKNET}
++	@cd ${WRKSRC} && ${PATCH} --quiet < ${DFLY_FILESDIR}/vknet-patch
++.endif
+ .if empty(PORT_OPTIONS:MCDROM_DMA)
+ 	@cd ${WRKSRC} && ${PATCH} --quiet < ${FILESDIR}/cdrom-dma-patch
+ .endif

--- a/ports/emulators/qemu-devel/dragonfly/vknet-patch
+++ b/ports/emulators/qemu-devel/dragonfly/vknet-patch
@@ -1,0 +1,373 @@
+--- qapi-schema.json.orig	2015-08-11 21:11:09.000000000 +0200
++++ qapi-schema.json	2015-12-20 16:31:55.624678000 +0100
+@@ -2063,7 +2063,7 @@
+ # Add a network backend.
+ #
+ # @type: the type of network backend.  Current valid values are 'user', 'tap',
+-#        'vde', 'socket', 'dump' and 'bridge'
++#        'vde', 'vknet', 'socket', 'dump' and 'bridge'
+ #
+ # @id: the name of the new network backend
+ #
+@@ -2391,6 +2391,19 @@
+     '*mode':  'uint16' } }
+ 
+ ##
++# @NetdevVknetOptions
++#
++# Connect the VLAN to a vknet switch running on the host.
++#
++# @sock: #optional socket path
++#
++# Since 2.4
++##
++{ 'struct': 'NetdevVknetOptions',
++  'data': {
++    '*sock':  'str' } }
++
++##
+ # @NetdevDumpOptions
+ #
+ # Dump VLAN network traffic to a file.
+@@ -2492,6 +2505,7 @@
+     'l2tpv3':   'NetdevL2TPv3Options',
+     'socket':   'NetdevSocketOptions',
+     'vde':      'NetdevVdeOptions',
++    'vknet':    'NetdevVknetOptions',
+     'dump':     'NetdevDumpOptions',
+     'bridge':   'NetdevBridgeOptions',
+     'hubport':  'NetdevHubPortOptions',
+--- qemu-options.hx.orig	2015-08-11 21:11:09.000000000 +0200
++++ qemu-options.hx	2015-12-21 11:14:38.507807000 +0100
+@@ -1542,6 +1542,12 @@
+     "                Use group 'groupname' and mode 'octalmode' to change default\n"
+     "                ownership and permissions for communication port.\n"
+ #endif
++#ifdef CONFIG_VKNET
++    "-netdev vknet,id=str[,sock=socketpath]\n"
++    "                configure a network backend to connect to a vknet switch\n"
++    "                running on host and listening for incoming connections on\n"
++    "                'socketpath' (default is '/var/run/vknet').\n"
++#endif
+ #ifdef CONFIG_NETMAP
+     "-netdev netmap,id=str,ifname=name[,devname=nmname]\n"
+     "                attach to the existing netmap-enabled network interface 'name', or to a\n"
+@@ -1569,6 +1575,9 @@
+ #ifdef CONFIG_VDE
+     "vde|"
+ #endif
++#ifdef CONFIG_VKNET
++    "vknet|"
++#endif
+ #ifdef CONFIG_NETMAP
+     "netmap|"
+ #endif
+--- /dev/null	2015-12-21 11:04:27.549350077 +0100
++++ net/vknet.c	2015-12-21 11:06:54.790858000 +0100
+@@ -0,0 +1,205 @@
++/*
++ * QEMU System Emulator
++ *
++ * Copyright (c) 2003-2008 Fabrice Bellard
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining a copy
++ * of this software and associated documentation files (the "Software"), to deal
++ * in the Software without restriction, including without limitation the rights
++ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
++ * copies of the Software, and to permit persons to whom the Software is
++ * furnished to do so, subject to the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be included in
++ * all copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
++ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
++ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
++ * THE SOFTWARE.
++ */
++#include "config-host.h"
++
++#include "net/net.h"
++#include "clients.h"
++#include "qemu-common.h"
++#include "qemu/option.h"
++#include "qemu/sockets.h"
++#include "qemu/main-loop.h"
++
++#define MAXPKT	(8192 + 128)
++
++typedef struct VKNETState {
++    NetClientState nc;
++    int fd;
++    uint8_t buf[MAXPKT];
++    bool read_poll;               /* waiting to receive data? */
++    bool write_poll;              /* waiting to transmit data? */
++} VKNETState;
++
++static void net_vknet_send(void *opaque);
++static void net_vknet_writable(void *opaque);
++static void net_vknet_cleanup(NetClientState *nc);
++
++static void net_vknet_update_fd_handler(VKNETState *s)
++{
++    qemu_set_fd_handler(s->fd,
++                        s->read_poll ? net_vknet_send : NULL,
++                        s->write_poll ? net_vknet_writable : NULL,
++                        s);
++}
++
++static void net_vknet_read_poll(VKNETState *s, bool enable)
++{
++    s->read_poll = enable;
++    net_vknet_update_fd_handler(s);
++}
++
++static void net_vknet_write_poll(VKNETState *s, bool enable)
++{
++    s->write_poll = enable;
++    net_vknet_update_fd_handler(s);
++}
++
++static void net_vknet_writable(void *opaque)
++{
++    VKNETState *s = opaque;
++
++    net_vknet_write_poll(s, false);
++
++    qemu_flush_queued_packets(&s->nc);
++}
++
++static ssize_t net_vknet_receive(NetClientState *nc, const uint8_t *buf,
++                                 size_t size)
++{
++    VKNETState *s = DO_UPCAST(VKNETState, nc, nc);
++    ssize_t ret;
++
++    ret = write(s->fd, buf, size);
++    if (ret == -1)
++        return -errno;
++    else if (ret != size)
++        return 0;
++
++    return size;
++}
++
++static void net_vknet_send_completed(NetClientState *nc, ssize_t len)
++{
++    VKNETState *s = DO_UPCAST(VKNETState, nc, nc);
++
++    if (!s->read_poll) {
++        net_vknet_read_poll(s, true);
++    }
++}
++
++static NetClientInfo net_vknet_info = {
++    .type = NET_CLIENT_OPTIONS_KIND_VKNET,
++    .size = sizeof(VKNETState),
++    .receive = net_vknet_receive,
++    .cleanup = net_vknet_cleanup,
++};
++
++static VKNETState *net_vknet_fd_init(NetClientState *peer,
++                                     const char *model,
++                                     const char *name,
++                                     int fd)
++{
++    NetClientState *nc;
++    VKNETState *s;
++
++    nc = qemu_new_net_client(&net_vknet_info, peer, model, name);
++
++    snprintf(nc->info_str, sizeof(nc->info_str), "socket: fd=%d", fd);
++
++    s = DO_UPCAST(VKNETState, nc, nc);
++
++    s->fd = fd;
++
++    net_vknet_read_poll(s, true);
++    return s;
++}
++
++static void net_vknet_send(void *opaque)
++{
++    VKNETState *s = opaque;
++    ssize_t size;
++
++    size = read(s->fd, s->buf, MAXPKT);
++    if (size <= 0 || size > MAXPKT)
++        return;
++
++    if (qemu_send_packet_async(&s->nc, s->buf, (int)size,
++                               net_vknet_send_completed) == 0) {
++        net_vknet_read_poll(s, false);
++    }
++}
++
++static void net_vknet_cleanup(NetClientState *nc)
++{
++    VKNETState *s = DO_UPCAST(VKNETState, nc, nc);
++    if (s->fd != -1) {
++        net_vknet_read_poll(s, false);
++        net_vknet_write_poll(s, false);
++        close(s->fd);
++        s->fd = -1;
++    }
++}
++
++static int net_vknet_init(NetClientState *peer, const char *model,
++                          const char *name, const char *sock)
++{
++    NetClientState *nc;
++    VKNETState *s;
++    struct sockaddr_un sunx;
++    int fd, len;
++
++    snprintf(sunx.sun_path, sizeof(sunx.sun_path), "%s", sock);
++    len = offsetof(struct sockaddr_un, sun_path[strlen(sunx.sun_path)]);
++    ++len;  /* include nul */
++    sunx.sun_family = AF_UNIX;
++    sunx.sun_len = len;
++
++    fd = qemu_socket(AF_UNIX, SOCK_SEQPACKET, 0);
++    if (fd >= 0) {
++        if (connect(fd, (void *)&sunx, len) < 0) {
++            closesocket(fd);
++            return -1;
++        }
++    }
++    fcntl(fd, F_SETFL, 0);
++
++    s = net_vknet_fd_init(peer, model, name, fd);
++    if (!s)
++        return -1;
++    snprintf(s->nc.info_str, sizeof(s->nc.info_str),
++             "socket: connect to %s", sock);
++
++    return 0;
++}
++
++int net_init_vknet(const NetClientOptions *opts, const char *name,
++                   NetClientState *peer, Error **errp)
++{
++    /* FIXME error_setg(errp, ...) on failure */
++    const NetdevVknetOptions *vknet;
++    const char *path;
++
++    assert(opts->kind == NET_CLIENT_OPTIONS_KIND_VKNET);
++    vknet = opts->vknet;
++    if (vknet->sock == NULL)
++        path = "/var/run/vknet";
++    else
++        path = vknet->sock;
++
++    /* missing optional values have been initialized to "all bits zero" */
++    if (net_vknet_init(peer, "vknet", name, path) == -1) {
++        return -1;
++    }
++
++    return 0;
++}
+--- net/Makefile.objs.orig	2015-12-20 14:05:42.282624000 +0100
++++ net/Makefile.objs	2015-12-20 14:05:46.272686000 +0100
+@@ -12,4 +12,5 @@
+ common-obj-$(CONFIG_HAIKU) += tap-haiku.o
+ common-obj-$(CONFIG_SLIRP) += slirp.o
+ common-obj-$(CONFIG_VDE) += vde.o
++common-obj-$(CONFIG_VKNET) += vknet.o
+ common-obj-$(CONFIG_NETMAP) += netmap.o
+--- net/net.c.orig	2015-12-20 14:05:04.642040000 +0100
++++ net/net.c	2015-12-20 14:05:26.112373000 +0100
+@@ -74,6 +74,9 @@
+ #ifdef CONFIG_VDE
+     "vde",
+ #endif
++#ifdef CONFIG_VKNET
++    "vknet",
++#endif
+     "vhost-user",
+     NULL,
+ };
+@@ -1114,6 +1117,9 @@
+ #ifdef CONFIG_VDE
+         [NET_CLIENT_OPTIONS_KIND_VDE]       = net_init_vde,
+ #endif
++#ifdef CONFIG_VKNET
++        [NET_CLIENT_OPTIONS_KIND_VKNET]     = net_init_vknet,
++#endif
+ #ifdef CONFIG_NETMAP
+         [NET_CLIENT_OPTIONS_KIND_NETMAP]    = net_init_netmap,
+ #endif
+--- net/hub.c.orig	2015-08-11 21:11:09.000000000 +0200
++++ net/hub.c	2015-12-20 17:52:40.141244000 +0100
+@@ -321,6 +321,7 @@
+             case NET_CLIENT_OPTIONS_KIND_TAP:
+             case NET_CLIENT_OPTIONS_KIND_SOCKET:
+             case NET_CLIENT_OPTIONS_KIND_VDE:
++            case NET_CLIENT_OPTIONS_KIND_VKNET:
+             case NET_CLIENT_OPTIONS_KIND_VHOST_USER:
+                 has_host_dev = 1;
+                 break;
+--- net/clients.h.orig	2015-08-11 21:11:09.000000000 +0200
++++ net/clients.h	2015-12-20 14:06:37.663483000 +0100
+@@ -54,6 +54,11 @@
+                  NetClientState *peer, Error **errp);
+ #endif
+ 
++#ifdef CONFIG_VKNET
++int net_init_vknet(const NetClientOptions *opts, const char *name,
++                   NetClientState *peer, Error **errp);
++#endif
++
+ #ifdef CONFIG_NETMAP
+ int net_init_netmap(const NetClientOptions *opts, const char *name,
+                     NetClientState *peer, Error **errp);
+--- configure.orig	2015-12-20 19:05:56.747347000 +0100
++++ configure	2015-12-20 19:06:44.058070000 +0100
+@@ -242,6 +242,7 @@
+ sparse="no"
+ uuid=""
+ vde=""
++vknet=""
+ vnc_tls=""
+ vnc_sasl=""
+ vnc_jpeg=""
+@@ -906,6 +907,10 @@
+   ;;
+   --enable-vde) vde="yes"
+   ;;
++  --disable-vknet) vknet="no"
++  ;;
++  --enable-vknet) vknet="yes"
++  ;;
+   --disable-netmap) netmap="no"
+   ;;
+   --enable-netmap) netmap="yes"
+@@ -1349,6 +1354,7 @@
+   rdma            RDMA-based migration support
+   uuid            uuid support
+   vde             support for vde network
++  vknet           support for vknet network
+   netmap          support for netmap network
+   linux-aio       Linux AIO support
+   cap-ng          libcap-ng support
+@@ -4535,6 +4541,7 @@
+ echo "GUEST_BASE        $guest_base"
+ echo "PIE               $pie"
+ echo "vde support       $vde"
++echo "vknet support     $vknet"
+ echo "netmap support    $netmap"
+ echo "Linux AIO support $linux_aio"
+ echo "ATTR/XATTR support $attr"
+@@ -4699,6 +4706,9 @@
+ if test "$vde" = "yes" ; then
+   echo "CONFIG_VDE=y" >> $config_host_mak
+ fi
++if test "$vknet" = "yes" ; then
++  echo "CONFIG_VKNET=y" >> $config_host_mak
++fi
+ if test "$netmap" = "yes" ; then
+   echo "CONFIG_NETMAP=y" >> $config_host_mak
+ fi


### PR DESCRIPTION
Adds a vknet network backend to qemu-devel that allows utilizing the vknetd(1) userspace switch similarly to how it can already be used vor DragonFly vkernels.

can be used by adding to the qemu command-line something like:

-netdev vknet,id=vke0 -device virtio-net,netdev=vke0

which would add a virtio network device for the guest, which is connected to the outside via the default vknetd socket ( /var/run/vknet ). The vknetd socket can also be explicitly specified, e.g. with:

-netdev vknet,id=vke0,sock=/var/run/myvknet -device virtio-net,netdev=vke0