### PR TITLE
mail/antivirus-milter: add alias

### DIFF
--- a/ports/mail/antivirus-milter/Makefile.DragonFly
+++ b/ports/mail/antivirus-milter/Makefile.DragonFly
@@ -1,0 +1,1 @@
+USES+= alias


### PR DESCRIPTION
Untested: requires complicated setup