### PR TITLE
union wait removal

### DIFF
--- a/ports/deskutils/plan/Makefile.DragonFly
+++ b/ports/deskutils/plan/Makefile.DragonFly
@@ -1,0 +1,1 @@
+USES+= alias

--- a/ports/deskutils/xmdiary/Makefile.DragonFly
+++ b/ports/deskutils/xmdiary/Makefile.DragonFly
@@ -1,1 +1,7 @@
-CFLAGS:=	${CFLAGS:S/-Werror//}
+
+# zrj: union wait removal
+dfly-patch:
+	${REINPLACE_CMD} -e 's@ifndef \(__FreeBSD__\)@if \!(defined(\1)||defined(__DragonFly__))@g'	\
+		${WRKSRC}/ndbm/xdndbm.c
+	${REINPLACE_CMD} -e 's@\(defined(__FreeBSD__)\)@(\1||defined(__DragonFly__))@g'	\
+		${WRKSRC}/tools/SigHandler.c

--- a/ports/devel/xxgdb/Makefile.DragonFly
+++ b/ports/devel/xxgdb/Makefile.DragonFly
@@ -1,0 +1,7 @@
+
+# zrj: union wait removal
+dfly-patch:
+	${REINPLACE_CMD} -e 's@\(defined(__FreeBSD__)\)@(\1||defined(__DragonFly__))@g'	\
+		${WRKSRC}/command.c						\
+		${WRKSRC}/filemenu.c						\
+		${WRKSRC}/signals.c

--- a/ports/japanese/skkfep/Makefile.DragonFly
+++ b/ports/japanese/skkfep/Makefile.DragonFly
@@ -1,0 +1,1 @@
+USES+= alias

--- a/ports/x11/xautolock/Makefile.DragonFly
+++ b/ports/x11/xautolock/Makefile.DragonFly
@@ -1,0 +1,5 @@
+
+# zrj: union wait removal
+dfly-patch:
+	${REINPLACE_CMD} -e 's@\(defined (__FreeBSD__)\)@(\1||defined(__DragonFly__))@g'	\
+		${WRKSRC}/src/engine.c

--- a/ports/x11/xdtm/Makefile.DragonFly
+++ b/ports/x11/xdtm/Makefile.DragonFly
@@ -1,0 +1,5 @@
+
+# zrj: union wait removal
+dfly-patch:
+	${REINPLACE_CMD} -e 's@\(defined(__FreeBSD__)\)@(\1||defined(__DragonFly__))@g'	\
+		${WRKSRC}/appman.c


### PR DESCRIPTION
For upcoming wait.h cleanup (removal of deprecated 4.4bsd union wait). 
Most of these can be patched in fports files/ patches directly.
Doesn't create compilation problems on 4.4, but might need version checking.

Affected ports so far:
deskutils/xmdiary
devel/xxgdb
deskutils/plan
japanese/plan
japanese/skkfep
x11/xautolock
x11/xdtm
