### PR TITLE
audio/cddb: add dragonfly

### DIFF
--- a/ports/audio/cd-discid/dragonfly/patch-cd-discid.c
+++ b/ports/audio/cd-discid/dragonfly/patch-cd-discid.c
@@ -1,0 +1,28 @@
+
+Not sure if ntohl is needed
+--- cd-discid.c.orig	2003-12-16 01:55:00.000000000 +0200
++++ cd-discid.c
+@@ -37,7 +37,7 @@
+  * to compile on Solaris */
+ #define cdte_track_address cdte_addr.lba
+ 
+-#elif defined(__FreeBSD__)
++#elif defined(__FreeBSD__) || defined(__DragonFly__)
+ 
+ #include <sys/cdio.h>
+ #define        CDROM_LBA       CD_LBA_FORMAT   /* first frame is 0 */
+@@ -214,12 +214,12 @@ int main(int argc, char *argv[])
+ 	}
+ #endif
+ 
+-#if defined(__FreeBSD__)
++#if defined(__FreeBSD__) || defined(__DragonFly__)
+ 	TocEntry[i].cdte_track_address = ntohl(TocEntry[i].cdte_track_address);
+ #endif       
+ 
+ 	for (i=0; i < last; i++) {
+-#if defined(__FreeBSD__)
++#if defined(__FreeBSD__) || defined(__DragonFly__)
+ 		TocEntry[i].cdte_track_address = ntohl(TocEntry[i].cdte_track_address);
+ #endif
+ 		cksum += cddb_sum((TocEntry[i].cdte_track_address + CD_MSF_OFFSET) / CD_FRAMES);

--- a/ports/audio/py-cddb/dragonfly/patch-unix_cdrommodule.c
+++ b/ports/audio/py-cddb/dragonfly/patch-unix_cdrommodule.c
@@ -1,0 +1,20 @@
+--- unix/cdrommodule.c.orig	2003-09-01 02:24:30.000000000 +0300
++++ unix/cdrommodule.c
+@@ -29,7 +29,7 @@
+ #include <linux/cdrom.h>
+ #endif
+ 
+-#if defined(sun) || defined(__FreeBSD__) || defined(__OpenBSD__)
++#if defined(sun) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
+ #include <sys/cdio.h>
+ #endif
+ 
+@@ -45,7 +45,7 @@
+  * so that we don't have to repeat the code.
+  */
+ 
+-#ifdef __FreeBSD__
++#if defined(__FreeBSD__) || defined(__DragonFly__)
+ 
+ #define CDDB_TOC_HEADER_STRUCT ioc_toc_header 
+ #define CDDB_STARTING_TRACK_FIELD starting_track 


### PR DESCRIPTION
Not sure if these are correct, don't have any audio-cds
so adding not as alias but as patches to grep.

There are quite many audio ports with lots of runtime deps,
so this will help a bit even if these aren't fully functional.