### PR TITLE
x11/i3status: unbreak build on new version

### DIFF
--- a/ports/x11/i3status/Makefile.DragonFly
+++ b/ports/x11/i3status/Makefile.DragonFly
@@ -1,0 +1,1 @@
+PULSEAUDIO_EXTRA_PATCHES_OFF+= ${DFLY_FILESDIR}/hellno-pulseaudio.diff

--- a/ports/x11/i3status/dragonfly/hellno-pulseaudio.diff
+++ b/ports/x11/i3status/dragonfly/hellno-pulseaudio.diff
@@ -1,0 +1,25 @@
+--- Makefile.intermediate	2016-01-15 15:40:01.000000000 +0200
++++ Makefile
+@@ -80,6 +80,11 @@ OBJS:=$(filter-out src/pulse.o, $(OBJS))
+ LIBS:=$(filter-out -lpulse, $(LIBS)) -lpthread
+ endif
+ 
++ifeq ($(OS),DragonFly)
++OBJS:=$(filter-out src/pulse.o, $(OBJS))
++LIBS:=$(filter-out -lpulse, $(LIBS)) -lpthread
++endif
++
+ src/%.o: src/%.c include/i3status.h
+ 	$(CC) $(CPPFLAGS) $(CFLAGS) -c -o $@ $<
+ 	@echo " CC $<"
+--- src/print_volume.c.intermediate	2016-01-15 15:40:01.000000000 +0200
++++ src/print_volume.c
+@@ -60,7 +60,7 @@ void print_volume(yajl_gen json_gen, cha
+         free(instance);
+     }
+ 
+-#if !defined(__OPENBSD__) && !defined(__FreeBSD__)
++#if !defined(__OPENBSD__) && !defined(__FreeBSD__) && !defined(__DragonFly__)
+     /* Try PulseAudio first */
+ 
+     /* If the device name has the format "pulse[:N]" where N is the


### PR DESCRIPTION
Looks like bapt forgot to include DragonFly in extra patch while
handling upstream forced req on libpulse (not default OPTION).
So this takes care of PULSEAUDIO option handling on dports side.

Tested (ofc just w/ "default" options mode)
Both battery stats and cpu tz temps are still reported correctly.