### PR TITLE
audio/clunk: fix build

### DIFF
--- a/ports/audio/clunk/dragonfly/patch-clunk_hrtf.cpp
+++ b/ports/audio/clunk/dragonfly/patch-clunk_hrtf.cpp
@@ -1,0 +1,11 @@
+--- clunk/hrtf.cpp.orig	2014-09-29 09:48:48.000000000 +0300
++++ clunk/hrtf.cpp
+@@ -24,7 +24,7 @@
+ 
+ #include "kemar.h"
+ 
+-#if defined _MSC_VER || __APPLE__ || __FreeBSD__
++#if defined _MSC_VER || __APPLE__ || __FreeBSD__ || __DragonFly__
+ #	define pow10f(x) powf(10.0f, (x))
+ #	define log2f(x) (logf(x) / M_LN2)
+ #endif

--- a/ports/audio/clunk/dragonfly/patch-clunk_source.cpp
+++ b/ports/audio/clunk/dragonfly/patch-clunk_source.cpp
@@ -1,0 +1,11 @@
+--- clunk/source.cpp.orig	2014-09-29 09:48:48.000000000 +0300
++++ clunk/source.cpp
+@@ -25,7 +25,7 @@
+ #include <clunk/clunk_assert.h>
+ #include <clunk/mixer.h>
+ 
+-#if defined _MSC_VER || __APPLE__ || __FreeBSD__
++#if defined _MSC_VER || __APPLE__ || __FreeBSD__ || __DragonFly__
+ #	define pow10f(x) powf(10.0f, (x))
+ #	define log2f(x) (logf(x) / M_LN2)
+ #endif


### PR DESCRIPTION
Depends on subst of OPTIONS_DEFAULT_x86_64=SSE (from _amd64)