### PR TITLE
x11-drivers/xf86-input-evdev: drop webcamd run dep

### DIFF
--- a/ports/x11-drivers/xf86-input-evdev/Makefile.DragonFly
+++ b/ports/x11-drivers/xf86-input-evdev/Makefile.DragonFly
@@ -1,0 +1,3 @@
+
+# zrj: for now disable synthetic run dep on webcamd(no cuse4bsd on DragonFly)
+RUN_DEPENDS:= ${RUN_DEPENDS:Nwebcamd*}


### PR DESCRIPTION
ivadasz says that it still useful if someone would want to
write/port device driver that uses evdev device file and it
would useful if userspace tools would be already available.