### PR TITLE
x11-drivers/xf86-input-wacom: remove wbcamd run dep

### DIFF
--- a/ports/x11-drivers/xf86-input-wacom/Makefile.DragonFly
+++ b/ports/x11-drivers/xf86-input-wacom/Makefile.DragonFly
@@ -1,0 +1,3 @@
+
+# zrj: for now disable synthetic run dep on webcamd(no cuse4bsd on DragonFly)
+RUN_DEPENDS:= ${RUN_DEPENDS:Nwebcamd*}


### PR DESCRIPTION
same as previous