### PR TITLE
www/w3m: disable fb (frambuffer)

### DIFF
--- a/ports/www/w3m/Makefile.DragonFly
+++ b/ports/www/w3m/Makefile.DragonFly
@@ -1,0 +1,3 @@
+
+# zrj: disable fb (framebuffer) no fb_cmap_get() etc functions implemented
+INLINE_IMAGE_CONFIGURE_ON:= ${INLINE_IMAGE_CONFIGURE_ON:S/fb,x11/x11/}


### PR DESCRIPTION
lots of work to implement linux fb compat would be needed, so just disable
X11 backend should still work.

Unbreaks:
www/w3m (w/ INLINE_IMAGE option)
www/w3m-img
japanese/w3m-img