### PR TITLE
emulators/qemu-devel: just an educated guess

### DIFF
--- a/ports/emulators/qemu-devel/Makefile.DragonFly
+++ b/ports/emulators/qemu-devel/Makefile.DragonFly
@@ -5,3 +5,6 @@ OPTIONS_DEFAULT:=	${OPTIONS_DEFAULT} VKNET
 VKNET_DESC=		vknet network backend for simple userspace bridge
 VKNET_CONFIGURE_ENABLE=	vknet
 VKNET_EXTRA_PATCHES=	${DFLY_FILESDIR}/vknet-patch
+
+# zrj: dunno about this BSD_USER thingy but adding this flag fixes plist (and build warnings)
+CONFIGURE_ARGS+= --disable-bsd-user

--- a/ports/emulators/qemu-devel/dragonfly/vknet-patch
+++ b/ports/emulators/qemu-devel/dragonfly/vknet-patch
@@ -256,8 +256,8 @@
 +    const NetdevVknetOptions *vknet;
 +    const char *path;
 +
-+    assert(opts->kind == NET_CLIENT_OPTIONS_KIND_VKNET);
-+    vknet = opts->vknet;
++    assert(opts->type == NET_CLIENT_OPTIONS_KIND_VKNET);
++    vknet = opts->u.vknet;
 +    if (vknet->sock == NULL)
 +        path = "/var/run/vknet";
 +    else


### PR DESCRIPTION
based on changes to net/vde.c
Have no idea about internals of bridges nor bsd_user

Seems to work:
qemu-system-x86_64 -cdrom /data/dfly-x86_64-4.4.1.iso