### PR TITLE
sysutils/hal: to prevent gnome fallout after isofs/cd9660 changes

### DIFF
--- a/ports/sysutils/hal/Makefile.DragonFly
+++ b/ports/sysutils/hal/Makefile.DragonFly
@@ -1,2 +1,9 @@
 USE_AUTOTOOLS+= autoconf
 PLIST_SUB+= USB2="@comment "
+
+# zrj: for cd9660/iso.h fixup compat for previous versions
+dfly-patch:
+.if ${DFLYVERSION} < 400502
+	${REINPLACE_CMD} -e "/600101/s@(__DragonFly__)@ __dRAGONfLY__@g"	\
+		${WRKSRC}/hald/freebsd/probing/probe-volume.c
+.endif

--- a/ports/sysutils/hal/dragonfly/patch-hald_freebsd_probing_probe-volume.c
+++ b/ports/sysutils/hal/dragonfly/patch-hald_freebsd_probing_probe-volume.c
@@ -1,5 +1,5 @@
 --- hald/freebsd/probing/probe-volume.c.intermediate	2012-12-21 19:26:23.418869000 +0100
-+++ hald/freebsd/probing/probe-volume.c	2012-12-21 19:40:08.842767000 +0100
++++ hald/freebsd/probing/probe-volume.c
 @@ -33,7 +33,11 @@
  #include <fcntl.h>
  #include <unistd.h>
@@ -24,7 +24,16 @@
  #include <isofs/cd9660/iso.h>
  #include <glib.h>
  #include <libvolume_id.h>
-@@ -332,6 +340,9 @@
+@@ -64,7 +72,7 @@
+ };
+ #define ISO_PATH_TABLE_ENTRY_SIZE         8
+ 
+-#if (__FreeBSD_version < 600101) && (__FreeBSD_kernel_version < 600101)
++#if (__FreeBSD_version < 600101) && (__FreeBSD_kernel_version < 600101) && !defined(__DragonFly__)
+ static uint32_t
+ isonum_731(unsigned char *p)
+ {
+@@ -332,6 +340,9 @@ main (int argc, char **argv)
    gboolean is_blank = FALSE;
    const char *usage;
    char *label;


### PR DESCRIPTION
After leaf/~zrj/cd9660_changes, for now just on pending state
cause i need to acquire base version bump token.

Basically currently hal compilation relies on __FreeBSD_version
evaluating as 0, that is bad.

Btw synth always recompile devel/nspr and friends ..