### PR TITLE
Fix build of devel/readline after privatization of ncurses.

### DIFF
--- a/ports/devel/readline/Makefile.DragonFly
+++ b/ports/devel/readline/Makefile.DragonFly
@@ -1,5 +1,6 @@
 USES+=	ncurses
-OPTIONS_DEFAULT:= ${DEFAULT_OPTIONS:NTERMCAP}
+OPTIONS_DEFAULT:= ${OPTIONS_DEFAULT:NTERMCAP}
 
 pre-configure-script:
 	${REINPLACE_CMD} "s/SHOBJ_LDFLAGS =/SHOBJ_LDFLAGS = -lncurses/" ${WRKSRC}/shlib/Makefile.in
+	${REINPLACE_CMD} "s/-ltermcap//" ${WRKSRC}/shlib/Makefile.in


### PR DESCRIPTION
Explicitely remove -ltermcap from linker flags to ensure the port is buildable
even with TERMCAP option set.