### PR TITLE
devel/android: fix synth test (disable test)

### DIFF
--- a/ports/devel/android-tools-simpleperf/Makefile.DragonFly
+++ b/ports/devel/android-tools-simpleperf/Makefile.DragonFly
@@ -1,0 +1,5 @@
+
+# zrj: to fix TEST option
+dfly-patch:
+	${REINPLACE_CMD} -e "/^TEST/ s@ \(UNIMPLEMENTED\)@ DISABLED_\1@g" \
+		${WRKSRC}/base/logging_test.cpp


### PR DESCRIPTION
Seems there is some regex_error in cxx
Look into MF, free10 also had this problem.
For us just UNIMPLEMENTED.