### PR TITLE
sysutils/ah-tty: fix ncurses

### DIFF
--- a/ports/sysutils/ah-tty/Makefile.DragonFly
+++ b/ports/sysutils/ah-tty/Makefile.DragonFly
@@ -1,0 +1,8 @@
+USES+=		ncurses
+
+#disable static version for now. libtinfo.a issue
+PLIST_FILES:=${PLIST_FILES:Nbin/ah-tty.static}
+
+dfly-patch:
+	${REINPLACE_CMD} -e '/bin_PROGRAMS/s@ah-tty.static@@g'	\
+		${WRKSRC}/Makefile.in


### PR DESCRIPTION
Disabled static bin building for now,
devel/ncurses has a separated -ltinfo from ncurses
and since configure doesn't detect that better to avoid that.