### PR TITLE
cad/kicad-devel: Build fix

### DIFF
--- a/ports/cad/kicad-devel/Makefile.DragonFly
+++ b/ports/cad/kicad-devel/Makefile.DragonFly
@@ -1,1 +1,2 @@
-CXXFLAGS+=	-Wno-deprecated-declarations
+# boost stuff: dep auto_ptr and __float128 literals ext
+CXXFLAGS+=	-Wno-deprecated-declarations -fext-numeric-literals


### PR DESCRIPTION
Technically it is a boost bug and kicad should actually test
boost headers for caps (deal with BOOST_MATH_DISABLE_FLOAT128).

For now just explicitly activate the literals extension.
Breakage reason: kicad no longer uses "safe" internal boost contrib.