### PR TITLE
sysutils/devfw-*: Set NO_ARCH to 'yes'

### DIFF
--- a/ports/sysutils/devfw-amdgpu/newport/Makefile
+++ b/ports/sysutils/devfw-amdgpu/newport/Makefile
@@ -39,7 +39,7 @@ FWNAME=		amdgpufw
 FWFILE=		amdgpu-firmware-${FWVERSION}.tar.gz
 FWVERSION=	20160413
 
-NO_ARCH=
+NO_ARCH=	yes
 DATADIR=	${PREFIX}/share/fw-amdgpu
 
 USES=		uidfix

--- a/ports/sysutils/devfw-bwn/newport/Makefile
+++ b/ports/sysutils/devfw-bwn/newport/Makefile
@@ -44,7 +44,7 @@ FWVERSION_LP=	4.178.10.4
 .if (!defined(DPORTS_BUILDER) && defined(PACKAGE_BUILDING)) && !defined(DEVELOPER)
 NO_PACKAGE=	this is a modified version of a restricted firmware
 .endif
-NO_ARCH=
+NO_ARCH=	yes
 DATADIR=	${PREFIX}/share/fw-bwn
 
 USES=		uidfix

--- a/ports/sysutils/devfw-i915/newport/Makefile
+++ b/ports/sysutils/devfw-i915/newport/Makefile
@@ -18,7 +18,7 @@ FWNAME=		i915fw
 FWFILE=		i915-firmware-${FWVERSION}.tar.gz
 FWVERSION=	20160311
 
-NO_ARCH=
+NO_ARCH=	yes
 DATADIR=	${PREFIX}/share/fw-i915
 
 USES=		uidfix

--- a/ports/sysutils/devfw-radeon/newport/Makefile
+++ b/ports/sysutils/devfw-radeon/newport/Makefile
@@ -78,7 +78,7 @@ FWNAME=		radeonfw
 FWFILE=		radeon-firmware-${FWVERSION}.tar.gz
 FWVERSION=	20160328
 
-NO_ARCH=
+NO_ARCH=	yes
 DATADIR=	${PREFIX}/share/fw-radeon
 
 USES=		uidfix


### PR DESCRIPTION
For some reason I thought it is enough to just set NO_ARCH
Should avoid the:
DEVELOPER_MODE: Notice: arch ... no architecture specific files found: