### PR TITLE
x11-drivers/xf86-video-ati: Newport it to update.

### DIFF
--- a/ports/x11-drivers/xf86-video-ati/Makefile.DragonFly
+++ b/ports/x11-drivers/xf86-video-ati/Makefile.DragonFly
@@ -1,3 +1,0 @@
-
-# zrj: enable radeonsi support(requires glamor support in Xorg)
-CONFIGURE_ARGS:= ${CONFIGURE_ARGS:N--disable-glamor} --enable-glamor

--- a/ports/x11-drivers/xf86-video-ati/STATUS
+++ b/ports/x11-drivers/xf86-video-ati/STATUS
@@ -1,3 +1,3 @@
-PORT
+DPORT
 Last attempt: 7.5.0_3
 Last success: 7.5.0_3

--- a/ports/x11-drivers/xf86-video-ati/newport/Makefile
+++ b/ports/x11-drivers/xf86-video-ati/newport/Makefile
@@ -1,0 +1,28 @@
+# Updated driver version, keep PORTREVISION bumping with every xorg-server bump
+
+PORTNAME=	xf86-video-ati
+PORTVERSION=	7.7.0
+PORTREVISION=	3
+CATEGORIES=	x11-drivers
+
+MAINTAINER=	x11@FreeBSD.org
+COMMENT=	X.Org ati display driver
+
+USE_GL=		gl
+XORG_CAT=	driver
+USE_XORG=	xf86driproto \
+		xineramaproto \
+		xf86miscproto \
+		glproto \
+		presentproto
+INSTALL_TARGET=	install-strip
+# No Radeon kernel driver on non-x86 and PC98.
+ONLY_FOR_ARCHS=	i386 amd64
+
+CONFIGURE_ARGS+=--disable-udev
+# zrj: enable radeonsi support(requires glamor support in Xorg)
+CONFIGURE_ARGS+=--enable-glamor
+
+.include <bsd.port.options.mk>
+
+.include <bsd.port.mk>

--- a/ports/x11-drivers/xf86-video-ati/newport/distinfo
+++ b/ports/x11-drivers/xf86-video-ati/newport/distinfo
@@ -1,0 +1,2 @@
+SHA256 (xorg/driver/xf86-video-ati-7.7.0.tar.bz2) = 844d1c577b145c90dc8ef027678f0c27f554363f782cd696a3aea26415b2c1c3
+SIZE (xorg/driver/xf86-video-ati-7.7.0.tar.bz2) = 836902

--- a/ports/x11-drivers/xf86-video-ati/newport/files/patch-src__radeon_kms.c
+++ b/ports/x11-drivers/xf86-video-ati/newport/files/patch-src__radeon_kms.c
@@ -1,0 +1,45 @@
+--- src/radeon_kms.c.orig	2014-10-02 05:31:27.000000000 +0200
++++ src/radeon_kms.c	2014-10-23 18:56:18.359108170 +0200
+@@ -30,6 +30,8 @@
+ 
+ #include <errno.h>
+ #include <sys/ioctl.h>
++#include <sys/param.h>
++#include <sys/linker.h>
+ /* Driver data structures */
+ #include "radeon.h"
+ #include "radeon_reg.h"
+@@ -280,7 +282,7 @@
+ radeon_dirty_update(ScreenPtr screen)
+ {
+ 	RegionPtr region;
+-	PixmapDirtyUpdatePtr ent;
++	PixmapDirtyUpdatePtr ent = NULL;
+ 
+ 	if (xorg_list_is_empty(&screen->pixmap_dirty_list))
+ 		return;
+@@ -589,7 +591,7 @@
+ #endif
+     struct pci_device *dev = info->PciInfo;
+     char *busid;
+-    int fd;
++    int fd, err;
+ 
+ #ifdef XF86_PDEV_SERVER_FD
+     if (pRADEONEnt->platform_dev) {
+@@ -608,6 +610,15 @@
+ 		      dev->domain, dev->bus, dev->dev, dev->func);
+ #endif
+ 
++    err = kldload("radeonkms");
++    if (err == -1 && errno != EEXIST) {
++	xf86DrvMsg(pScrn->scrnIndex, X_ERROR,
++		   "[drm] Failed to load kernel module for %s: %s\n",
++		   busid, strerror(errno));
++	free(busid);
++	return -1;
++    }
++
+     fd = drmOpen(NULL, busid);
+     if (fd == -1)
+ 	xf86DrvMsg(pScrn->scrnIndex, X_ERROR,

--- a/ports/x11-drivers/xf86-video-ati/newport/files/patch-src_radeon_accel.c
+++ b/ports/x11-drivers/xf86-video-ati/newport/files/patch-src_radeon_accel.c
@@ -1,0 +1,15 @@
+--- src/radeon_accel.c.orig	2012-06-25 10:19:41.000000000 +0200
++++ src/radeon_accel.c	2012-07-30 02:11:51.000000000 +0200
+@@ -967,10 +967,9 @@
+ 
+ 	    for (; nwords > 0; --nwords, ++d, ++s)
+ #ifdef __powerpc__
+-		asm volatile("stwbrx %0,0,%1" : : "r" (*s), "r" (d));
++		asm volatile("sthbrx %0,0,%1" : : "r" (*s), "r" (d));
+ #else
+-		*d = ((*s >> 24) & 0xff) | ((*s >> 8) & 0xff00)
+-			| ((*s & 0xff00) << 8) | ((*s & 0xff) << 24);
++		*d = (*s >> 8) | (*s << 8);
+ #endif
+ 	    return;
+         }

--- a/ports/x11-drivers/xf86-video-ati/newport/pkg-descr
+++ b/ports/x11-drivers/xf86-video-ati/newport/pkg-descr
@@ -1,0 +1,1 @@
+This package contains the X.Org xf86-video-ati driver.

--- a/ports/x11-drivers/xf86-video-ati/newport/pkg-plist
+++ b/ports/x11-drivers/xf86-video-ati/newport/pkg-plist
@@ -1,0 +1,4 @@
+lib/xorg/modules/drivers/ati_drv.so
+lib/xorg/modules/drivers/radeon_drv.so
+man/man4/ati.4x.gz
+man/man4/radeon.4x.gz


### PR DESCRIPTION
Current oficial 7.7 version performs better on xorg v1.17.4.
Also, contains both new supported hardware (like R7 360 bonaire)
and driver fixes that are hard to backport back to 7.5 version.

Tested-on: master w/ JUNIPER, CAICOS, OLAND and BONAIRE cards.