### PR TITLE
Fix a longstanding issue with named pipes in libuv

### DIFF
--- a/ports/www/node/dragonfly/patch-deps_uv_src_unix_stream.c
+++ b/ports/www/node/dragonfly/patch-deps_uv_src_unix_stream.c
@@ -1,0 +1,17 @@
+--- deps/uv/src/unix/stream.c.orig	2016-05-22 22:43:49 UTC
++++ deps/uv/src/unix/stream.c
+@@ -961,6 +961,14 @@ uv_handle_type uv__handle_type(int fd) {
+     return UV_UNKNOWN_HANDLE;
+
+   if (type == SOCK_STREAM) {
++#if defined(_AIX) || defined(__DragonFly__)
++    /* on AIX/DragonFly the getsockname call returns an empty sa structure
++     * for sockets of type AF_UNIX.  For all other types it will
++     * return a properly filled in structure.
++     */
++    if (len == 0)
++      return UV_NAMED_PIPE;
++#endif
+     switch (ss.ss_family) {
+       case AF_UNIX:
+         return UV_NAMED_PIPE;

--- a/ports/www/node/dragonfly/patch-deps_uv_src_unix_tty.c
+++ b/ports/www/node/dragonfly/patch-deps_uv_src_unix_tty.c
@@ -1,0 +1,20 @@
+--- deps/uv/src/unix/tty.c.orig	2016-05-22 22:43:55 UTC
++++ deps/uv/src/unix/tty.c
+@@ -236,14 +236,14 @@ uv_handle_type uv_guess_handle(uv_file f
+       return UV_UDP;
+
+   if (type == SOCK_STREAM) {
+-#if defined(_AIX)
+-    /* on AIX the getsockname call returns an empty sa structure
++#if defined(_AIX) || defined(__DragonFly__)
++    /* on AIX/DragonFly the getsockname call returns an empty sa structure
+      * for sockets of type AF_UNIX.  For all other types it will
+      * return a properly filled in structure.
+      */
+     if (len == 0)
+       return UV_NAMED_PIPE;
+-#endif /* defined(_AIX) */
++#endif /* defined(_AIX) || defined(__DragonFly__) */
+
+     if (sa.sa_family == AF_INET || sa.sa_family == AF_INET6)
+       return UV_TCP;


### PR DESCRIPTION
This is a [bug][1] in libuv. The type of a named pipe was not correctly
identified on DragonFly, which led to the following problems in node:

    internal/process/stdio.js:152
          throw new Error('Implement me. Unknown stream file type!');
          ^

    Error: Implement me. Unknown stream file type!
        at createWritableStdioStream (internal/process/stdio.js:152:13)
        at process.stderr (internal/process/stdio.js:25:14)
        at Socket._destroy (net.js:476:25)
        at Socket.destroy (net.js:510:8)
        at maybeDestroy (net.js:434:12)
        at Pipe.onread (net.js:562:5)

[1]: https://github.com/libuv/libuv/pull/884