### PR TITLE
multimedia/handbrake: Build fix

### DIFF
--- a/ports/multimedia/handbrake/Makefile.DragonFly
+++ b/ports/multimedia/handbrake/Makefile.DragonFly
@@ -1,0 +1,7 @@
+USES+= alias
+
+dfly-patch:
+	${LN} -v ${WRKSRC}/make/variant/gnu.defs		\
+		 ${WRKSRC}/make/variant/dragonfly.defs
+	-${REINPLACE_CMD} -e 's@&& __FreeBSD_version >= 470000@|| defined(__DragonFly__)@g'	\
+		${WRKSRC}/build/contrib/libdvdread/libdvdread-5.0.0-6-gcb1ae87/src/bswap.h

--- a/ports/multimedia/handbrake/dragonfly/patch-contrib_ffmpeg_module.defs
+++ b/ports/multimedia/handbrake/dragonfly/patch-contrib_ffmpeg_module.defs
@@ -1,0 +1,11 @@
+--- contrib/ffmpeg/module.defs.bak	2016-05-30 17:00:05.000000000 +0300
++++ contrib/ffmpeg/module.defs
+@@ -80,6 +80,8 @@ else ifeq (1-mingw,$(BUILD.cross)-$(BUIL
+     FFMPEG.GCC.args.extra += -fno-common
+ else ifeq (freebsd,$(BUILD.system))
+     FFMPEG.CONFIGURE.extra += --enable-pthreads --disable-devices
++else ifeq (dragonfly,$(BUILD.system))
++    FFMPEG.CONFIGURE.extra += --enable-pthreads --disable-devices
+ else
+     FFMPEG.CONFIGURE.extra += --enable-pthreads
+ endif

--- a/ports/multimedia/handbrake/dragonfly/patch-make_include_main.defs
+++ b/ports/multimedia/handbrake/dragonfly/patch-make_include_main.defs
@@ -1,0 +1,14 @@
+--- make/include/main.defs.bak	2016-05-30 17:00:04.000000000 +0300
++++ make/include/main.defs
+@@ -130,6 +130,11 @@ ifeq (1-freebsd,$(FEATURE.gtk)-$(BUILD.s
+     MODULES += gtk
+ endif
+ 
++ifeq (1-dragonfly,$(FEATURE.gtk)-$(BUILD.system))
++    ## build gtk when gtk+dragonfly
++    MODULES += gtk
++endif
++
+ ifeq (1,$(FEATURE.local_yasm))
+     MODULES += contrib/yasm
+ endif


### PR DESCRIPTION
Someone at users@ mentioned that it doesn't build.
Fix is quite trivial and still alows to have synth test pass
even with lots of contrib packages.

No runtime GUI test, cause of GTK3->dbus