### PR TITLE
graphics/embree: Restore previous variants

### DIFF
--- a/ports/graphics/embree/Makefile.DragonFly
+++ b/ports/graphics/embree/Makefile.DragonFly
@@ -1,0 +1,10 @@
+
+# zrj: just to avoid MAP_HUGETLB, MAP_POPULATE, MAP_PREFAULT_READ
+dfly-patch:
+	${REINPLACE_CMD} -e 's@MAP_ALIGNED_SUPER@0x0@g'	\
+		${WRKSRC}/common/sys/alloc.cpp
+	${REINPLACE_CMD} -e 's@MAP_POPULATE@0x0@g'	\
+			 -e 's@MAP_PREFAULT_READ@0x0@g'	\
+		${WRKSRC}/tests/benchmark.cpp
+	${REINPLACE_CMD} -e 's@\(defined(__FreeBSD__)\)@(\1||defined(__DragonFly__))@g'	\
+		${WRKSRC}/common/math/math.h

--- a/ports/graphics/embree/dragonfly/patch-common_sys_alloc.cpp
+++ b/ports/graphics/embree/dragonfly/patch-common_sys_alloc.cpp
@@ -1,0 +1,18 @@
+--- common/sys/alloc.cpp	2016-05-20 08:45:13.000000000 +0300
++++ common/sys/alloc.cpp
+@@ -97,6 +97,7 @@ namespace embree
+ {
+   __forceinline bool isHugePageCandidate(const size_t bytes) 
+   {
++#ifndef __DragonFly__
+     /* try to use huge pages for large allocations */
+     if (bytes >= PAGE_SIZE_2M)
+     {
+@@ -106,6 +107,7 @@ namespace embree
+       else if (bytes >= 64 * PAGE_SIZE_2M) /* will only introduce a 3% overhead */
+         return true;
+     }
++#endif
+     return false;
+   }
+ 


### PR DESCRIPTION
All of these were done for "speed" in a very unclean way,
restore to simpler form.