### PR TITLE
x11-servers/xwayland: Add newport similar to xephyr for Xwayland.

### DIFF
--- a/ports/x11-servers/xwayland/newport/Makefile
+++ b/ports/x11-servers/xwayland/newport/Makefile
@@ -1,0 +1,33 @@
+PORTNAME=	xwayland
+
+COMMENT=	X server from X.Org for running X11 applications on Wayland.
+
+LIB_DEPENDS+=	libdrm.so:graphics/libdrm \
+		libepoxy.so:graphics/libepoxy
+
+BUILD_DEPENDS=	wayland>=1.9.0:graphics/wayland \
+		${LOCALBASE}/include/linux/input.h:${PORTSDIR}/multimedia/v4l_compat
+
+MASTERDIR=	${.CURDIR}/../xorg-server
+DESCR=		${.CURDIR}/pkg-descr
+USE_XORG=	x11 xf86driproto glproto randrproto renderproto fixesproto \
+		dri2proto damageproto xcmiscproto xtrans inputproto \
+		xf86bigfontproto scrnsaverproto bigreqsproto \
+		resourceproto fontsproto videoproto \
+		compositeproto trapproto recordproto \
+		xineramaproto xinerama evieproto xkbfile xfont \
+		xau xdmcp xext fontenc xv pixman presentproto
+
+CONFIGURE_ARGS=	--disable-kdrive --disable-xephyr --disable-dmx --disable-xvfb \
+		--disable-xwin --disable-xorg --enable-xwayland \
+		--without-xmlto --disable-docs --disable-devel-docs \
+		--disable-xnest --localstatedir=/var --without-dtrace \
+		--enable-install-setuid=no
+
+SLAVE_PORT=	yes
+PLIST_FILES=	bin/Xwayland
+
+do-install:
+	${INSTALL_PROGRAM} ${WRKSRC}/hw/xwayland/Xwayland ${STAGEDIR}${PREFIX}/bin
+
+.include "${MASTERDIR}/Makefile"

--- a/ports/x11-servers/xwayland/newport/pkg-descr
+++ b/ports/x11-servers/xwayland/newport/pkg-descr
@@ -1,0 +1,3 @@
+Xwayland is an Xorg server for running X applications on a Wayland compositor.
+
+WWW: http://www.x.org/


### PR DESCRIPTION
I was quite surprised that (at least for the xwayland from the 1.17.xx xserver), building Xwayland as a slave port like xephyr seems to just work out, without any special configure flags needed :)

The main issue left is that we should have all the options available in the master xorg-server port's Makefile (DEVD, HAL and SUID) disabled by default.

based on https://github.com/DragonFlyBSD/DPorts/issues/178
thanks to peeterm007 for looking at this again, and providing some motiviation to get this done.