### PR TITLE
www/npm: Remove obsolete patch

### DIFF
--- a/ports/www/npm/Makefile.DragonFly
+++ b/ports/www/npm/Makefile.DragonFly
@@ -1,3 +1,0 @@
-dfly-patch:
-	${REINPLACE_CMD} -e "s|'nobody'|'${:!/usr/bin/id -u nobody!}'|" \
-		${WRKSRC}/lib/config/defaults.js


### PR DESCRIPTION
Since the acceptance of the patch to libuv introduced in https://github.com/DragonFlyBSD/DeltaPorts/pull/452 the module uidNumber works with nodejs. As a result, the patch introduced in https://github.com/DragonFlyBSD/DeltaPorts/pull/1 is no longer required.