### PR TITLE
www/firefox: Add slave port for lite package

### DIFF
--- a/ports/www/firefox-lite/Makefile
+++ b/ports/www/firefox-lite/Makefile
@@ -1,0 +1,8 @@
+
+MAINTAINER=	zrj@ef.irc
+COMMENT=	Web browser based on the browser portion of Mozilla (lite package)
+
+LITE=		yes
+MASTERDIR=	${.CURDIR}/../firefox
+
+.include "${MASTERDIR}/Makefile"

--- a/ports/www/firefox/Makefile.DragonFly
+++ b/ports/www/firefox/Makefile.DragonFly
@@ -1,2 +1,11 @@
 MOZ_OPTIONS+= --disable-webrtc
 OPTIONS_DEFAULT:= ${OPTIONS_DEFAULT:NPULSEAUDIO}
+
+# zrj: override default options to "lite" mode (no dbus,gtk3,pulseaudio etc)
+.if defined(LITE)
+PKGNAMESUFFIX+=	-lite
+CONFLICTS_INSTALL+=	firefox-[0-9].*
+OPTIONS_DEFAULT= BUNDLED_CAIRO FFMPEG ALSA GTK2
+.else
+CONFLICTS_INSTALL+=	firefox-lite-[0-9].*
+.endif


### PR DESCRIPTION
Intended to avoid dep on gtk3 and ensure gtk2 one still functional.

Build order:
  first rebuild www/firefox to include updated MD
  then in separate build, attempt the www/firefox-lite slave