### PR TITLE
comms/kermit: Fix build.

### DIFF
--- a/ports/comms/kermit/Makefile.DragonFly
+++ b/ports/comms/kermit/Makefile.DragonFly
@@ -1,0 +1,5 @@
+USES+= alias ncurses
+
+dfly-patch:
+	${REINPLACE_CMD} -e "s@\(-lncurses\)@-L${LOCALBASE}/lib \1@g"	\
+		${WRKSRC}/makefile

--- a/ports/comms/kermit/dragonfly/patch-ckcdeb.h
+++ b/ports/comms/kermit/dragonfly/patch-ckcdeb.h
@@ -1,0 +1,12 @@
+--- ckcdeb.h.orig	2010-08-23 16:30:56.000000000 +0300
++++ ckcdeb.h
+@@ -4532,7 +4532,9 @@ extern int errno;
+   following is an anachronism and should be the execption rather than the
+   rule.
+ */
++#ifndef __DragonFly__
+ extern int errno;
++#endif
+ #endif /* __GLIBC__ */
+ #endif /* OS2 */
+ #endif /* VMS */

--- a/ports/comms/kermit/dragonfly/patch-ckucmd.c
+++ b/ports/comms/kermit/dragonfly/patch-ckucmd.c
@@ -1,0 +1,17 @@
+--- ckucmd.c.orig	2011-07-14 15:14:37.000000000 +0300
++++ ckucmd.c	2016-06-15 16:12:08.000000000 +0300
+@@ -7396,8 +7396,14 @@ cmdconchk() {
+     if (x < 0) x = 0;
+ #else  /* USE_FILE_CNT */
+ #ifdef USE_FILE_R			/* FreeBSD, OpenBSD, etc */
++#ifdef __DragonFly__
++    struct __FILE_public *fpp = (struct __FILE_public *)__stdinp;
++    debug(F101,"cmdconchk stdin->_r","",fpp->_r);
++    x = fpp->_r;
++#else
+     debug(F101,"cmdconchk stdin->_r","",stdin->_r);
+     x = stdin->_r;
++#endif
+     if (x == 0) x = conchk();
+     if (x < 0) x = 0;
+ 


### PR DESCRIPTION
kermit runs, ncurses functional.
Very complicated low level port, useful for headers testing.