### PR TITLE
emulators/bsvc: Fix c in not c stuff.

### DIFF
--- a/ports/emulators/bsvc/dragonfly/patch-Framework_Interface.cxx
+++ b/ports/emulators/bsvc/dragonfly/patch-Framework_Interface.cxx
@@ -1,0 +1,10 @@
+--- Framework/Interface.cxx.orig	2016-06-15 18:32:28.000000000 +0300
++++ Framework/Interface.cxx
+@@ -34,6 +34,7 @@
+   #include <iostream>
+   #include <strstream>
+   #include <string>
++  #include <cstring>
+ #endif
+ 
+ #ifdef USE_STD

--- a/ports/emulators/bsvc/dragonfly/patch-sim68000_devices_M68681.cxx
+++ b/ports/emulators/bsvc/dragonfly/patch-sim68000_devices_M68681.cxx
@@ -1,0 +1,10 @@
+--- sim68000/devices/M68681.cxx.orig	2016-06-15 18:41:31.000000000 +0300
++++ sim68000/devices/M68681.cxx
+@@ -16,6 +16,7 @@
+ #include <iostream>
+ #include <strstream>
+ #include <string>
++#include <cstdlib>
+ 
+ #include <sys/types.h>
+ #include <unistd.h>

--- a/ports/emulators/bsvc/dragonfly/patch-sim68360_devices_M68681.cxx
+++ b/ports/emulators/bsvc/dragonfly/patch-sim68360_devices_M68681.cxx
@@ -1,0 +1,10 @@
+--- sim68360/devices/M68681.cxx.orig	2016-06-15 18:41:31.000000000 +0300
++++ sim68360/devices/M68681.cxx
+@@ -16,6 +16,7 @@
+ #include <iostream>
+ #include <strstream>
+ #include <string>
++#include <cstdlib>
+ 
+ #include <sys/types.h>
+ #include <unistd.h>


### PR DESCRIPTION
Emulator starts in GUI tk/tcl mode, RAM registers all are there.