### PR TITLE
emulators/skyeye: Mark as ignored.

### DIFF
--- a/ports/emulators/skyeye/Makefile.DragonFly
+++ b/ports/emulators/skyeye/Makefile.DragonFly
@@ -1,0 +1,1 @@
+IGNORE= embedded ARM emulator that requires heavy tun dev support


### PR DESCRIPTION
Requires too much work to get working for little benefit.