### PR TITLE
emulators/gem5: Use alias and mark ignored

### DIFF
--- a/ports/emulators/gem5/Makefile.DragonFly
+++ b/ports/emulators/gem5/Makefile.DragonFly
@@ -1,0 +1,3 @@
+USES+= alias
+
+IGNORE= Very slow build, prune to failures


### PR DESCRIPTION
Very heavy ARM emulator, builds in serial and very long.
Given that simple alias is enough and that it might be useful
for someone to do further develop.

But given that it will fail too often just adding IGNORE= slow build