### PR TITLE
net/dosdetector: Fix build

### DIFF
--- a/ports/net/dosdetector/Makefile.DragonFly
+++ b/ports/net/dosdetector/Makefile.DragonFly
@@ -1,0 +1,1 @@
+USES+= ncurses

--- a/ports/net/dosdetector/dragonfly/patch-include_dos.h
+++ b/ports/net/dosdetector/dragonfly/patch-include_dos.h
@@ -1,0 +1,14 @@
+--- include/dos.h.orig	2006-02-03 14:37:38.000000000 +0200
++++ include/dos.h
+@@ -23,7 +23,11 @@
+ #include <errno.h>
+ #include <netinet/udp.h>
+ #include <net/if.h>
++#ifdef __DragonFly__
++#include <net/ppp/if_ppp.h>
++#else
+ #include <net/ppp_defs.h>
++#endif
+ #include <sys/ioctl.h>
+ #include <time.h>
+ 


### PR DESCRIPTION
Program starts when ran by root, attaches to re0, but dunno how to test it.