### PR TITLE
ftp/llnlxftp: Mark as ignored.

### DIFF
--- a/ports/ftp/llnlxftp/Makefile.DragonFly
+++ b/ports/ftp/llnlxftp/Makefile.DragonFly
@@ -1,0 +1,6 @@
+
+IGNORE= old and segfaults on startup
+
+dfly-patch:
+	${REINPLACE_CMD} -e 's@\(defined(__FreeBSD__)\)@(\1 || defined(__DragonFly__))@g'	\
+		${WRKSRC}/log.c


### PR DESCRIPTION
X11 ftp program dated 1995 that has a tendency to segfault. Just ignore.