### PR TITLE
x11-clocks/wmclockmon: Add support for DragonFly

### DIFF
--- a/ports/x11-clocks/wmclockmon/Makefile.DragonFly
+++ b/ports/x11-clocks/wmclockmon/Makefile.DragonFly
@@ -1,0 +1,1 @@
+USES+= alias

--- a/ports/x11-clocks/wmclockmon/dragonfly/patch-configure
+++ b/ports/x11-clocks/wmclockmon/dragonfly/patch-configure
@@ -1,0 +1,11 @@
+--- configure.orig	2005-04-07 12:37:43.000000000 +0300
++++ configure
+@@ -4047,7 +4047,7 @@ linux*)
+   ignore_buffers=yes
+   ignore_cached=yes
+   ;;
+-freebsd*)
++freebsd*|dragonfly*)
+   OS=freebsd
+   ignore_wired=yes
+   ignore_cached=yes


### PR DESCRIPTION
Small clock widget runs, can be configured