### PR TITLE
sysutils/xmbmon: Mark as ignored

### DIFF
--- a/ports/sysutils/xmbmon/Makefile.DragonFly
+++ b/ports/sysutils/xmbmon/Makefile.DragonFly
@@ -1,0 +1,1 @@
+IGNORE= assumes FreeBSD SMBUS implementation


### PR DESCRIPTION
Could be made working but too much effort while there are cleaner
alternatives, also due to heavy patching prune to probing wrong stuff.