### PR TITLE
devel/bam: Add DragonFly to unix family

### DIFF
--- a/ports/devel/bam/dragonfly/patch-src_platform.h
+++ b/ports/devel/bam/dragonfly/patch-src_platform.h
@@ -1,0 +1,16 @@
+--- src/platform.h.orig	2010-08-09 21:08:24.000000000 +0300
++++ src/platform.h
+@@ -34,6 +34,13 @@
+ 	#define BAM_PLATFORM_STRING "openbsd"
+ #endif
+ 
++#if defined(__DragonFly__)
++	#define BAM_FAMILY_UNIX
++	#define BAM_FAMILY_STRING "unix"
++	#define BAM_PLATFORM_DRAGONFLY
++	#define BAM_PLATFORM_STRING "dragonfly"
++#endif
++
+ #if defined(__LINUX__) || defined(__linux__)
+ 	#define BAM_FAMILY_UNIX
+ 	#define BAM_FAMILY_STRING "unix"


### PR DESCRIPTION
Requires bam.lua as input so untested