### PR TITLE
net/trafshow3: Mark as ignored

### DIFF
--- a/ports/net/trafshow3/Makefile.DragonFly
+++ b/ports/net/trafshow3/Makefile.DragonFly
@@ -1,0 +1,1 @@
+IGNORE= ancient version


### PR DESCRIPTION
uses things like "register", return (u_char *)0 and ncurses.