### PR TITLE
devel/simavr: Mark as ignored

### DIFF
--- a/ports/devel/simavr/Makefile.DragonFly
+++ b/ports/devel/simavr/Makefile.DragonFly
@@ -1,0 +1,1 @@
+IGNORE= heavy patches, Atmel avr simulator


### PR DESCRIPTION
Lots of freebsd patches and twice of that dragonfly ones.
Given that it is for avr cpu emulation, skip for now.