### PR TITLE
sysutils/ua: Fix posix c in not c (bzero)

### DIFF
--- a/ports/sysutils/ua/dragonfly/patch-filei.cc
+++ b/ports/sysutils/ua/dragonfly/patch-filei.cc
@@ -1,0 +1,10 @@
+--- filei.cc.orig	2007-12-05 12:35:25.000000000 +0200
++++ filei.cc
+@@ -37,6 +37,7 @@
+ extern "C" {
+ #include <stdlib.h>
+ #include <unistd.h>
++#include <strings.h>
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <openssl/md5.h>


### PR DESCRIPTION
While it is considered bad practice to use either bzero or memset
in c++ in this case it is relatively safe.

This utility very usefull to easily gather dup files in handy output:
$ find /usr/src/ -type f | ua -