### PR TITLE
sysutils/wm{up,disk}mon: Mark as broken.

### DIFF
--- a/ports/sysutils/wmdiskmon/Makefile.DragonFly
+++ b/ports/sysutils/wmdiskmon/Makefile.DragonFly
@@ -1,0 +1,1 @@
+BROKEN= misbehaves at runtime

--- a/ports/sysutils/wmupmon/Makefile.DragonFly
+++ b/ports/sysutils/wmupmon/Makefile.DragonFly
@@ -1,0 +1,1 @@
+BROKEN= misbehaves at runtime


### PR DESCRIPTION
They could be made to compile and run, but doesn't give expected results.