### PR TITLE
sysutils/jobd: Mark as ignored.

### DIFF
--- a/ports/sysutils/jobd/Makefile.DragonFly
+++ b/ports/sysutils/jobd/Makefile.DragonFly
@@ -1,0 +1,1 @@
+IGNORED="no upstream support"


### PR DESCRIPTION
While it compiles, it lacks any support for DragonFly rc:
**WARNING** Unable to determine the correct rc script to install
Since it is untested, just skip.