### PR TITLE
sysutils/geomgui: Mark as ignored

### DIFF
--- a/ports/sysutils/geomgui/Makefile.DragonFly
+++ b/ports/sysutils/geomgui/Makefile.DragonFly
@@ -1,0 +1,1 @@
+IGNORE= DragonFly kernel doesn't use geom


### PR DESCRIPTION
This port intended for FreeBSD geom layer, that DragonFly doesn't use