### PR TITLE
sysutils/nvramtool: Use alias

### DIFF
--- a/ports/sysutils/nvramtool/Makefile.DragonFly
+++ b/ports/sysutils/nvramtool/Makefile.DragonFly
@@ -1,0 +1,1 @@
+USES+= alias


### PR DESCRIPTION
Utility works, just not very useful on DragonFly cause it is
intended for coreboot(opensource bios) boot.
Still utility is very simple and can dump the cmos contents.