### PR TITLE
deskutils/cal: Fix build

### DIFF
--- a/ports/deskutils/cal/Makefile.DragonFly
+++ b/ports/deskutils/cal/Makefile.DragonFly
@@ -1,0 +1,4 @@
+
+dfly-patch:
+	${REINPLACE_CMD} -e 's@ifdef \(__FreeBSD__\)@if defined(\1) || defined(__DragonFly__)@g'	\
+		${WRKSRC}/cal.c


### PR DESCRIPTION
USES+= alias is a no go, port doesn't honour the CFLAGS.

Calenddar utility runs and has good looking to it.