### PR TITLE
global: Remove ${PORTSDIR}/ from dependencies from MD and newports

### DIFF
--- a/ports/audio/amarok-kde4/Makefile.DragonFly
+++ b/ports/audio/amarok-kde4/Makefile.DragonFly
@@ -1,3 +1,3 @@
 CFLAGS+= -D__STDC_CONSTANT_MACROS=1
 
-BUILD_DEPENDS+=	${LOCALBASE}/include/mysql/mysql.h:${PORTSDIR}/${_MYSQL_CLIENT}
+BUILD_DEPENDS+=	${LOCALBASE}/include/mysql/mysql.h:${_MYSQL_CLIENT}

--- a/ports/audio/kaudiocreator/Makefile.DragonFly
+++ b/ports/audio/kaudiocreator/Makefile.DragonFly
@@ -1,6 +1,6 @@
 USE_KDE4+=	kdelibs libkcddb libkcompactdisc
 
-LIB_DEPENDS+=	libphonon.so:${PORTSDIR}/multimedia/phonon
+LIB_DEPENDS+=	libphonon.so:multimedia/phonon
 
 LDFLAGS+=	-L${LOCALBASE}/kde4/lib -lkio -lsolid
 LDFLAGS+=	-L${LOCALBASE}/lib -lphonon

--- a/ports/chinese/FreeWnn-server/Makefile.DragonFly
+++ b/ports/chinese/FreeWnn-server/Makefile.DragonFly
@@ -1,2 +1,2 @@
-BUILD_DEPENDS+=	tradcpp:${PORTSDIR}/devel/tradcpp
+BUILD_DEPENDS+=	tradcpp:devel/tradcpp
 CPP:=		tradcpp

--- a/ports/comms/jsdr/Makefile.DragonFly
+++ b/ports/comms/jsdr/Makefile.DragonFly
@@ -1,3 +1,3 @@
 USES+= alias
 
-RUN_DEPENDS+= ${LOCALBASE}/lib/librtlsdr.so:${PORTSDIR}/comms/rtl-sdr
+RUN_DEPENDS+= ${LOCALBASE}/lib/librtlsdr.so:comms/rtl-sdr

--- a/ports/converters/pdf2djvu/Makefile.DragonFly
+++ b/ports/converters/pdf2djvu/Makefile.DragonFly
@@ -1,3 +1,3 @@
-LIB_DEPENDS+=	libexpat.so:${PORTSDIR}/textproc/expat2
-LIB_DEPENDS+=	libfreetype.so:${PORTSDIR}/print/freetype2
-LIB_DEPENDS+=	libfontconfig.so:${PORTSDIR}/x11-fonts/fontconfig
+LIB_DEPENDS+=	libexpat.so:textproc/expat2
+LIB_DEPENDS+=	libfreetype.so:print/freetype2
+LIB_DEPENDS+=	libfontconfig.so:x11-fonts/fontconfig

--- a/ports/databases/akonadi/Makefile.DragonFly
+++ b/ports/databases/akonadi/Makefile.DragonFly
@@ -1,1 +1,1 @@
-LIB_DEPENDS+=	libxml2.so:${PORTSDIR}/textproc/libxml2
+LIB_DEPENDS+=	libxml2.so:textproc/libxml2

--- a/ports/databases/evolution-data-server/diffs/Makefile.diff
+++ b/ports/databases/evolution-data-server/diffs/Makefile.diff
@@ -6,7 +6,7 @@
  CONFIGURE_ARGS+=	--with-krb5=/usr
 -KRB5_LIB=		`/usr/bin/krb5-config gssapi --libs`
 +KRB5_LIB=		`${LOCALBASE}/bin/krb5-config gssapi --libs`
-+BUILD_DEPENDS+=		krb5-config:${PORTSDIR}/security/krb5
++BUILD_DEPENDS+=		krb5-config:security/krb5
  .else
  CONFIGURE_ARGS+=	--without-krb5
  .endif

--- a/ports/deskutils/kdepim4-runtime/Makefile.DragonFly
+++ b/ports/deskutils/kdepim4-runtime/Makefile.DragonFly
@@ -1,1 +1,1 @@
-BUILD_DEPENDS+= ${LOCALBASE}/bin/update-mime-database:${PORTSDIR}/misc/shared-mime-info
+BUILD_DEPENDS+= ${LOCALBASE}/bin/update-mime-database:misc/shared-mime-info

--- a/ports/deskutils/kdepimlibs4/Makefile.DragonFly
+++ b/ports/deskutils/kdepimlibs4/Makefile.DragonFly
@@ -1,1 +1,1 @@
-BUILD_DEPENDS+= ${LOCALBASE}/bin/update-mime-database:${PORTSDIR}/misc/shared-mime-info
+BUILD_DEPENDS+= ${LOCALBASE}/bin/update-mime-database:misc/shared-mime-info

--- a/ports/deskutils/kdeplasma-addons/Makefile.DragonFly
+++ b/ports/deskutils/kdeplasma-addons/Makefile.DragonFly
@@ -1,1 +1,1 @@
-BUILD_DEPENDS+= ${LOCALBASE}/bin/update-mime-database:${PORTSDIR}/misc/shared-mime-info
+BUILD_DEPENDS+= ${LOCALBASE}/bin/update-mime-database:misc/shared-mime-info

--- a/ports/devel/kdevelop-kde4/Makefile.DragonFly
+++ b/ports/devel/kdevelop-kde4/Makefile.DragonFly
@@ -1,1 +1,1 @@
-BUILD_DEPENDS+= ${LOCALBASE}/bin/update-mime-database:${PORTSDIR}/misc/shared-mime-info
+BUILD_DEPENDS+= ${LOCALBASE}/bin/update-mime-database:misc/shared-mime-info

--- a/ports/devel/libbonobo/Makefile.DragonFly
+++ b/ports/devel/libbonobo/Makefile.DragonFly
@@ -1,1 +1,1 @@
-BUILD_DEPENDS+= p5-XML-Parser>=0:${PORTSDIR}/textproc/p5-XML-Parser
+BUILD_DEPENDS+= p5-XML-Parser>=0:textproc/p5-XML-Parser

--- a/ports/devel/libdwarf/Makefile.DragonFly
+++ b/ports/devel/libdwarf/Makefile.DragonFly
@@ -1,1 +1,1 @@
-LIB_DEPENDS+= libelf.so.0:${PORTSDIR}/devel/libelf
+LIB_DEPENDS+= libelf.so.0:devel/libelf

--- a/ports/devel/libgdata/Makefile.DragonFly
+++ b/ports/devel/libgdata/Makefile.DragonFly
@@ -1,1 +1,1 @@
-LIB_DEPENDS+=	libgnome-keyring.so:${PORTSDIR}/security/libgnome-keyring
+LIB_DEPENDS+=	libgnome-keyring.so:security/libgnome-keyring

--- a/ports/devel/newfile/Makefile.DragonFly
+++ b/ports/devel/newfile/Makefile.DragonFly
@@ -1,1 +1,1 @@
-BUILD_DEPENDS+= bash:${PORTSDIR}/shells/bash
+BUILD_DEPENDS+= bash:shells/bash

--- a/ports/editors/lazarus/Makefile.DragonFly
+++ b/ports/editors/lazarus/Makefile.DragonFly
@@ -1,7 +1,7 @@
 DFLY_FILESDIR= ${FILESDIR:S@/files$$@/dragonfly@}
 DFLY_PATCHDIR= ${PATCHDIR:S@/files$$@/dragonfly@}
 
-BUILD_DEPENDS+= ${LOCALBASE}/bin/fpcmake:${PORTSDIR}/lang/fpc
+BUILD_DEPENDS+= ${LOCALBASE}/bin/fpcmake:lang/fpc
 MAKE_ENV+= FPCDIR="${LOCALBASE}/lib/fpc/3.0.0"
 # bootstrap dragonfly
 pre-build-script:

--- a/ports/finance/kmymoney-kde4/Makefile.DragonFly
+++ b/ports/finance/kmymoney-kde4/Makefile.DragonFly
@@ -1,1 +1,1 @@
-BUILD_DEPENDS+= ${LOCALBASE}/bin/update-mime-database:${PORTSDIR}/misc/shared-mime-info
+BUILD_DEPENDS+= ${LOCALBASE}/bin/update-mime-database:misc/shared-mime-info

--- a/ports/games/retroarch/Makefile.DragonFly
+++ b/ports/games/retroarch/Makefile.DragonFly
@@ -1,6 +1,6 @@
 OPTIONS_DEFAULT:= ${OPTIONS_DEFAULT:NPULSEAUDIO}
 
-V4L_BUILD_DEPENDS+=	${LOCALBASE}/include/linux/videodev2.h:${PORTSDIR}/multimedia/v4l_compat
+V4L_BUILD_DEPENDS+=	${LOCALBASE}/include/linux/videodev2.h:multimedia/v4l_compat
 
 # hardcode python34 for now
 dfly-patch:

--- a/ports/graphics/blender/Makefile.DragonFly
+++ b/ports/graphics/blender/Makefile.DragonFly
@@ -8,8 +8,8 @@ OPTIONS_DEFAULT+= CYCLES
 # no libunwind
 CAMERATRACK_LIB_DEPENDS:=
 
-#BUILD_DEPENDS=	${PYTHON_PKGNAMEPREFIX}requests>=0:${PORTSDIR}/www/py-requests
-#RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}requests>=0:${PORTSDIR}/www/py-requests
+#BUILD_DEPENDS=	${PYTHON_PKGNAMEPREFIX}requests>=0:www/py-requests
+#RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}requests>=0:www/py-requests
 
 dfly-patch:
 	${REINPLACE_CMD} -e "s@ -liconv@ -L${LOCALBASE}/lib -liconv@g"	\

--- a/ports/graphics/dcp2icc/Makefile.DragonFly
+++ b/ports/graphics/dcp2icc/Makefile.DragonFly
@@ -1,5 +1,5 @@
 USES+= alias
 
-EXTRACT_DEPENDS=${UNZIP_CMD}:${PORTSDIR}/archivers/unzip
+EXTRACT_DEPENDS=${UNZIP_CMD}:archivers/unzip
 
 UNZIP_NATIVE_CMD:= ${UNZIP_CMD}

--- a/ports/graphics/wayland/newport/Makefile
+++ b/ports/graphics/wayland/newport/Makefile
@@ -10,10 +10,10 @@ LICENSE=	MIT
 USES=		tar:xz gmake libtool pkgconfig
 WRKSRC=		${WRKDIR}/${PORTNAME}-${PORTVERSION}
 
-LIB_DEPENDS=	libevent.so:${PORTSDIR}/devel/libevent2	\
-		libevent_pthreads.so:${PORTSDIR}/devel/libevent2 \
-		libexpat.so:${PORTSDIR}/textproc/expat2 \
-		libffi.so:${PORTSDIR}/devel/libffi
+LIB_DEPENDS=	libevent.so:devel/libevent2	\
+		libevent_pthreads.so:devel/libevent2 \
+		libexpat.so:textproc/expat2 \
+		libffi.so:devel/libffi
 
 GNU_CONFIGURE=	YES
 

--- a/ports/graphics/weston/newport/Makefile
+++ b/ports/graphics/weston/newport/Makefile
@@ -15,27 +15,27 @@ LDFLAGS+=	-L${LOCALBASE}/lib
 USE_XORG=	x11 xcb xcursor
 USE_GL=		egl gbm
 
-LIB_DEPENDS=	libxkbcommon.so:${PORTSDIR}/x11/libxkbcommon		\
-		libexecinfo.so:${PORTSDIR}/devel/libexecinfo		\
-		libpixman-1.so:${PORTSDIR}/x11/pixman			\
-		libcairo.so:${PORTSDIR}/graphics/cairo			\
-		libcolord.so:${PORTSDIR}/graphics/colord		\
-		libfontconfig.so:${PORTSDIR}/x11-fonts/fontconfig	\
-		libfreetype.so:${PORTSDIR}/print/freetype2		\
-		libwayland-server.so:${PORTSDIR}/graphics/wayland	\
-		libwayland-client.so:${PORTSDIR}/graphics/wayland	\
-		libwayland-cursor.so:${PORTSDIR}/graphics/wayland	\
-		libevent.so:${PORTSDIR}/devel/libevent2			\
-		libdrm.so:${PORTSDIR}/graphics/libdrm			\
-		libpng.so:${PORTSDIR}/graphics/png			\
-		libwebp.so:${PORTSDIR}/graphics/webp			\
-		libffi.so:${PORTSDIR}/devel/libffi
+LIB_DEPENDS=	libxkbcommon.so:x11/libxkbcommon		\
+		libexecinfo.so:devel/libexecinfo		\
+		libpixman-1.so:x11/pixman			\
+		libcairo.so:graphics/cairo			\
+		libcolord.so:graphics/colord			\
+		libfontconfig.so:x11-fonts/fontconfig		\
+		libfreetype.so:print/freetype2			\
+		libwayland-server.so:graphics/wayland		\
+		libwayland-client.so:graphics/wayland		\
+		libwayland-cursor.so:graphics/wayland		\
+		libevent.so:devel/libevent2			\
+		libdrm.so:graphics/libdrm			\
+		libpng.so:graphics/png				\
+		libwebp.so:graphics/webp			\
+		libffi.so:devel/libffi
 
 LIBS+=		-lexecinfo
 
-BUILD_DEPENDS=	${LOCALBASE}/include/linux/input.h:${PORTSDIR}/multimedia/v4l_compat
+BUILD_DEPENDS=	${LOCALBASE}/include/linux/input.h:multimedia/v4l_compat
 
-RUN_DEPENDS=	${LOCALBASE}/lib/libglapi.so.0:${PORTSDIR}/graphics/libglapi
+RUN_DEPENDS=	${LOCALBASE}/lib/libglapi.so.0:graphics/libglapi
 
 GNU_CONFIGURE=	YES
 

--- a/ports/japanese/FreeWnn-server/Makefile.DragonFly
+++ b/ports/japanese/FreeWnn-server/Makefile.DragonFly
@@ -1,2 +1,2 @@
-BUILD_DEPENDS+=	tradcpp:${PORTSDIR}/devel/tradcpp
+BUILD_DEPENDS+=	tradcpp:devel/tradcpp
 CPP:=		tradcpp

--- a/ports/korean/scim-tables/Makefile.DragonFly
+++ b/ports/korean/scim-tables/Makefile.DragonFly
@@ -1,1 +1,1 @@
-BUILD_DEPENDS+= scim:${PORTSDIR}/textproc/scim
+BUILD_DEPENDS+= scim:textproc/scim

--- a/ports/lang/clover/Makefile.DragonFly
+++ b/ports/lang/clover/Makefile.DragonFly
@@ -1,2 +1,2 @@
 # zrj: needed for lib/clc/oland-r600--.bc dep
-RUN_DEPENDS+=	libclc>=0:${PORTSDIR}/devel/libclc
+RUN_DEPENDS+=	libclc>=0:devel/libclc

--- a/ports/mail/batv-milter/Makefile.DragonFly
+++ b/ports/mail/batv-milter/Makefile.DragonFly
@@ -1,4 +1,4 @@
 .if !exists( /usr/include/libmilter/mfapi.h )
-BUILD_DEPENDS+=	${LOCALBASE}/include/libmilter/mfapi.h:${PORTSDIR}/mail/sendmail
+BUILD_DEPENDS+=	${LOCALBASE}/include/libmilter/mfapi.h:mail/sendmail
 CFLAGS+=	-I${LOCALBASE}/include
 .endif

--- a/ports/mail/evolution/Makefile.DragonFly
+++ b/ports/mail/evolution/Makefile.DragonFly
@@ -1,2 +1,2 @@
-RUN_DEPENDS+=	krb5-config:${PORTSDIR}/security/krb5
-BUILD_DEPENDS+=	krb5-config:${PORTSDIR}/security/krb5
+RUN_DEPENDS+=	krb5-config:security/krb5
+BUILD_DEPENDS+=	krb5-config:security/krb5

--- a/ports/mail/lmtp2nntp/Makefile.DragonFly
+++ b/ports/mail/lmtp2nntp/Makefile.DragonFly
@@ -1,2 +1,2 @@
-LIB_DEPENDS+=	libpcre.so:${PORTSDIR}/devel/pcre \
-		libpopt.so:${PORTSDIR}/devel/popt
+LIB_DEPENDS+=	libpcre.so:devel/pcre \
+		libpopt.so:devel/popt

--- a/ports/misc/compat34x/newport/pkg-descr
+++ b/ports/misc/compat34x/newport/pkg-descr
@@ -7,6 +7,6 @@ Ports usage example:
 .include <bsd.port.pre.mk>
 
 .if ${DFLYVERSION} >= 300501
-LIB_DEPENDS+=	c.6:${PORTSDIR}/misc/compat34x
+LIB_DEPENDS+=	c.6:misc/compat34x
 .endif
 --

--- a/ports/multimedia/ffmpeg/Makefile.DragonFly
+++ b/ports/multimedia/ffmpeg/Makefile.DragonFly
@@ -1,2 +1,2 @@
-BINUTILS_DEP:=	${LOCALBASE}/bin/as:${PORTSDIR}/devel/binutils
+BINUTILS_DEP:=	${LOCALBASE}/bin/as:devel/binutils
 BUILD_DEPENDS:=	${BUILD_DEPENDS:S/${BINUTILS_DEP}//}

--- a/ports/multimedia/totem-pl-parser/Makefile.DragonFly
+++ b/ports/multimedia/totem-pl-parser/Makefile.DragonFly
@@ -1,1 +1,1 @@
-LIB_DEPENDS+= libgnome-keyring.so:${PORTSDIR}/security/libgnome-keyring
+LIB_DEPENDS+= libgnome-keyring.so:security/libgnome-keyring

--- a/ports/net-im/folks/Makefile.DragonFly
+++ b/ports/net-im/folks/Makefile.DragonFly
@@ -1,1 +1,1 @@
-LIB_DEPENDS+= libkrb5.so:${PORTSDIR}/security/krb5
+LIB_DEPENDS+= libkrb5.so:security/krb5

--- a/ports/net-im/pidgin-sipe/Makefile.DragonFly
+++ b/ports/net-im/pidgin-sipe/Makefile.DragonFly
@@ -1,1 +1,1 @@
-LIB_DEPENDS+=	libgssapi_krb5.so:${PORTSDIR}/security/krb5
+LIB_DEPENDS+=	libgssapi_krb5.so:security/krb5

--- a/ports/net-mgmt/nagios4/Makefile.DragonFly
+++ b/ports/net-mgmt/nagios4/Makefile.DragonFly
@@ -1,1 +1,1 @@
-BUILD_DEPENDS+=	unzip:${PORTSDIR}/archivers/unzip
+BUILD_DEPENDS+=	unzip:archivers/unzip

--- a/ports/net/kdenetwork4/Makefile.DragonFly
+++ b/ports/net/kdenetwork4/Makefile.DragonFly
@@ -1,1 +1,1 @@
-BUILD_DEPENDS+= ${LOCALBASE}/bin/update-mime-database:${PORTSDIR}/misc/shared-mime-info
+BUILD_DEPENDS+= ${LOCALBASE}/bin/update-mime-database:misc/shared-mime-info

--- a/ports/net/mosh/Makefile.DragonFly
+++ b/ports/net/mosh/Makefile.DragonFly
@@ -1,3 +1,3 @@
-LIB_DEPENDS+=	libutempter.so:${PORTSDIR}/sysutils/libutempter
+LIB_DEPENDS+=	libutempter.so:sysutils/libutempter
 CFLAGS+=	-I${LOCALBASE}/include
 LDFLAGS+=	-L${LOCALBASE}/lib

--- a/ports/net/nss_ldap/Makefile.DragonFly
+++ b/ports/net/nss_ldap/Makefile.DragonFly
@@ -1,1 +1,1 @@
-LIB_DEPENDS+= libkrb5.so:${PORTSDIR}/security/krb5
+LIB_DEPENDS+= libkrb5.so:security/krb5

--- a/ports/net/x2goclient/Makefile.DragonFly
+++ b/ports/net/x2goclient/Makefile.DragonFly
@@ -1,1 +1,1 @@
-LIB_DEPENDS+= libkrb5.so:${PORTSDIR}/security/krb5
+LIB_DEPENDS+= libkrb5.so:security/krb5

--- a/ports/security/opensaml2/Makefile.DragonFly
+++ b/ports/security/opensaml2/Makefile.DragonFly
@@ -1,1 +1,1 @@
-LIB_DEPENDS+= libboost_thread.so:${PORTSDIR}/devel/boost-libs
+LIB_DEPENDS+= libboost_thread.so:devel/boost-libs

--- a/ports/security/pam_krb5-rh/Makefile.DragonFly
+++ b/ports/security/pam_krb5-rh/Makefile.DragonFly
@@ -1,1 +1,1 @@
-LIB_DEPENDS+= libkrb5.so:${PORTSDIR}/security/krb5
+LIB_DEPENDS+= libkrb5.so:security/krb5

--- a/ports/sysutils/brasero/Makefile.DragonFly
+++ b/ports/sysutils/brasero/Makefile.DragonFly
@@ -1,1 +1,1 @@
-LIB_DEPENDS+=	libltdl.so:${PORTSDIR}/devel/libltdl
+LIB_DEPENDS+=	libltdl.so:devel/libltdl

--- a/ports/sysutils/dar/Makefile.DragonFly
+++ b/ports/sysutils/dar/Makefile.DragonFly
@@ -1,1 +1,1 @@
-LIB_DEPENDS+= libelf.so:${PORTSDIR}/devel/libelf
+LIB_DEPENDS+= libelf.so:devel/libelf

--- a/ports/sysutils/devfw-bwn/newport/Makefile
+++ b/ports/sysutils/devfw-bwn/newport/Makefile
@@ -12,7 +12,7 @@ EXTRACT_ONLY=
 MAINTAINER=	zrj@ef.irc
 COMMENT=	Broadcom AirForce IEEE 802.11 Firmware
 
-BUILD_DEPENDS=	b43-fwcutter:${PORTSDIR}/sysutils/b43-fwcutter
+BUILD_DEPENDS=	b43-fwcutter:sysutils/b43-fwcutter
 
 FIRMWARES=								\
 	ucode5 ucode11 ucode13 ucode14 ucode15				\

--- a/ports/sysutils/gnome-control-center/Makefile.DragonFly
+++ b/ports/sysutils/gnome-control-center/Makefile.DragonFly
@@ -1,2 +1,2 @@
-LIB_DEPENDS+= 		libkrb5.so:${PORTSDIR}/security/krb5
+LIB_DEPENDS+= 		libkrb5.so:security/krb5
 OPTIONS_EXCLUDE_x86_64=	CHEESE

--- a/ports/sysutils/msktutil/Makefile.DragonFly
+++ b/ports/sysutils/msktutil/Makefile.DragonFly
@@ -1,1 +1,1 @@
-LIB_DEPENDS+= libkrb5.so:${PORTSDIR}/security/krb5
+LIB_DEPENDS+= libkrb5.so:security/krb5

--- a/ports/sysutils/munin-node/Makefile.DragonFly
+++ b/ports/sysutils/munin-node/Makefile.DragonFly
@@ -1,1 +1,1 @@
-RUN_DEPENDS+=	p5-IO-Socket-INET6>=0:${PORTSDIR}/net/p5-IO-Socket-INET6
+RUN_DEPENDS+=	p5-IO-Socket-INET6>=0:net/p5-IO-Socket-INET6

--- a/ports/sysutils/qzeitgeist/Makefile.DragonFly
+++ b/ports/sysutils/qzeitgeist/Makefile.DragonFly
@@ -1,3 +1,3 @@
-LIB_DEPENDS+=	libicuuc.so:${PORTSDIR}/devel/icu \
-		libxml2.so:${PORTSDIR}/textproc/libxml2 \
-		libyajl.so:${PORTSDIR}/devel/yajl
+LIB_DEPENDS+=	libicuuc.so:devel/icu \
+		libxml2.so:textproc/libxml2 \
+		libyajl.so:devel/yajl

--- a/ports/sysutils/slider/newport/Makefile
+++ b/ports/sysutils/slider/newport/Makefile
@@ -10,7 +10,7 @@ COMMENT=	HAMMER file system time slider utility
 
 LICENSE=	BSD2CLAUSE   # actually ISC
 
-BUILD_DEPENDS=	adacurses-config:${PORTSDIR}/devel/adacurses
+BUILD_DEPENDS=	adacurses-config:devel/adacurses
 
 USES=		ada ncurses
 MAKE_ENV=	mode=release

--- a/ports/textproc/flex/Makefile.DragonFly
+++ b/ports/textproc/flex/Makefile.DragonFly
@@ -1,2 +1,2 @@
 CONFIGURE_ENV+=	ac_cv_path_M4=${LOCALBASE}/bin/gm4
-RUN_DEPENDS=gm4:${PORTSDIR}/devel/m4
+RUN_DEPENDS=gm4:devel/m4

--- a/ports/textproc/po4a/Makefile.DragonFly
+++ b/ports/textproc/po4a/Makefile.DragonFly
@@ -1,5 +1,5 @@
 DXFILE=		${LOCALBASE}/share/xsl/docbook/VERSION
-BUILD_DEPENDS+=	xsltproc:${PORTSDIR}/textproc/libxslt \
-		${DXFILE}:${PORTSDIR}/textproc/docbook-xsl
+BUILD_DEPENDS+=	xsltproc:textproc/libxslt \
+		${DXFILE}:textproc/docbook-xsl
 MAKE_ENV+=	LC_ALL=en_US.UTF-8
 

--- a/ports/textproc/rasqal/Makefile.DragonFly
+++ b/ports/textproc/rasqal/Makefile.DragonFly
@@ -1,7 +1,7 @@
 USES+= iconv
 
-LIB_DEPENDS+=	libcurl.so:${PORTSDIR}/ftp/curl \
-		libicuuc.so:${PORTSDIR}/devel/icu \
-		libxml2.so:${PORTSDIR}/textproc/libxml2 \
-		libxslt.so:${PORTSDIR}/textproc/libxslt \
-		libyajl.so:${PORTSDIR}/devel/yajl
+LIB_DEPENDS+=	libcurl.so:ftp/curl \
+		libicuuc.so:devel/icu \
+		libxml2.so:textproc/libxml2 \
+		libxslt.so:textproc/libxslt \
+		libyajl.so:devel/yajl

--- a/ports/www/quickie/Makefile.DragonFly
+++ b/ports/www/quickie/Makefile.DragonFly
@@ -1,4 +1,4 @@
 
 # zrj: these to work around missing -I option in base soelim for building DOCS
-BUILD_DEPENDS+= ${LOCALBASE}/bin/groff:${PORTSDIR}/textproc/groff
+BUILD_DEPENDS+= ${LOCALBASE}/bin/groff:textproc/groff
 CONFIGURE_ARGS+= SOELIM=${LOCALBASE}/bin/soelim GROFF=${LOCALBASE}/bin/groff

--- a/ports/x11-drivers/xf86-video-intel29/newport/Makefile
+++ b/ports/x11-drivers/xf86-video-intel29/newport/Makefile
@@ -9,7 +9,7 @@ MASTER_SITES=	http://dl.wolfpond.org/distfiles/
 MAINTAINER=	ftigeot@wolfpond.org
 COMMENT=	Driver for Intel integrated graphics chipsets
 
-LIB_DEPENDS=	libxcb-util.so:${PORTSDIR}/x11/xcb-util
+LIB_DEPENDS=	libxcb-util.so:x11/xcb-util
 # Needed to build tests
 LIB_DEPENDS+=	libpng.so:${PORTSDIR}/graphics/png
 

--- a/ports/x11-servers/xwayland/newport/Makefile
+++ b/ports/x11-servers/xwayland/newport/Makefile
@@ -6,7 +6,7 @@ LIB_DEPENDS+=	libdrm.so:graphics/libdrm \
 		libepoxy.so:graphics/libepoxy
 
 BUILD_DEPENDS=	wayland>=1.9.0:graphics/wayland \
-		${LOCALBASE}/include/linux/input.h:${PORTSDIR}/multimedia/v4l_compat
+		${LOCALBASE}/include/linux/input.h:multimedia/v4l_compat
 
 MASTERDIR=	${.CURDIR}/../xorg-server
 DESCR=		${.CURDIR}/pkg-descr

--- a/ports/x11-toolkits/gnustep-gui/Makefile.DragonFly
+++ b/ports/x11-toolkits/gnustep-gui/Makefile.DragonFly
@@ -1,4 +1,4 @@
-LIB_DEPENDS+=	libxml2.so:${PORTSDIR}/textproc/libxml2 \
-		libxslt.so:${PORTSDIR}/textproc/libxslt
+LIB_DEPENDS+=	libxml2.so:textproc/libxml2 \
+		libxslt.so:textproc/libxslt
 
 ADDITIONAL_LIB_DIRS+= -L${LOCALBASE}/libs

--- a/ports/x11-toolkits/open-motif/Makefile.DragonFly
+++ b/ports/x11-toolkits/open-motif/Makefile.DragonFly
@@ -2,9 +2,9 @@ USE_XORG+=	xproto
 USE_XORG+=	xt
 USE_XORG+=	xrender
 
-LIB_DEPENDS+=	libfontconfig.so:${PORTSDIR}/x11-fonts/fontconfig
-LIB_DEPENDS+=	libfreetype.so:${PORTSDIR}/print/freetype2
-LIB_DEPENDS+=	libexpat.so:${PORTSDIR}/textproc/expat2
+LIB_DEPENDS+=	libfontconfig.so:x11-fonts/fontconfig
+LIB_DEPENDS+=	libfreetype.so:print/freetype2
+LIB_DEPENDS+=	libexpat.so:textproc/expat2
 
 CFLAGS+=	-I${PREFIX}/include/freetype2
 

--- a/ports/x11-wm/xfce4/Makefile.DragonFly
+++ b/ports/x11-wm/xfce4/Makefile.DragonFly
@@ -1,1 +1,1 @@
-RUN_DEPENDS+=	dragonfly-wallpapers>0:${PORTSDIR}/x11-themes/dragonfly-wallpapers
+RUN_DEPENDS+=	dragonfly-wallpapers>0:x11-themes/dragonfly-wallpapers

--- a/ports/x11/kde4-workspace/Makefile.DragonFly
+++ b/ports/x11/kde4-workspace/Makefile.DragonFly
@@ -1,4 +1,4 @@
 LDFLAGS+= -lz -lutil
 
-WALLPAPERS_RUN_DEPENDS=	${KDE4_PREFIX}/share/wallpapers/Horos/metadata.desktop:${PORTSDIR}/x11-themes/kde4-wallpapers \
-			dragonfly-wallpapers>0:${PORTSDIR}/x11-themes/dragonfly-wallpapers
+WALLPAPERS_RUN_DEPENDS=	${KDE4_PREFIX}/share/wallpapers/Horos/metadata.desktop:x11-themes/kde4-wallpapers \
+			dragonfly-wallpapers>0:x11-themes/dragonfly-wallpapers

--- a/ports/x11/kdelibs4/Makefile.DragonFly
+++ b/ports/x11/kdelibs4/Makefile.DragonFly
@@ -1,4 +1,4 @@
-BUILD_DEPENDS+= ${LOCALBASE}/bin/update-mime-database:${PORTSDIR}/misc/shared-mime-info
-LIB_DEPENDS+=	libraptor2.so:${PORTSDIR}/textproc/raptor2 \
-		libxml2.so:${PORTSDIR}/textproc/libxml2 \
-		libyajl.so:${PORTSDIR}/devel/yajl
+BUILD_DEPENDS+= ${LOCALBASE}/bin/update-mime-database:misc/shared-mime-info
+LIB_DEPENDS+=	libraptor2.so:textproc/raptor2 \
+		libxml2.so:textproc/libxml2 \
+		libyajl.so:devel/yajl

--- a/ports/x11/libgnome/Makefile.DragonFly
+++ b/ports/x11/libgnome/Makefile.DragonFly
@@ -1,2 +1,2 @@
-LIB_DEPENDS+=	libltdl.so:${PORTSDIR}/devel/libltdl
-LIB_DEPENDS+=	libpopt.so:${PORTSDIR}/devel/popt
+LIB_DEPENDS+=	libltdl.so:devel/libltdl
+LIB_DEPENDS+=	libpopt.so:devel/popt

--- a/ports/x11/libxfce4menu/Makefile.DragonFly
+++ b/ports/x11/libxfce4menu/Makefile.DragonFly
@@ -1,1 +1,1 @@
-LIB_DEPENDS+=	libdbus-glib-1.so:${PORTSDIR}/devel/dbus-glib
+LIB_DEPENDS+=	libdbus-glib-1.so:devel/dbus-glib


### PR DESCRIPTION
As it was done in freebsd-ports.

If nobody is against, this will solve DEVELOPER build nagging warning messages that slow the build.