### PR TITLE
Revert "www/npm: Remove obsolete patch"

### DIFF
--- a/ports/www/npm/Makefile.DragonFly
+++ b/ports/www/npm/Makefile.DragonFly
@@ -1,0 +1,3 @@
+dfly-patch:
+	${REINPLACE_CMD} -e "s|'nobody'|'${:!/usr/bin/id -u nobody!}'|" \
+		${WRKSRC}/lib/config/defaults.js


### PR DESCRIPTION
Reverts DragonFlyBSD/DeltaPorts#462

It's still required:
node cli.js --cache /wrkdirs/www/npm/.cache install -g -f 
Error: could not get uid/gid
internal/process/stdio.js:166
      throw new Error('Implement me. Unknown stream file type!');
      ^

Error: Implement me. Unknown stream file type!
    at createWritableStdioStream (internal/process/stdio.js:166:13)
    at process.getStdout [as stdout] (internal/process/stdio.js:10:14)
    at console.js:100:37