### PR TITLE
www/chromium: Attempt to allow build new version

### DIFF
--- a/ports/www/chromium/Makefile.DragonFly
+++ b/ports/www/chromium/Makefile.DragonFly
@@ -2,3 +2,37 @@
 .if exists(/usr/include/bus/u4b/usb_freebsd.h)
 CFLAGS+=	-D__STDC_LIMIT_MACROS
 .endif
+
+KERBEROS_LIB_DEPENDS+=	libgssapi_krb5.so:security/krb5
+USES+=		alias
+
+GYP_DEFINES+=	target_arch=x64 OS=dragonfly disable_fatal_linker_warnings=1
+
+dfly-patch:
+	@${FIND} ${WRKSRC} -type f -name \*\.gyp\* | \
+		${GREP} -vE "/v8/|libusb" | ${XARGS} ${GREP} -l '"freebsd"' | \
+		${XARGS} ${REINPLACE_CMD} -e 's|"freebsd"|"dragonfly"|g'
+	@${FIND} ${WRKSRC} -type f -name \*\.gyp\* | \
+		${GREP} -vE "/v8/|libusb" | ${XARGS} ${GREP} -l '"freebsd"' | \
+		${XARGS} ${REINPLACE_CMD} -e 's|"freebsd"|"dragonfly"|g'
+	@${FIND} ${WRKSRC} -type f -name \*\.py | ${GREP} -v /v8/ | \
+		${XARGS} ${GREP} -l "'freebsd'" | \
+		${XARGS} ${REINPLACE_CMD} -e "s|'freebsd'|'dragonfly'|g"
+	@${REINPLACE_CMD} -e 's|"freebsd"|"dragonfly"|g' \
+		${WRKSRC}/v8/build/standalone.gypi \
+		${WRKSRC}/v8/build/toolchain.gypi \
+		${WRKSRC}/v8/src/d8.gyp \
+		${WRKSRC}/v8/tools/gyp/v8.gyp
+	@${REINPLACE_CMD} -e 's|0xFFFFFFFF|0x7FFFFFFF|' \
+		${WRKSRC}/third_party/mesa/src/include/GL/glext.h \
+		${WRKSRC}/third_party/mesa/src/src/mapi/glapi/gen/ARB_uniform_buffer_object.xml \
+		${WRKSRC}/third_party/mesa/src/chromium_gensrc/mesa/enums.c \
+		${WRKSRC}/third_party/khronos/GLES3/gl3.h \
+		${WRKSRC}/third_party/khronos/GLES3/gl31.h \
+		${WRKSRC}/third_party/khronos/noninclude/GL/glext.h \
+		${WRKSRC}/third_party/webgl/src/specs/latest/2.0/webgl2.idl \
+		${WRKSRC}/third_party/WebKit/public/platform/WebGraphicsContext3D.h \
+		${WRKSRC}/third_party/angle/include/GLES3/gl3.h \
+		${WRKSRC}/third_party/angle/src/libANGLE/renderer/gl/functionsgl_enums.h
+	${REINPLACE_CMD} -e "s|'freebsd'|'dragonfly'|g"	\
+		${WRKSRC}/v8/build/landmine_utils.py

--- a/ports/www/chromium/diffs/Makefile.diff
+++ b/ports/www/chromium/diffs/Makefile.diff
@@ -1,81 +1,52 @@
 --- Makefile.orig	2016-06-12 10:23:43 UTC
 +++ Makefile
-@@ -54,6 +54,8 @@ LIB_DEPENDS=	libasound.so:audio/alsa-lib
- 		libwebp.so:graphics/webp \
- 		libxml2.so:textproc/libxml2
- 
-+LIB_DEPENDS+=	libgssapi_krb5.so:security/krb5
+@@ -61,16 +61,8 @@ RUN_DEPENDS=	${LOCALBASE}/lib/alsa-lib/l
+ ONLY_FOR_ARCHS=	i386 amd64
+ USES=		bison cpe desktop-file-utils execinfo jpeg \
+ 		ninja perl5 pkgconfig python:2,build shebangfix tar:xz
+-# chromium requires a recent compiler (C++11 capable, but clang 3.4 is
+-# not able to build chromium. OTOH clang36 on FreeBSD 9.3 cannot build
+-# chromium as the libc++ includes are not up to the task. USES flags
+-# have to be set before bsd.ports.pre.mk and thereby cannot depend on
+-# bsd.ports.pre.mk's variables, so I'm using a hack here.
+-.if exists(/usr/lib/libc++.a)
 +
- RUN_DEPENDS=	${LOCALBASE}/lib/alsa-lib/libasound_module_pcm_oss.so:audio/alsa-plugins \
- 		alsa-lib>=1.1.1_1:audio/alsa-lib \
- 		droid-fonts-ttf>0:x11-fonts/droid-fonts-ttf \
-@@ -84,6 +86,8 @@ SHEBANG_FILES=	chrome/tools/build/linux/
- ALL_TARGET=	chrome
- INSTALLS_ICONS=	yes
+ USES+=	compiler:c++14-lang
+-.else
+-USES+=	compiler:c++11-lib
+-.endif
  
-+USES+=		alias
-+USE_GCC=	4.8+
- #TODO bz@ : install libwidevinecdm.so (see
- #   third_party/widevine/cdm/widevine_cdm.gyp)
- # See build/common.gypi for all the available variables.
-@@ -94,6 +98,7 @@ GYP_DEFINES+=	\
- 		linux_strip_binary=1 \
- 		use_aura=1 \
- 		test_isolation_mode=noop \
-+		disable_fatal_linker_warnings=1 \
- 		disable_nacl=1 \
+ CPE_VENDOR=	google
+ CPE_PRODUCT=	chrome
+@@ -97,10 +89,9 @@ GYP_DEFINES+=	\
  		enable_extensions=1 \
  		enable_one_click_signin=1 \
-@@ -213,6 +218,7 @@ CONFIGURE_ENV+=	CC="${CC}" \
- 		GYP_GENERATORS=ninja \
- 		GYP_DEFINES="${GYP_DEFINES}"
- MAKE_ENV+=	BUILDTYPE=${BUILDTYPE} \
-+		GYPFLAGS=-DOS=freebsd \
- 		GPERF="${LOCALBASE}/bin/gperf"
+ 		enable_openmax=1 \
+-		enable_webrtc=1 \
++		enable_webrtc=0 \
+ 		werror= \
+ 		no_gc_sections=1 \
+-                OS=freebsd \
+ 		os_ver=${OSVERSION} \
+ 		prefix_dir=${LOCALBASE} \
+ 		python_ver=${PYTHON_VER} \
+@@ -136,6 +127,7 @@ GYP_DEFINES+=	\
+ # allow removal of third_party/adobe
+ GYP_DEFINES+=	flapper_version_h_file='${WRKSRC}/flapper_version.h'
  
++# XXX: technically for us these are a no-no
+ # FreeBSD Chromium Api Key
+ # Set up Google API keys, see http://www.chromium.org/developers/how-tos/api-keys .
+ # Note: these are for FreeBSD use ONLY. For your own distribution,
+@@ -217,9 +209,8 @@ MAKE_ENV+=	BUILDTYPE=${BUILDTYPE} \
  .include <bsd.port.pre.mk>
-@@ -223,6 +229,7 @@ EXTRA_PATCHES+=	${FILESDIR}/extra-patch-
- CFLAGS+=	-fno-stack-protector # gcc 4.8 cannot find __stack_chk_fail_local
+ 
+ .if ${CHOSEN_COMPILER_TYPE} == gcc
+-GYP_DEFINES+=	gcc_version=${CXX:S/g++//}
+-EXTRA_PATCHES+=	${FILESDIR}/extra-patch-gcc
+-CFLAGS+=	-fno-stack-protector # gcc 4.8 cannot find __stack_chk_fail_local
++GYP_DEFINES+=	gcc_version=5
++#GYP_DEFINES+=	gcc_version=${CXX:S/g++//}
  .else
  GYP_DEFINES+=	clang=1
-+CXXFLAGS+=	-D__float128=void -D_GLIBCXX_PERMIT_BACKWARD_HASH=1
  CFLAGS+=	-Wno-unknown-warning-option \
- 			-D_LIBCPP_TRIVIAL_PAIR_COPY_CTOR=1 # work around base r261801
- EXTRA_PATCHES+=	${FILESDIR}/extra-patch-clang
-@@ -254,12 +261,36 @@ pre-everything::
- 
- post-patch:
- 	@${REINPLACE_CMD} -e "s|/usr/local|${LOCALBASE}|" \
-+		${WRKSRC}/base/base_paths_posix.cc \
-+		${WRKSRC}/base/process/process_handle_freebsd.cc \
- 		${WRKSRC}/crypto/crypto.gyp \
- 		${WRKSRC}/v8/tools/gyp/v8.gyp \
- 		${WRKSRC}/v8/build/toolchain.gypi
- 	@${REINPLACE_CMD} -e "s|/usr/local|${PREFIX}|" \
- 		${WRKSRC}/chrome/common/chrome_paths.cc \
- 		${WRKSRC}/base/base.gyp
-+	@${FIND} ${WRKSRC} -type f -name \*\.gyp\* | \
-+		${GREP} -vE "/v8/|libusb" | ${XARGS} ${GREP} -l '"freebsd"' | \
-+		${XARGS} ${REINPLACE_CMD} -e 's|"freebsd"|"dragonfly"|g'
-+	@${FIND} ${WRKSRC} -type f -name \*\.py | ${GREP} -v /v8/ | \
-+		${XARGS} ${GREP} -l "'freebsd'" | \
-+		${XARGS} ${REINPLACE_CMD} -e "s|'freebsd'|'dragonfly'|g"
-+	@${REINPLACE_CMD} -e 's|"freebsd"|"dragonfly"|g' \
-+		${WRKSRC}/v8/build/standalone.gypi \
-+		${WRKSRC}/v8/build/toolchain.gypi \
-+		${WRKSRC}/v8/src/d8.gyp \
-+		${WRKSRC}/v8/tools/gyp/v8.gyp
-+	@${REINPLACE_CMD} -e 's|0xFFFFFFFF|0x7FFFFFFF|' \
-+		${WRKSRC}/third_party/mesa/src/include/GL/glext.h \
-+		${WRKSRC}/third_party/mesa/src/src/mapi/glapi/gen/ARB_uniform_buffer_object.xml \
-+		${WRKSRC}/third_party/mesa/src/chromium_gensrc/mesa/enums.c \
-+		${WRKSRC}/third_party/khronos/GLES3/gl3.h \
-+		${WRKSRC}/third_party/khronos/GLES3/gl31.h \
-+		${WRKSRC}/third_party/khronos/noninclude/GL/glext.h \
-+		${WRKSRC}/third_party/webgl/src/specs/latest/2.0/webgl2.idl \
-+		${WRKSRC}/third_party/WebKit/public/platform/WebGraphicsContext3D.h \
-+		${WRKSRC}/third_party/angle/include/GLES3/gl3.h \
-+		${WRKSRC}/third_party/angle/src/libANGLE/renderer/gl/functionsgl_enums.h
- 
- pre-configure:
- 	# phajdan-jr: list of things *not* to remove, so maybe the script

--- a/ports/www/chromium/dragonfly/patch-third_party_usrsctp_usrsctplib_usrsctplib_netinet_sctp_os.h
+++ b/ports/www/chromium/dragonfly/patch-third_party_usrsctp_usrsctplib_usrsctplib_netinet_sctp_os.h
@@ -1,0 +1,11 @@
+--- third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_os.h.orig	2016-06-16 22:04:02.000000000 +0300
++++ third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_os.h
+@@ -62,7 +62,7 @@ __FBSDID("$FreeBSD: head/sys/netinet/sct
+  * SCTP_ZONE_DESTROY(zone)
+  */
+ 
+-#if defined(__FreeBSD__)
++#if defined(__FreeBSD__) && !defined(__DragonFly__)
+ #include <netinet/sctp_os_bsd.h>
+ #else
+ #define MODULE_GLOBAL(_B) (_B)


### PR DESCRIPTION
Lots of shifting around, but it builds for synth just-build
synth test fails because activates TEST option and build fails on linux testing sources
dunno what is missing for those

Just build fix, untested runtime! archived version at ~zrj/dports/chromium_try.tar.bz2

btw i just pushed some stuff directly, and it didn't got into last run (rsync?)