### PR TITLE
textproc/docbook-xsl-ns: Don't package .tmp files

### DIFF
--- a/ports/textproc/docbook-xsl-ns/Makefile.DragonFly
+++ b/ports/textproc/docbook-xsl-ns/Makefile.DragonFly
@@ -1,0 +1,4 @@
+
+# zrj: fix synth test, do not install such files!
+dfly-patch:
+	-${RM} -f ${WRKSRC}/svn-commit.tmp


### PR DESCRIPTION
silly one