### PR TITLE
multimedia/libva: Fix build on new version

### DIFF
--- a/ports/multimedia/libva/Makefile.DragonFly
+++ b/ports/multimedia/libva/Makefile.DragonFly
@@ -1,0 +1,1 @@
+USES:= ${USES:Nalias}

--- a/ports/multimedia/libva/dragonfly/patch-test_v4l_h264_encode_capture.cpp
+++ b/ports/multimedia/libva/dragonfly/patch-test_v4l_h264_encode_capture.cpp
@@ -1,0 +1,20 @@
+--- test/v4l_h264/encode/capture.cpp.intermediate	2016-06-29 19:12:12 UTC
++++ test/v4l_h264/encode/capture.cpp
+@@ -38,7 +38,7 @@
+ #include <fcntl.h> /* low-level i/o */
+ #include <errno.h>
+ #include <unistd.h>
+-#ifdef __FreeBSD__
++#if  defined(__FreeBSD__) || defined(__DragonFly__)
+ #include <stdlib.h>
+ #else
+ #include <malloc.h>
+@@ -456,7 +456,7 @@ static void init_userp (unsigned int buf
+     }
+     for (n_buffers = 0; n_buffers < 4; ++n_buffers) {
+         buffers[n_buffers].length = buffer_size;
+-#ifdef __FreeBSD__
++#if defined(__FreeBSD__) || defined(__DragonFly__)
+ 	if(posix_memalign(&buffers[n_buffers].start, page_size, buffer_size))
+ 	{
+ #else

--- a/ports/multimedia/libva/dragonfly/patch-va_va_trace.c
+++ b/ports/multimedia/libva/dragonfly/patch-va_va_trace.c
@@ -1,0 +1,47 @@
+--- va/va_trace.c.intermediate	2016-06-29 19:04:28 UTC
++++ va/va_trace.c
+@@ -299,6 +299,8 @@ static void add_trace_config_info(
+     int idx = 0;
+ #ifdef __FreeBSD__
+     pid_t thd_id = pthread_getthreadid_np();
++#elif defined(__DragonFly__)
++    pid_t thd_id = syscall(SYS_lwp_gettid);
+ #else
+     pid_t thd_id = syscall(__NR_gettid);
+ #endif
+@@ -327,6 +329,8 @@ static void delete_trace_config_info(
+     int idx = 0;
+ #ifdef __FreeBSD__
+     pid_t thd_id = pthread_getthreadid_np();
++#elif defined(__DragonFly__)
++    pid_t thd_id = syscall(SYS_lwp_gettid);
+ #else
+     pid_t thd_id = syscall(__NR_gettid);
+ #endif
+@@ -676,6 +680,8 @@ static struct trace_log_file *start_trac
+     struct trace_log_file *plog_file = NULL;
+ #ifdef __FreeBSD__
+     pid_t thd_id = pthread_getthreadid_np();
++#elif defined(__DragonFly__)
++    pid_t thd_id = syscall(SYS_lwp_gettid);
+ #else
+     pid_t thd_id = syscall(__NR_gettid);
+ #endif
+@@ -719,6 +725,8 @@ static void refresh_log_file(
+     struct trace_log_file *plog_file = NULL;
+ #ifdef __FreeBSD__
+     pid_t thd_id = pthread_getthreadid_np();
++#elif defined(__DragonFly__)
++    pid_t thd_id = syscall(SYS_lwp_gettid);
+ #else
+     pid_t thd_id = syscall(__NR_gettid);
+ #endif
+@@ -1247,6 +1255,8 @@ static void internal_TraceUpdateContext
+     int i = 0, delete = 1;
+ #ifdef __FreeBSD__
+     pid_t thd_id = pthread_getthreadid_np();
++#elif defined(__DragonFly__)
++    pid_t thd_id = syscall(SYS_lwp_gettid);
+ #else
+     pid_t thd_id = syscall(__NR_gettid);
+ #endif


### PR DESCRIPTION
Drop alias and patch accordingly (port now contains sys dep stuff)
there is an issue with libEGL (when it is present, extra backend gets enabled, plist stuff)

Only merge just before next bulk (patch is just to reduce fail counts on next)
