### PR TITLE
cxx: Explicitly add limits.h for PATH_MAX visibility.

### DIFF
--- a/ports/devel/clanlib1/dragonfly/patch-Sources_Core_System_Unix_init_linux.cpp
+++ b/ports/devel/clanlib1/dragonfly/patch-Sources_Core_System_Unix_init_linux.cpp
@@ -1,0 +1,10 @@
+--- Sources/Core/System/Unix/init_linux.cpp.intermediate	2016-07-04 19:23:49 UTC
++++ Sources/Core/System/Unix/init_linux.cpp
+@@ -39,6 +39,7 @@
+ #include <cstdio>
+ #include <cstdlib>
+ #include <cstring>
++#include <climits> // for PATH_MAX
+ #include "implementation.h"
+ #include "init_linux.h"
+ // note: this cannot be replaced by <ctime>! (timeval needs to be defined)

--- a/ports/games/orbital_eunuchs_sniper/dragonfly/patch-src_snipe2d.cpp
+++ b/ports/games/orbital_eunuchs_sniper/dragonfly/patch-src_snipe2d.cpp
@@ -1,0 +1,10 @@
+--- src/snipe2d.cpp.intermediate	2016-07-04 19:58:20 UTC
++++ src/snipe2d.cpp
+@@ -38,6 +38,7 @@
+ #include "snipe2d.h"
+ //#include <getopt.h>
+ #include "binds.h"
++#include <limits.h> // for PATH_MAX
+ 
+ PREFS gPrefs;
+ 

--- a/ports/games/zatacka/dragonfly/patch-src_main.cpp
+++ b/ports/games/zatacka/dragonfly/patch-src_main.cpp
@@ -1,0 +1,12 @@
+Since FreeBSD in MF does s/30/PATH_MAX/ it earns an extra include
+
+--- src/main.cpp.intermediate	2016-07-04 19:42:13 UTC
++++ src/main.cpp
+@@ -20,6 +20,7 @@
+ #ifdef __FreeBSD__
+ #include <unistd.h>
+ #include <defaults.h>
++#include <limits.h> // for PATH_MAX
+ #endif
+ 
+ #include "fx.h"

--- a/ports/sysutils/cdargs/dragonfly/patch-src_cdargs.cc
+++ b/ports/sysutils/cdargs/dragonfly/patch-src_cdargs.cc
@@ -1,0 +1,10 @@
+--- src/cdargs.cc.orig	2006-02-26 19:06:47.000000000 +0200
++++ src/cdargs.cc
+@@ -56,6 +56,7 @@ using namespace std;
+ # include <unistd.h>
+ # include <signal.h>
+ # include <string.h>
++# include <limits.h> // for PATH_MAX
+ 
+ //# if defined(USE_NCURSES) && !defined(RENAMED_NCURSES)
+ # if defined(HAVE_NCURSES_H)


### PR DESCRIPTION
Changes after <pthread.h> cleanup in
http://gitweb.dragonflybsd.org/dragonfly.git/commit/32cb82727ec681e604bb5631909bd642cd14fe5a

<limits.h> no longer get implicitly added into ns.
Cleaner C++ headers == faster compile time.
No functional change, only should affected cxx bits that rely on n/p