### PR TITLE
x11-drivers/xf86-input-joystick: convert to USE+= autoreconf

### DIFF
--- a/ports/x11-drivers/xf86-input-joystick/Makefile.DragonFly
+++ b/ports/x11-drivers/xf86-input-joystick/Makefile.DragonFly
@@ -1,4 +1,5 @@
-USE_AUTOTOOLS+=	autoconf
+USES+= autoreconf pathfix pkgconfig
+PATHFIX_MAKEFILEIN= Makefile.am
 
 pre-configure:
 .if ${DFLYVERSION} >= 300703


### PR DESCRIPTION
USE_AUTOTOOLS is deprecated