### PR TITLE
archivers/zoo: Fix makefile deps.

### DIFF
--- a/ports/archivers/zoo/Makefile.DragonFly
+++ b/ports/archivers/zoo/Makefile.DragonFly
@@ -1,0 +1,5 @@
+CFLAGS+=-D__OpenBSD__
+
+dfly-patch:
+	${REINPLACE_CMD} -e 's@/varargs.h@/stdarg.h@g'	\
+		${WRKSRC}/makefile


### PR DESCRIPTION
ptrerror.c actually has a dep on <stdarg.h> cause of STDARG
so just patch dep in makefile.

While there, throw in the alias to OpenBSD for timestamps handling.
Archiver works as intended