### PR TITLE
cad/openscad: Fix build

### DIFF
--- a/ports/cad/openscad/Makefile.DragonFly
+++ b/ports/cad/openscad/Makefile.DragonFly
@@ -1,0 +1,5 @@
+USE_CXXSTD= gnu++11
+
+# zrj: less noise!
+CFLAGS+= -Wno-deprecated-declarations -Wno-unused-variable
+


### PR DESCRIPTION
Technically this is not a bug in openscad.
It got broken after updated math/cgal that causes problems in handling
the #if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) yup da boost issues

For now just shoehorn the -std=gnu++11 and silence few warns,
to show up real issues (cgal headers a quite noisy)