### PR TITLE
Fix a longstanding issue with named pipes in libuv

### DIFF
--- a/ports/devel/libuv/dragonfly/patch-src_unix_stream.c
+++ b/ports/devel/libuv/dragonfly/patch-src_unix_stream.c
@@ -1,0 +1,13 @@
+--- src/unix/stream.c.orig	2016-05-16 21:22:19 UTC
++++ src/unix/stream.c
+@@ -962,8 +962,8 @@ uv_handle_type uv__handle_type(int fd) {
+     return UV_UNKNOWN_HANDLE;
+ 
+   if (type == SOCK_STREAM) {
+-#if defined(_AIX)
+-    /* on AIX the getsockname call returns an empty sa structure
++#if defined(_AIX) || defined(__DragonFly__)
++    /* on AIX/DragonFly the getsockname call returns an empty sa structure
+      * for sockets of type AF_UNIX.  For all other types it will
+      * return a properly filled in structure.
+      */

--- a/ports/devel/libuv/dragonfly/patch-src_unix_tty.c
+++ b/ports/devel/libuv/dragonfly/patch-src_unix_tty.c
@@ -1,0 +1,20 @@
+--- src/unix/tty.c.orig	2016-05-16 21:22:19 UTC
++++ src/unix/tty.c
+@@ -268,14 +268,14 @@ uv_handle_type uv_guess_handle(uv_file f
+       return UV_UDP;
+ 
+   if (type == SOCK_STREAM) {
+-#if defined(_AIX)
+-    /* on AIX the getsockname call returns an empty sa structure
++#if defined(_AIX) || defined(__DragonFly__)
++    /* on AIX/DragonFly the getsockname call returns an empty sa structure
+      * for sockets of type AF_UNIX.  For all other types it will
+      * return a properly filled in structure.
+      */
+     if (len == 0)
+       return UV_NAMED_PIPE;
+-#endif /* defined(_AIX) */
++#endif /* defined(_AIX) || defined(__DragonFly__) */
+ 
+     if (sa.sa_family == AF_INET || sa.sa_family == AF_INET6)
+       return UV_TCP;


### PR DESCRIPTION
These are the same patches as those found in [1] for the shipped version
of libuv of nodejs. Recent port revisions of nodejs (www/node) start to
build with the libuv version from dports. This led to a regression of
this bug in nodejs (and npm), as we haven't fixed this in devel/libuv
(yet). This commit fixes this issue.

[1]: https://github.com/DragonFlyBSD/DeltaPorts/pull/452