### PR TITLE
Fix cargo 0.11.0

### DIFF
--- a/ports/devel/cargo/Makefile.DragonFly
+++ b/ports/devel/cargo/Makefile.DragonFly
@@ -1,0 +1,4 @@
+MASTER_SITES=	http://www.ntecs.de/downloads/rust/:bootstrap \
+		LOCAL/jbeich:registry
+
+EXTRACT_SUFX=.tar.gz

--- a/ports/devel/cargo/diffs/distinfo.diff
+++ b/ports/devel/cargo/diffs/distinfo.diff
@@ -1,0 +1,8 @@
+--- distinfo.orig	2016-07-16 13:41:45 UTC
++++ distinfo
+@@ -6,3 +6,5 @@ SHA256 (rust-lang-cargo-0.11.0_GH0.tar.g
+ SIZE (rust-lang-cargo-0.11.0_GH0.tar.gz) = 566557
+ SHA256 (rust-lang-rust-installer-4915c75_GH0.tar.gz) = 022116173684c97d61e014940aada20f3830d2d3e1670887bf1861997133c234
+ SIZE (rust-lang-rust-installer-4915c75_GH0.tar.gz) = 19234
++SHA256 (cargo-nightly-x86_64-unknown-dragonfly.tar.gz) = 684814663bcd6fe3e1235b2c3a1d4a345d7e3dd33af5d7d628f2d6c234dcd21f
++SIZE (cargo-nightly-x86_64-unknown-dragonfly.tar.gz) = 3001301

--- a/ports/devel/cargo/dragonfly/patch-Cargo.lock
+++ b/ports/devel/cargo/dragonfly/patch-Cargo.lock
@@ -1,0 +1,20 @@
+--- Cargo.lock.orig	2016-07-16 13:28:46 UTC
++++ Cargo.lock
+@@ -12,7 +12,7 @@ dependencies = [
+  "env_logger 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+  "filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+  "flate2 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+- "fs2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "fs2 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+  "git2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+  "git2-curl 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -144,7 +144,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "fs2"
+-version = "0.2.3"
++version = "0.2.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/devel/cargo/dragonfly/patch-src_snapshots.txt
+++ b/ports/devel/cargo/dragonfly/patch-src_snapshots.txt
@@ -1,0 +1,9 @@
+--- src/snapshots.txt.orig2	2016-07-16 13:20:45 UTC
++++ src/snapshots.txt
+@@ -1,3 +1,6 @@
++2016-07-16
++  dragonfly-x86_64 fdfdc059afab83aeea5b7fb63cc75500dbca8018
++  
+ 2016-04-10
+   freebsd-x86_64 8c459cbdc890cedb43c0952ad7f1ef0b7fcbe535
+ 


### PR DESCRIPTION
This uses a new cargo snapshot I built, plus some minor fixes
(crate version of fs2 0.2.3 -> 0.2.5).