### PR TITLE
devel/gdb: Fix build after new patches

### DIFF
--- a/ports/devel/gdb/dragonfly/amd64dfly-nat.c
+++ b/ports/devel/gdb/dragonfly/amd64dfly-nat.c
@@ -1,6 +1,6 @@
 /* Native-dependent code for DragonFly/amd64.
 
-   Copyright (C) 2003-2015 Free Software Foundation, Inc.
+   Copyright (C) 2003-2016 Free Software Foundation, Inc.
 
    This file is part of GDB.
 
@@ -36,7 +36,7 @@
 #include "fbsd-nat.h"
 #include "amd64-tdep.h"
 #include "amd64-nat.h"
-#include "amd64bsd-nat.h"
+#include "x86bsd-nat.h"
 #include "x86-nat.h"
 
 
@@ -187,17 +187,6 @@ amd64dfly_supply_pcb (struct regcache *regcache, struct pcb *pcb)
 #endif /* DFLY_PCB_SUPPLY */
 
 
-static void (*super_mourn_inferior) (struct target_ops *ops);
-
-static void
-amd64dfly_mourn_inferior (struct target_ops *ops)
-{
-#ifdef HAVE_PT_GETDBREGS
-  x86_cleanup_dregs ();
-#endif
-  super_mourn_inferior (ops);
-}
-
 /* Implement the to_read_description method.  */
 
 static const struct target_desc *
@@ -222,13 +211,13 @@ amd64fbsd_read_description (struct target_ops *ops)
       if (ptrace (PT_GETXSTATE_INFO, ptid_get_pid (inferior_ptid),
 		  (PTRACE_TYPE_ARG3) &info, sizeof (info)) == 0)
 	{
-	  amd64bsd_xsave_len = info.xsave_len;
+	  x86bsd_xsave_len = info.xsave_len;
 	  xcr0 = info.xsave_mask;
 	}
       xsave_probed = 1;
     }
 
-  if (amd64bsd_xsave_len != 0)
+  if (x86bsd_xsave_len != 0)
     {
       if (is64)
 	return amd64_target_description (xcr0);
@@ -256,22 +245,6 @@ _initialize_amd64dfly_nat (void)
 
   /* Add some extra features to the common *BSD/x86 target.  */
   t = amd64bsd_target ();
-
-#ifdef HAVE_PT_GETDBREGS
-
-  x86_use_watchpoints (t);
-
-  x86_dr_low.set_control = amd64bsd_dr_set_control;
-  x86_dr_low.set_addr = amd64bsd_dr_set_addr;
-  x86_dr_low.get_addr = amd64bsd_dr_get_addr;
-  x86_dr_low.get_status = amd64bsd_dr_get_status;
-  x86_dr_low.get_control = amd64bsd_dr_get_control;
-  x86_set_debug_register_length (8);
-
-#endif /* HAVE_PT_GETDBREGS */
-
-  super_mourn_inferior = t->to_mourn_inferior;
-  t->to_mourn_inferior = amd64dfly_mourn_inferior;
   t->to_read_description = amd64fbsd_read_description;
 
   dfly_nat_add_target (t);

--- a/ports/devel/gdb/dragonfly/dfly64.mh
+++ b/ports/devel/gdb/dragonfly/dfly64.mh
@@ -1,6 +1,6 @@
 # Host: DragonFly/amd64
 NATDEPFILES= fork-child.o inf-ptrace.o \
-	dfly-nat.o amd64-nat.o amd64bsd-nat.o amd64dfly-nat.o \
+	dfly-nat.o amd64-nat.o x86bsd-nat.o amd64bsd-nat.o amd64dfly-nat.o \
 	x86-nat.o x86-dregs.o
 
 LOADLIBES= -lkvm


### PR DESCRIPTION
It builds in synth and runs on simple quick small programs.
Just one thing: on "layout split && break main && run" sometimes gdb segfaults.
Seems like ncurses issue, but mostly it works.

DragonFly support in gdb should be really be fixed and upstreamed...