### PR TITLE
devel/commoncpp: Convert alias to patches

### DIFF
--- a/ports/audio/ccaudio2/Makefile.DragonFly
+++ b/ports/audio/ccaudio2/Makefile.DragonFly
@@ -1,1 +1,0 @@
-USES+= alias:11

--- a/ports/devel/commoncpp/Makefile.DragonFly
+++ b/ports/devel/commoncpp/Makefile.DragonFly
@@ -1,1 +1,0 @@
-USES+= alias:11

--- a/ports/devel/commoncpp/dragonfly/patch-config.h.in
+++ b/ports/devel/commoncpp/dragonfly/patch-config.h.in
@@ -1,0 +1,20 @@
+--- config.h.in.orig	2010-11-01 00:10:18.000000000 +0200
++++ config.h.in
+@@ -38,7 +38,7 @@
+ #endif
+ #endif
+ 
+-#if defined(__FreeBSD__)
++#if defined(__FreeBSD__) || defined(__DragonFly__)
+ #ifndef __BSD_VISIBLE
+ #define __BSD_VISIBLE 1
+ #endif
+@@ -82,7 +82,7 @@
+ #define _GNU_SOURCE 1
+ #endif
+ 
+-#if     !defined(_XOPEN_SOURCE) && !defined(__FreeBSD__) &&!defined(__OpenBSD__) && !defined(__MACH__) && !defined(__NetBSD__)
++#if     !defined(_XOPEN_SOURCE) && !defined(__FreeBSD__) &&!defined(__OpenBSD__) && !defined(__MACH__) && !defined(__NetBSD__) && !defined(__DragonFly__)
+ #define _XOPEN_SOURCE 600
+ #endif
+ 

--- a/ports/devel/commoncpp/dragonfly/patch-src_serial.cpp
+++ b/ports/devel/commoncpp/dragonfly/patch-src_serial.cpp
@@ -1,0 +1,11 @@
+--- src/serial.cpp.orig	2010-11-01 02:08:53.000000000 +0200
++++ src/serial.cpp
+@@ -94,7 +94,7 @@ using std::ios;
+ #define MAX_CANON MAX_INPUT
+ #endif
+ 
+-#ifdef  __FreeBSD__
++#if  defined(__FreeBSD__) || defined(__DragonFly__)
+ #undef  _PC_MAX_INPUT
+ #undef  _PC_MAX_CANON
+ #endif

--- a/ports/devel/commoncpp/dragonfly/patch-src_socket.cpp
+++ b/ports/devel/commoncpp/dragonfly/patch-src_socket.cpp
@@ -1,0 +1,29 @@
+--- src/socket.cpp.orig	2010-11-01 02:33:55.000000000 +0200
++++ src/socket.cpp
+@@ -1549,7 +1549,7 @@ Socket::Error UDPSocket::join(const IPV4
+     int retval = setsockopt(so, IPPROTO_IP, IP_ADD_MEMBERSHIP, (char *)&group, sizeof(group));
+     return errSuccess;
+ 
+-#elif defined(IP_ADD_MEMBERSHIP) && defined(SIOCGIFINDEX) && !defined(__FreeBSD__) && !defined(__FreeBSD_kernel__) && !defined(_OSF_SOURCE) && !defined(__hpux) && !defined(__GNU__)
++#elif defined(IP_ADD_MEMBERSHIP) && defined(SIOCGIFINDEX) && !defined(__FreeBSD__) && !defined(__FreeBSD_kernel__) && !defined(_OSF_SOURCE) && !defined(__hpux) && !defined(__GNU__) && !defined(__DragonFly__)
+ 
+         struct ip_mreqn      group;
+     struct sockaddr_in   myaddr;
+@@ -1589,7 +1589,7 @@ Socket::Error UDPSocket::join(const IPV4
+ Socket::Error UDPSocket::getInterfaceIndex(const char *DeviceName,int& InterfaceIndex)
+ {
+ #ifndef WIN32
+-#if defined(IP_ADD_MEMBERSHIP) && defined(SIOCGIFINDEX) && !defined(__FreeBSD__) && !defined(__FreeBSD_kernel__) && !defined(_OSF_SOURCE) && !defined(__hpux) && !defined(__GNU__)
++#if defined(IP_ADD_MEMBERSHIP) && defined(SIOCGIFINDEX) && !defined(__FreeBSD__) && !defined(__FreeBSD_kernel__) && !defined(_OSF_SOURCE) && !defined(__hpux) && !defined(__GNU__) && !defined(__DragonFly__)
+ 
+     struct ip_mreqn  mreqn;
+     struct ifreq       m_ifreq;
+@@ -1608,7 +1608,7 @@ Socket::Error UDPSocket::getInterfaceInd
+     if (ioctl (so, SIOCGIFINDEX, &m_ifreq))
+         return error(errServiceUnavailable);
+ 
+-#if defined(__FreeBSD__) || defined(__GNU__)
++#if defined(__FreeBSD__) || defined(__DragonFly__) || defined(__GNU__)
+     InterfaceIndex = m_ifreq.ifr_ifru.ifru_index;
+ #else
+     InterfaceIndex = m_ifreq.ifr_ifindex;

--- a/ports/devel/commoncpp/dragonfly/patch-src_thread.cpp
+++ b/ports/devel/commoncpp/dragonfly/patch-src_thread.cpp
@@ -1,0 +1,20 @@
+--- src/thread.cpp.intermediate	2016-07-21 15:57:15 UTC
++++ src/thread.cpp
+@@ -241,7 +241,7 @@ void Thread::suspend(void)
+ #endif // WIN32
+ }
+ 
+-#if defined(__FreeBSD__)
++#if defined(__FreeBSD__) || defined(__DragonFly__)
+ #define AUTOSTACK   0x10000
+ #endif
+ 
+@@ -631,7 +631,7 @@ _cancel(cancelDefault), _start(NULL), pr
+     }
+ #endif
+ 
+-#ifndef __FreeBSD__
++#if !defined(__FreeBSD__) && !defined(__DragonFly__) 
+ #ifdef  _POSIX_THREAD_PRIORITY_SCHEDULING
+ #ifdef HAVE_SCHED_GETSCHEDULER
+ #define __HAS_PRIORITY_SCHEDULING__

--- a/ports/devel/commoncpp/dragonfly/patch-src_timer.cpp
+++ b/ports/devel/commoncpp/dragonfly/patch-src_timer.cpp
@@ -1,0 +1,11 @@
+--- src/timer.cpp.intermediate	2016-07-21 15:57:15 UTC
++++ src/timer.cpp
+@@ -118,7 +118,7 @@ void TimerPort::decTimer(timeout_t timeo
+     active = true;
+ }
+ 
+-#if defined(HAVE_HIRES_TIMER) && !defined(__FreeBSD__)
++#if defined(HAVE_HIRES_TIMER) && !defined(__FreeBSD__) && !defined(__DragonFly__)
+ void TimerPort::sleepTimer(void)
+ {
+     struct timespec ts;


### PR DESCRIPTION
commoncpp installs common headers that are used by ports depending on it.
Since it building CFLAGS aren't fully considered everywhere it is better
to patch such ports directly to provide fixed headers than depend on
implicit alias + strange patches in other ports.

This fixes another case of upcoming POSIX ns cleanup in base.
Specifically net/panoptis that for now passes w/o any patching.

To rebuild: audio/ccaudio2 devel/commoncpp net/panoptis

Disected-by: swildner