### PR TITLE
www/chromium: Fix ffmpeg contrib strict POSIX env

### DIFF
--- a/ports/www/chromium/dragonfly/patch-third__party_ffmpeg_ffmpeg.gyp
+++ b/ports/www/chromium/dragonfly/patch-third__party_ffmpeg_ffmpeg.gyp
@@ -1,0 +1,11 @@
+--- third_party/ffmpeg/ffmpeg.gyp.orig	2016-07-23 10:20:59.227545000 +0200
++++ third_party/ffmpeg/ffmpeg.gyp	2016-07-23 10:21:11.097131000 +0200
+@@ -188,8 +188,6 @@
+           ],
+           'defines': [
+             'HAVE_AV_CONFIG_H',
+-            '_POSIX_C_SOURCE=200112',
+-            '_XOPEN_SOURCE=600',
+             'PIC',
+             # Disable deprecated features that generate spammy warnings.
+             # BUILD.gn & media/ffmpeg/ffmpeg_common.h must be kept in sync.


### PR DESCRIPTION
For upcoming header cleanup, similar patch is available
as freebsd conditional files/extra-patch-gcc but:
1) doesn't apply to our gcc5 very well
2) likely will be gone together w/ f9
3) just removing the defines is simplier to track

Submitted-by: swildner (tested on poudriere 6.4h build at -j1)