### PR TITLE
www/firefox: Enable webrtc and pulseaudio in it.

### DIFF
--- a/ports/www/firefox/Makefile.DragonFly
+++ b/ports/www/firefox/Makefile.DragonFly
@@ -1,5 +1,3 @@
-MOZ_OPTIONS+= --disable-webrtc
-OPTIONS_DEFAULT:= ${OPTIONS_DEFAULT:NPULSEAUDIO}
 
 # zrj: override default options to "lite" mode (no dbus,gtk3,pulseaudio etc)
 .if defined(LITE)


### PR DESCRIPTION
Provisionally for now to allow users to test webrtc speaker/mic communications.
Something strange with rust, it has internal compiler error maybe master ABI change.
w/o rust option it compiles fine in synth.