### PR TITLE
x11-toolkits/gtk30: Mark missing dbus dependencies

### DIFF
--- a/ports/x11-toolkits/gtk30/Makefile.DragonFly
+++ b/ports/x11-toolkits/gtk30/Makefile.DragonFly
@@ -1,0 +1,13 @@
+
+# zrj: mark hidden dbus dependencies us such (respect users freedom!)
+# https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=194460
+
+BUILD_DEPENDS:=	${BUILD_DEPENDS:Nat-spi2-atk*}
+RUN_DEPENDS:=	${RUN_DEPENDS:Nat-spi2-atk*}
+
+OPTIONS_DEFINE+=	DBUS
+OPTIONS_DEFAULT+=	DBUS
+
+DBUS_CONFIGURE_WITH=atk-bridge
+DBUS_LIB_DEPENDS=libatk-bridge-2.0.so:${PORTSDIR}/accessibility/at-spi2-atk
+DBUS_DESC=	AT-SPI ATK bridge support (hidden depends on devel/dbus)

--- a/ports/x11-toolkits/gtk30/dragonfly/patch-atk-bridge-option
+++ b/ports/x11-toolkits/gtk30/dragonfly/patch-atk-bridge-option
@@ -1,0 +1,80 @@
+# Revert bug 677491 comment 45
+
+diff --git configure configure.ac
+index d4c2262..37b6349 100644
+--- configure
++++ configure
+@@ -1039,6 +1039,7 @@ enable_glibtest
+ enable_modules
+ with_included_immodules
+ with_x
++with_atk_bridge
+ enable_cups
+ enable_papi
+ enable_cloudprint
+@@ -1790,6 +1791,7 @@ Optional Packages:
+   --with-included-immodules=MODULE1,MODULE2,...
+                           build the specified input methods into gtk
+   --with-x                use the X Window System
++  --without-atk-bridge    Do not use atk-bridge-2.0
+   --with-html-dir=PATH    path to installed docs
+   --with-xml-catalog=CATALOG
+                           path to xml catalog to use
+@@ -24609,8 +24611,20 @@ fi
+ # Check for Accessibility Toolkit flags
+ ########################################
+ 
+-if test x$enable_x11_backend = xyes; then
++
++# Check whether --with-atk-bridge was given.
++if test "${with_atk_bridge+set}" = set; then :
++  withval=$with_atk_bridge; :
++else
++  with_atk_bridge=$enable_x11_backend
++fi
++
++
++if test x$with_atk_bridge != xno; then
+    ATK_PACKAGES="atk atk-bridge-2.0"
++
++$as_echo "#define HAVE_ATK_BRIDGE 1" >>confdefs.h
++
+ else
+    ATK_PACKAGES="atk"
+ fi
+diff --git config.h.in config.h.in
+index d4c2262..37b6349 100644
+--- config.h.in
++++ config.h.in
+@@ -15,6 +15,9 @@
+ /* Define the location where the catalogs will be installed */
+ #undef GTK_LOCALEDIR
+ 
++/* Define if we're using atk-bridge-2.0 */
++#undef HAVE_ATK_BRIDGE
++
+ /* Define to 1 if you have the `bind_textdomain_codeset' function. */
+ #undef HAVE_BIND_TEXTDOMAIN_CODESET
+ 
+diff --git gtk/a11y/gtkaccessibility.c gtk/a11y/gtkaccessibility.c
+index 4f5028b..ff8450a 100644
+--- gtk/a11y/gtkaccessibility.c
++++ gtk/a11y/gtkaccessibility.c
+@@ -37,7 +37,7 @@
+ #include <gtk/gtktogglebutton.h>
+ #include <gtk/gtkaccessible.h>
+ 
+-#ifdef GDK_WINDOWING_X11
++#ifdef HAVE_ATK_BRIDGE
+ #include <atk-bridge.h>
+ #endif
+ 
+@@ -987,7 +987,7 @@ _gtk_accessibility_init (void)
+   _gtk_accessibility_override_atk_util ();
+   do_window_event_initialization ();
+ 
+-#ifdef GDK_WINDOWING_X11
++#ifdef HAVE_ATK_BRIDGE
+   atk_bridge_adaptor_init (NULL, NULL);
+ #endif
+ 


### PR DESCRIPTION
Controversal issue:
https://bugzilla.gnome.org/show_bug.cgi?id=677491
Also even at freebsd-ports:
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=194460

Since we try to keep ports lean&fast and prefer to respect users choices
just add Jan Beich pending fix. (very unlikely to break in the future)
To keep upstream happy default behaviour is not changed.
If user compiles his set with OPTIONS_UNSET=DBUS this needs to be respected
and any artificial blockers should be patched out to ensure users freedom
to run their system as they see fit (even if that means patching).

As for me this allows to finally runtime test gtk3 ports too.
At least textproc/meld works fine and looks like I no longer need to use
ancient meld with gtk2 and hope updated deps stay compatible.