### PR TITLE
databases/cppdb: Revert 'use ninja'

### DIFF
--- a/ports/databases/cppdb/Makefile.DragonFly
+++ b/ports/databases/cppdb/Makefile.DragonFly
@@ -1,0 +1,2 @@
+# ninja once again can't relink properly..
+USES:= ${USES:Nninja}


### PR DESCRIPTION
Author: riggs <riggs@FreeBSD.org>
Date:   Sun Jul 17 06:46:45 2016 +0000
Build with ninja to reduce build time
PR:             210725
Submitted by:   info@babaei.net (maintainer)

Ok, lets check if it needs speeding up, w/o ninja first:
synth test databases/cpp
24.123u 7.958s 0:27.40 117.0%   5671+773k 17630+94io 102pf+0w

Are you fricking kidding me?!?