### PR TITLE
sysutils/flock-dfly: Bandage

### DIFF
--- a/ports/net/google-startup-scripts/Makefile.DragonFly
+++ b/ports/net/google-startup-scripts/Makefile.DragonFly
@@ -1,0 +1,3 @@
+
+# zrj: sigh.. until we grow timer_create und friends..
+RUN_DEPENDS:= ${RUN_DEPENDS:Nflock*} flock:sysutils/flock-dfly

--- a/ports/sysutils/flock-dfly/STATUS
+++ b/ports/sysutils/flock-dfly/STATUS
@@ -1,0 +1,3 @@
+DPORT
+Last attempt: 
+Last success: 

--- a/ports/sysutils/flock-dfly/newport/Makefile
+++ b/ports/sysutils/flock-dfly/newport/Makefile
@@ -1,0 +1,23 @@
+# DragonFly specific port, mainly to allow build chromium...
+# Until missing timer_create() und friends prevents to have main sysutils/flock
+
+PORTNAME=	flock
+PORTVERSION=	2.19
+CATEGORIES=	sysutils
+MASTER_SITES=	http://www.zonov.org/${PORTNAME}/ \
+		https://leaf.dragonflybsd.org/~zrj/dports/distcache/
+
+PKGNAMESUFFIX+=	-dfly
+CONFLICTS_INSTALL+=	flock-[0-9].*
+
+MAINTAINER=	zrj@ef.irc
+COMMENT=	Manage locks from shell scripts (dfly compat version)
+
+PLIST_FILES=	bin/${PORTNAME} \
+		man/man1/${PORTNAME}.1.gz
+
+do-install:
+	${INSTALL_PROGRAM} ${WRKSRC}/${PORTNAME} ${STAGEDIR}${PREFIX}/bin
+	${INSTALL_MAN} ${WRKSRC}/${PORTNAME}.1 ${STAGEDIR}${MANPREFIX}/man/man1
+
+.include <bsd.port.mk>

--- a/ports/sysutils/flock-dfly/newport/distinfo
+++ b/ports/sysutils/flock-dfly/newport/distinfo
@@ -1,0 +1,2 @@
+SHA256 (flock-2.19.tar.gz) = 9716618042a753cc4bd6e787d0886ea5fce8a167d5ce62421cee2c09ea86fbda
+SIZE (flock-2.19.tar.gz) = 5452

--- a/ports/sysutils/flock-dfly/newport/pkg-descr
+++ b/ports/sysutils/flock-dfly/newport/pkg-descr
@@ -1,0 +1,3 @@
+Manage locks from shell scripts
+
+WWW: http://ftp.kernel.org/pub/linux/utils/util-linux/

--- a/ports/www/chromium/Makefile.DragonFly
+++ b/ports/www/chromium/Makefile.DragonFly
@@ -6,6 +6,9 @@ CFLAGS+=	-D__STDC_LIMIT_MACROS
 KERBEROS_LIB_DEPENDS+=	libgssapi_krb5.so:security/krb5
 USES+=		alias
 
+# zrj: sigh.. until we grow timer_create und friends..
+BUILD_DEPENDS:= ${BUILD_DEPENDS:Nflock*} flock:sysutils/flock-dfly
+
 GYP_DEFINES+=	target_arch=x64 OS=dragonfly disable_fatal_linker_warnings=1
 
 dfly-patch:


### PR DESCRIPTION
We are missing POSIX timer_* functions and new sysutils/flock needs them.
For now only chromium and google-startup-scripts have a dep on flock
(except for www/mod_spdy that is still in failing heap).

Keep this port until we implement the missing POSIX functions.