### PR TITLE
ftp/R-cran-curl: Fix build on new version.

### DIFF
--- a/ports/ftp/R-cran-curl/dragonfly/patch-src_nslookup.c
+++ b/ports/ftp/R-cran-curl/dragonfly/patch-src_nslookup.c
@@ -1,0 +1,11 @@
+--- src/nslookup.c.orig	2016-07-26 11:53:35.000000000 +0300
++++ src/nslookup.c
+@@ -9,7 +9,7 @@ const char *inet_ntop(int af, const void
+ #include <sys/socket.h>
+ #include <netdb.h>
+ #include <arpa/inet.h>
+-#ifdef __FreeBSD__
++#if defined(__FreeBSD__) || defined(__DragonFly__)
+ #include <netinet/in.h>
+ #endif
+ #endif


### PR DESCRIPTION
In ports FreeBSD had a general patch, yet upstreamed just their case.
Patch accordingly for DragonFly too.

Btw, shouldn't main math/R port be somewhat more like: http://sprunge.us/XWOT