### PR TITLE
biology/seqtools: Fix FILE issue.

### DIFF
--- a/ports/biology/seqtools/dragonfly/patch-gbtools_src_include_blatSrc_fof.c
+++ b/ports/biology/seqtools/dragonfly/patch-gbtools_src_include_blatSrc_fof.c
@@ -1,0 +1,14 @@
+--- gbtools/src/blatSrc/lib/fof.c.orig	2016-07-22 10:44:49.000000000 +0300
++++ gbtools/src/blatSrc/lib/fof.c
+@@ -336,7 +336,11 @@ static int cmpOnFilePos(const void *va,
+ {
+ const struct fofBatch *a = *((struct fofBatch **)va);
+ const struct fofBatch *b = *((struct fofBatch **)vb);
++#ifdef __DragonFly__
++int dif = (struct __FILE_public*)a->f - (struct __FILE_public*)b->f;
++#else
+ int dif = a->f - b->f;
++#endif
+ if (dif == 0)
+     dif = a->offset - b->offset;
+ return dif;


### PR DESCRIPTION
On DragonFly FILE is __FILE typedef, so avoid:
error: arithmetic on pointer to an incomplete type
by casting it to public complete type.