### PR TITLE
net/xorp: Fix build after updated libpcap in dports.

### DIFF
--- a/ports/net/xorp/Makefile.DragonFly
+++ b/ports/net/xorp/Makefile.DragonFly
@@ -1,3 +1,4 @@
-USES+= alias ssl
+# don't use alias, conflicsts in libpcap headers
+USES+= ssl
 
 LDFLAGS+= -lcrypto

--- a/ports/net/xorp/dragonfly/patch-libcomm_comm__sock.c
+++ b/ports/net/xorp/dragonfly/patch-libcomm_comm__sock.c
@@ -1,0 +1,11 @@
+--- libcomm/comm_sock.c.orig	2012-01-11 19:56:10.000000000 +0200
++++ libcomm/comm_sock.c
+@@ -1332,7 +1332,7 @@ comm_set_bindtodevice(xsock_t sock, cons
+ 
+     return (XORP_OK);
+ #else
+-#ifndef __FreeBSD__
++#if !defined(__FreeBSD__) && !defined(__DragonFly__)
+     // FreeBSD doesn't implement this, so no use filling logs with errors that can't
+     // be helped.  Assume calling code deals with the error code as needed.
+     XLOG_ERROR("setsockopt SO_BINDTODEVICE %s: %s",

--- a/ports/net/xorp/dragonfly/patch-rtrmgr_lex.boot.cc
+++ b/ports/net/xorp/dragonfly/patch-rtrmgr_lex.boot.cc
@@ -1,0 +1,11 @@
+--- rtrmgr/lex.boot.cc.intermediate	2016-08-05 12:46:25 UTC
++++ rtrmgr/lex.boot.cc
+@@ -23,7 +23,7 @@
+  * $FreeBSD: src/usr.bin/lex/flex.skl,v 1.8 2004/01/06 19:03:44 nectar Exp $
+  */
+ 
+-#if defined(__FreeBSD__)
++#if defined(__FreeBSD__) || defined(__DragonFly__)
+ #include <sys/cdefs.h>
+ #else
+ #define __unused

--- a/ports/net/xorp/dragonfly/patch-rtrmgr_lex.opcmd.cc
+++ b/ports/net/xorp/dragonfly/patch-rtrmgr_lex.opcmd.cc
@@ -1,0 +1,11 @@
+--- rtrmgr/lex.opcmd.cc.intermediate	2016-08-05 12:46:25 UTC
++++ rtrmgr/lex.opcmd.cc
+@@ -23,7 +23,7 @@
+  * $FreeBSD: src/usr.bin/lex/flex.skl,v 1.8 2004/01/06 19:03:44 nectar Exp $
+  */
+ 
+-#if defined(__FreeBSD__)
++#if defined(__FreeBSD__) || defined(__DragonFly__)
+ #include <sys/cdefs.h>
+ #else
+ #define __unused

--- a/ports/net/xorp/dragonfly/patch-rtrmgr_lex.tplt.cc
+++ b/ports/net/xorp/dragonfly/patch-rtrmgr_lex.tplt.cc
@@ -1,0 +1,11 @@
+--- rtrmgr/lex.tplt.cc.intermediate	2016-08-05 12:46:25 UTC
++++ rtrmgr/lex.tplt.cc
+@@ -23,7 +23,7 @@
+  * $FreeBSD: src/usr.bin/lex/flex.skl,v 1.8 2004/01/06 19:03:44 nectar Exp $
+  */
+ 
+-#if defined(__FreeBSD__)
++#if defined(__FreeBSD__) || defined(__DragonFly__)
+ #include <sys/cdefs.h>
+ #else
+ #define __unused


### PR DESCRIPTION
Note to myself: don't be lazy, use patches and drop alias.
We can't use alias cause it causes problems in lipcap defines in headers.

Should we alias to freebsd in libpcap headers? nfc.