### PR TITLE
sysutils/bareos-client-static: Fix last failing port of bareos.

### DIFF
--- a/ports/sysutils/bareos-server/Makefile.DragonFly
+++ b/ports/sysutils/bareos-server/Makefile.DragonFly
@@ -1,0 +1,4 @@
+
+.if ${PKGNAMESUFFIX} == "-client-static"
+USES+= gettext ncurses
+.endif


### PR DESCRIPTION
client-static nees ncurses and gettext(-lintl).

Rebuild master port sysuitls/bareos-server first.