### PR TITLE
math/clblas: Fix build.

### DIFF
--- a/ports/math/clblas/Makefile.DragonFly
+++ b/ports/math/clblas/Makefile.DragonFly
@@ -1,0 +1,2 @@
+# zrj: in case of gcc we get extra pkgconfig file
+PLIST_FILES+= libdata/pkgconfig/clBLAS.pc

--- a/ports/math/clblas/dragonfly/patch-src_CMakeLists.txt
+++ b/ports/math/clblas/dragonfly/patch-src_CMakeLists.txt
@@ -1,0 +1,18 @@
+--- src/CMakeLists.txt.orig	2016-01-05 19:04:55.000000000 +0200
++++ src/CMakeLists.txt
+@@ -288,9 +288,15 @@ endif()
+ 
+ # Turn on maximum compiler verbosity
+ if(CMAKE_COMPILER_IS_GNUCXX)
++  if (CMAKE_SYSTEM_NAME STREQUAL "DragonFly")
++    add_definitions(-pedantic -Wall -Wextra
++        -D_POSIX_C_SOURCE=200112L -D_XOPEN_SOURCE=600
++    )
++  else( )
+     add_definitions(-pedantic -Wall -Wextra
+         -D_POSIX_C_SOURCE=199309L -D_XOPEN_SOURCE=500
+     )
++  endif( )
+     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -Wstrict-prototypes" CACHE STRING
+         "Default CFLAGS" FORCE)
+     # Don't use -rpath.

--- a/ports/math/clblas/dragonfly/patch-src_library_CMakeLists.txt
+++ b/ports/math/clblas/dragonfly/patch-src_library_CMakeLists.txt
@@ -1,0 +1,17 @@
+--- src/library/CMakeLists.txt.orig	2016-01-05 19:04:55.000000000 +0200
++++ src/library/CMakeLists.txt
+@@ -830,9 +830,13 @@ add_dependencies( GENERATE_CLT tplgen )
+ if( CMAKE_COMPILER_IS_GNUCC )
+     configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/clBLAS.pc.in
+                     ${CMAKE_CURRENT_BINARY_DIR}/clBLAS.pc @ONLY )
+-
++  if (CMAKE_SYSTEM_NAME STREQUAL "DragonFly")
++    install( FILES ${CMAKE_CURRENT_BINARY_DIR}/clBLAS.pc
++             DESTINATION libdata/pkgconfig )
++  else ()
+     install( FILES ${CMAKE_CURRENT_BINARY_DIR}/clBLAS.pc
+              DESTINATION lib${SUFFIX_LIB}/pkgconfig )
++  endif( )
+ endif( )
+ 
+ # clBLAS to depend on AutoGemm

--- a/ports/math/clblas/dragonfly/patch-src_samples_CMakeLists.pack
+++ b/ports/math/clblas/dragonfly/patch-src_samples_CMakeLists.pack
@@ -1,0 +1,18 @@
+--- src/samples/CMakeLists.pack.orig	2016-01-05 19:04:55.000000000 +0200
++++ src/samples/CMakeLists.pack
+@@ -63,9 +63,15 @@ mark_as_advanced(OPENCL_INCLUDE_DIRS OPE
+ 
+ # Turn on maximum compiler verbosity
+ if(CMAKE_COMPILER_IS_GNUCXX)
++  if (CMAKE_SYSTEM_NAME STREQUAL "DragonFly")
++    add_definitions(-pedantic -Wall -Wextra
++        -D_POSIX_C_SOURCE=200112L -D_XOPEN_SOURCE=600
++    )
++  else()
+     add_definitions(-pedantic -Wall -Wextra
+         -D_POSIX_C_SOURCE=199309L -D_XOPEN_SOURCE=500
+     )
++  endif()
+     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -Wstrict-prototypes" CACHE STRING
+         "Default CFLAGS" FORCE)
+     # Don't use -rpath.


### PR DESCRIPTION
Even if I don't approve boost usage in OpenCL stuff, well, it makes a good testcase,
so fix cripplings of gcc (other compilers would not handle it anyway).
CLOCK_REALTIME on dlfy is visible later in POSIX.

This installs extra file in case of gcc, so PLIST_FILES+= trick is ok?
or should i just patch so that pc file is not install even for gcc case?