### PR TITLE
devel/objecthash: Cure c++'ism.

### DIFF
--- a/ports/devel/objecthash/dragonfly/patch-Makefile
+++ b/ports/devel/objecthash/dragonfly/patch-Makefile
@@ -1,0 +1,15 @@
+--- Makefile.orig	2016-02-23 19:32:29.000000000 +0200
++++ Makefile
+@@ -14,10 +14,10 @@ java:
+ 	sbt test
+ 
+ objecthash_test: libobjecthash.so
+-	$(CC) -std=c99 -Wall -Werror -o objecthash_test objecthash_test.c -lobjecthash -L. -Wl,-rpath -Wl,.
++	$(CC) -std=c99 -Wall -o objecthash_test objecthash_test.c -lobjecthash -L. -Wl,-rpath -Wl,.
+ 
+ libobjecthash.so: objecthash.c
+-	$(CC) -fPIC -shared -std=c99 -Wall -Werror -o libobjecthash.so objecthash.c -lcrypto `pkg-config --libs --cflags icu-uc json-c`
++	$(CC) -fPIC -shared -std=c99 -Wall -o libobjecthash.so objecthash.c -lcrypto `pkg-config --libs --cflags icu-uc json-c`
+ 
+ get:
+ 	GOPATH=`pwd` go get golang.org/x/text/unicode/norm

--- a/ports/devel/objecthash/dragonfly/patch-objecthash.h
+++ b/ports/devel/objecthash/dragonfly/patch-objecthash.h
@@ -1,0 +1,15 @@
+--- objecthash.h.orig	2016-02-23 19:32:29.000000000 +0200
++++ objecthash.h
+@@ -8,7 +8,12 @@ extern "C" {
+ 
+ typedef unsigned char byte;
+ 
++#ifdef __DragonFly__
++/* avoid c++'ism */
++#define HASH_SIZE SHA256_DIGEST_LENGTH
++#else
+ static const int HASH_SIZE = SHA256_DIGEST_LENGTH;
++#endif
+ 
+ typedef byte hash[HASH_SIZE];
+ typedef SHA256_CTX hash_ctx;


### PR DESCRIPTION
GCC is right, static const int is not a "parameter" in C.
If clang accepts it then well it doesn't have a notion of file scopes..
Also disable -Werror=unused-but-set-variable