### PR TITLE
net/cjdns: Fix build problems.

### DIFF
--- a/ports/net/cjdns/Makefile.DragonFly
+++ b/ports/net/cjdns/Makefile.DragonFly
@@ -1,1 +1,0 @@
-IGNORE=	node, build locks up

--- a/ports/net/cjdns/dragonfly/patch-crypto_random_seed_BsdKernArndSysctlRandomSeed.h
+++ b/ports/net/cjdns/dragonfly/patch-crypto_random_seed_BsdKernArndSysctlRandomSeed.h
@@ -1,0 +1,13 @@
+No KERN_ARND on DragonFly yet?
+
+--- crypto/random/seed/BsdKernArndSysctlRandomSeed.h.orig	2016-06-15 00:58:54.000000000 +0300
++++ crypto/random/seed/BsdKernArndSysctlRandomSeed.h
+@@ -20,7 +20,7 @@
+ #include "memory/Allocator.h"
+ #include "util/Linker.h"
+ 
+-#if defined(freebsd) || defined(openbsd)
++#if (defined(freebsd) || defined(openbsd)) && !defined(__DragonFly__)
+     Linker_require("crypto/random/seed/BsdKernArndSysctlRandomSeed.c");
+     struct RandomSeed* BsdKernArndSysctlRandomSeed_new(struct Allocator* alloc);
+     RandomSeedProvider_register(BsdKernArndSysctlRandomSeed_new)

--- a/ports/net/cjdns/dragonfly/patch-interface_tuntap_TUNInterface__freebsd.c
+++ b/ports/net/cjdns/dragonfly/patch-interface_tuntap_TUNInterface__freebsd.c
@@ -1,0 +1,14 @@
+--- interface/tuntap/TUNInterface_freebsd.c.orig	2016-06-15 00:58:54.000000000 +0300
++++ interface/tuntap/TUNInterface_freebsd.c
+@@ -33,7 +33,11 @@
+ #include <string.h>
+ #include <netdb.h>
+ #include <net/if_var.h>
++#ifdef __DragonFly__
++#include <net/tun/if_tun.h>
++#else
+ #include <net/if_tun.h>
++#endif
+ #include <netinet/in.h>
+ #include <netinet6/in6_var.h>
+ #include <netinet6/nd6.h>

--- a/ports/net/cjdns/dragonfly/patch-node__build_dependencies_libuv_src_unix_freebsd.c
+++ b/ports/net/cjdns/dragonfly/patch-node__build_dependencies_libuv_src_unix_freebsd.c
@@ -1,0 +1,22 @@
+Current DragonFly has identical behaviour to FreeBSD and return full path.
+
+--- node_build/dependencies/libuv/src/unix/freebsd.c.orig	2016-06-15 00:58:54.000000000 +0300
++++ node_build/dependencies/libuv/src/unix/freebsd.c
+@@ -81,17 +81,10 @@ int uv_exepath(char* buffer, size_t* siz
+   if (buffer == NULL || size == NULL)
+     return -EINVAL;
+ 
+-#ifdef __DragonFly__
+-  mib[0] = CTL_KERN;
+-  mib[1] = KERN_PROC;
+-  mib[2] = KERN_PROC_ARGS;
+-  mib[3] = getpid();
+-#else
+   mib[0] = CTL_KERN;
+   mib[1] = KERN_PROC;
+   mib[2] = KERN_PROC_PATHNAME;
+   mib[3] = -1;
+-#endif
+ 
+   cb = *size;
+   if (sysctl(mib, 4, buffer, &cb, NULL, 0))

--- a/ports/net/cjdns/dragonfly/patch-node__build_make.js
+++ b/ports/net/cjdns/dragonfly/patch-node__build_make.js
@@ -1,0 +1,52 @@
+HhrrrrrR who made process.platform to return freebsd?????
+
+--- node_build/make.js.orig	2016-06-15 00:58:54.000000000 +0300
++++ node_build/make.js
+@@ -41,6 +41,12 @@ if (GCC) {
+     GCC = 'gcc';
+ }
+ 
++if (Os.type() == 'DragonFly') {
++    GCC = 'gcc';
++    console.error('system= ' + SYSTEM + "  " + process.env['SYSTEM'] + " " + process.platform);
++    console.error('gcc=    ' + GCC + " " + Os.type());
++}
++
+ Builder.configure({
+     systemName:     SYSTEM,
+     crossCompiling: process.env['CROSS'] !== undefined,
+@@ -113,6 +119,7 @@ Builder.configure({
+     }
+ 
+     if (process.env['NO_PIE'] === undefined && builder.config.systemName !== 'freebsd'
++        && builder.config.systemName !== 'dragonfly'
+         && builder.config.systemName !== 'win32')
+     {
+         builder.config.cflags.push('-fPIE');
+@@ -303,7 +310,7 @@ Builder.configure({
+             builder.config.libs.push('-lrt'); // clock_gettime()
+         } else if (builder.config.systemName === 'darwin') {
+             builder.config.libs.push('-framework', 'CoreServices');
+-        } else if (['freebsd', 'openbsd', 'netbsd'].indexOf(builder.config.systemName) >= 0) {
++        } else if (['dragonfly', 'freebsd', 'openbsd', 'netbsd'].indexOf(builder.config.systemName) >= 0) {
+             builder.config.cflags.push('-Wno-overlength-strings');
+             builder.config.libs.push('-lkvm');
+         } else if (builder.config.systemName === 'sunos') {
+@@ -361,7 +368,7 @@ Builder.configure({
+                 args.push.apply(args, env.GYP_ADDITIONAL_ARGS.split(' '));
+             }
+ 
+-            if (['freebsd', 'openbsd', 'netbsd'].indexOf(builder.config.systemName) !== -1) {
++            if (['dragonfly', 'freebsd', 'openbsd', 'netbsd'].indexOf(builder.config.systemName) !== -1) {
+                 // This platform lacks a functioning sem_open implementation, therefore...
+                 args.push('--no-parallel');
+                 args.push('-DOS=' + builder.config.systemName);
+@@ -387,7 +394,7 @@ Builder.configure({
+                 }
+                 args.push('CFLAGS=' + cflags.join(' '));
+ 
+-                var makeCommand = ['freebsd', 'openbsd', 'netbsd'].indexOf(builder.config.systemName) >= 0 ? 'gmake' : 'make';
++                var makeCommand = ['dragonfly', 'freebsd', 'openbsd', 'netbsd'].indexOf(builder.config.systemName) >= 0 ? 'gmake' : 'make';
+                 var make = Spawn(makeCommand, args, {stdio: 'inherit'});
+ 
+                 make.on('error', function (err) {

--- a/ports/net/cjdns/dragonfly/patch-util_platform_netdev_NetPlatform__freebsd.c
+++ b/ports/net/cjdns/dragonfly/patch-util_platform_netdev_NetPlatform__freebsd.c
@@ -1,0 +1,14 @@
+--- util/platform/netdev/NetPlatform_freebsd.c.orig	2016-06-15 00:58:54.000000000 +0300
++++ util/platform/netdev/NetPlatform_freebsd.c
+@@ -32,7 +32,11 @@
+ #include <string.h>
+ #include <netdb.h>
+ #include <net/if_var.h>
++#ifdef __DragonFly__
++#include <net/tun/if_tun.h>
++#else
+ #include <net/if_tun.h>
++#endif
+ #include <netinet/in.h>
+ #include <netinet6/in6_var.h>
+ #include <netinet6/nd6.h>


### PR DESCRIPTION
Well we might need KERN_ARNG syscall...
And libuv fix for correct full path on exec, not a relative in other ports too.
This one now has correct full path (/usr/.../exec).
There might be other issues but for now will do.