### PR TITLE
net/ntopng: Fix build

### DIFF
--- a/ports/net/ndpi/Makefile.DragonFly
+++ b/ports/net/ndpi/Makefile.DragonFly
@@ -1,0 +1,2 @@
+# zrj: installs headers w/ __FreeBSD__
+USES:= ${USES:Nalias}

--- a/ports/net/ndpi/dragonfly/patch-src_include_ndpi__define.h
+++ b/ports/net/ndpi/dragonfly/patch-src_include_ndpi__define.h
@@ -1,0 +1,11 @@
+--- src/include/ndpi_define.h.orig	2016-06-27 12:19:47.000000000 +0300
++++ src/include/ndpi_define.h
+@@ -27,7 +27,7 @@
+   gcc -E -dM - < /dev/null |grep ENDIAN
+ */
+ 
+-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
++#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
+ #include <machine/endian.h>
+ #endif
+ 

--- a/ports/net/ndpi/dragonfly/patch-src_include_ndpi__includes.h
+++ b/ports/net/ndpi/dragonfly/patch-src_include_ndpi__includes.h
@@ -1,0 +1,16 @@
+--- src/include/ndpi_includes.h.orig	2016-06-27 12:19:47.000000000 +0300
++++ src/include/ndpi_includes.h
+@@ -46,11 +46,11 @@
+ #include <netinet/tcp.h>
+ #include <netinet/udp.h>
+ 
+-#if !defined __APPLE__ && !defined __FreeBSD__ && !defined __NetBSD__ && !defined __OpenBSD__
++#if !defined __APPLE__ && !defined __FreeBSD__ && !defined __NetBSD__ && !defined __OpenBSD__ && !defined __DragonFly__
+ #include <endian.h>
+ #include <byteswap.h>
+ 
+-#if defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__
++#if defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__ || defined __DragonFly__
+ #include <netinet/in.h>
+ 
+ #if defined __NetBSD__ || defined __OpenBSD__

--- a/ports/net/ndpi/dragonfly/patch-src_include_ndpi__unix.h
+++ b/ports/net/ndpi/dragonfly/patch-src_include_ndpi__unix.h
@@ -1,0 +1,11 @@
+--- src/include/ndpi_unix.h.orig	2016-06-27 12:19:47.000000000 +0300
++++ src/include/ndpi_unix.h
+@@ -24,7 +24,7 @@
+ #ifndef __NDPI_UNIX_INCLUDE_FILE__
+ #define __NDPI_UNIX_INCLUDE_FILE__
+ 
+-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
++#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
+ #include <netinet/in.h>
+ #if defined(__NetBSD__) || defined(__OpenBSD__)
+ #include <netinet/in_systm.h>

--- a/ports/net/ntopng/dragonfly/patch-include_DivertInterface.h
+++ b/ports/net/ntopng/dragonfly/patch-include_DivertInterface.h
@@ -1,0 +1,11 @@
+--- include/DivertInterface.h.orig	2016-06-27 15:12:56.000000000 +0300
++++ include/DivertInterface.h
+@@ -19,7 +19,7 @@
+  *
+  */
+ 
+-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
++#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__APPLE__) || defined(__DragonFly__)
+ 
+ #ifndef _DIVERT_INTEFACE_H_
+ #define _DIVERT_INTEFACE_H_

--- a/ports/net/ntopng/dragonfly/patch-include_ntop__includes.h
+++ b/ports/net/ntopng/dragonfly/patch-include_ntop__includes.h
@@ -1,0 +1,11 @@
+--- include/ntop_includes.h.orig	2016-06-27 15:12:56.000000000 +0300
++++ include/ntop_includes.h
+@@ -204,7 +204,7 @@ using namespace std;
+ #include "NetfilterInterface.h"
+ #endif
+ #endif
+-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
++#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__APPLE__) || defined(__DragonFly__)
+ #include "DivertInterface.h"
+ #endif
+ #include "ParserInterface.h"

--- a/ports/net/ntopng/dragonfly/patch-src_DivertInterface.cpp
+++ b/ports/net/ntopng/dragonfly/patch-src_DivertInterface.cpp
@@ -1,0 +1,11 @@
+--- src/DivertInterface.cpp.orig	2016-06-27 15:12:56.000000000 +0300
++++ src/DivertInterface.cpp
+@@ -21,7 +21,7 @@
+ 
+ #include "ntop_includes.h"
+ 
+-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
++#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__APPLE__) || defined(__DragonFly__)
+ 
+ /* http://resin.csoft.net/cgi-bin/man.cgi?section=0&topic=divert */
+ 

--- a/ports/net/ntopng/dragonfly/patch-src_PacketDumperTuntap.cpp
+++ b/ports/net/ntopng/dragonfly/patch-src_PacketDumperTuntap.cpp
@@ -1,0 +1,11 @@
+--- src/PacketDumperTuntap.cpp.orig	2016-06-27 15:12:56.000000000 +0300
++++ src/PacketDumperTuntap.cpp
+@@ -127,7 +127,7 @@ int PacketDumperTuntap::openTap(char *de
+ 
+ /* ********************************************* */
+ 
+-#ifdef __OpenBSD__
++#if defined(__OpenBSD__) || defined(__DragonFly__)
+ #define OPENBSD_TAPDEVICE_SIZE 32
+ int PacketDumperTuntap::openTap(char *dev, /* user-definable interface name, eg. edge0 */ int mtu) {
+   int i;

--- a/ports/net/ntopng/dragonfly/patch-src_main.cpp
+++ b/ports/net/ntopng/dragonfly/patch-src_main.cpp
@@ -1,0 +1,11 @@
+--- src/main.cpp.orig	2016-06-27 15:12:56.000000000 +0300
++++ src/main.cpp
+@@ -169,7 +169,7 @@ int main(int argc, char *argv[])
+           iface = new NetfilterInterface(ifName);
+ #endif
+ 
+-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
++#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__APPLE__) || defined(__DragonFly__)
+         if(iface == NULL && strncmp(ifName, "divert:", 7) == 0)
+           iface = new DivertInterface(ifName);
+ #endif

--- a/ports/net/ntopng/dragonfly/patch-third-party_mongoose_mongoose.c
+++ b/ports/net/ntopng/dragonfly/patch-third-party_mongoose_mongoose.c
@@ -1,0 +1,20 @@
+--- third-party/mongoose/mongoose.c.orig	2016-06-27 15:12:56.000000000 +0300
++++ third-party/mongoose/mongoose.c
+@@ -4444,7 +4444,7 @@ static int parse_port_string(const struc
+   so->is_ssl = (vec->ptr[len] && vec->ptr[len] == 's');
+   so->ssl_redir = (vec->ptr[len] && vec->ptr[len] == 'r');
+ 
+-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
++#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
+   so->lsa.sin.sin_len = sizeof(struct sockaddr_in);
+ #endif
+ 
+@@ -5268,7 +5268,7 @@ struct mg_context *mg_start(const struct
+   check_ipv6_enabled();
+ #endif
+ 
+-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
++#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
+   is_ip6_enabled = 0;
+ #endif
+ 


### PR DESCRIPTION
Drop alias in net/ndpi (installs public headers w/ \__FreeBSD__) rebuild needed.
Add DragonFly for ntopng, but alias one place to OpenBSD.