### PR TITLE
databases/cego: Fix new c in not c.

### DIFF
--- a/ports/databases/cego/dragonfly/patch-samples_cgplustest_CegoCPlusTest.cc
+++ b/ports/databases/cego/dragonfly/patch-samples_cgplustest_CegoCPlusTest.cc
@@ -1,0 +1,10 @@
+--- samples/cgplustest/CegoCPlusTest.cc.orig	2013-05-18 09:01:29.000000000 +0300
++++ samples/cgplustest/CegoCPlusTest.cc
+@@ -39,6 +39,7 @@
+ #include <string.h>
+ #include <readline/readline.h>
+ #include <readline/history.h>
++#include <cstdlib>
+ 
+ #include <lfcbase/Chain.h>
+ #include <lfcbase/Exception.h>

--- a/ports/databases/cego/dragonfly/patch-src_CegoAdmin.cc
+++ b/ports/databases/cego/dragonfly/patch-src_CegoAdmin.cc
@@ -1,0 +1,10 @@
+--- src/CegoAdmin.cc.orig	2016-07-22 10:44:48.000000000 +0300
++++ src/CegoAdmin.cc
+@@ -43,6 +43,7 @@
+ #include <string.h>
+ #include <readline/readline.h>
+ #include <readline/history.h>
++#include <cstdlib>
+ 
+ #define USAGE "Usage: cgadm --user=<user>/<password>\n\
+    [ --server=<host>]\n\

--- a/ports/databases/cego/dragonfly/patch-src_CegoBufferPool.cc
+++ b/ports/databases/cego/dragonfly/patch-src_CegoBufferPool.cc
@@ -1,0 +1,10 @@
+--- src/CegoBufferPool.cc.orig	2016-07-16 10:10:47.000000000 +0300
++++ src/CegoBufferPool.cc
+@@ -32,6 +32,7 @@
+ // POSIX INCLUDES
+ #include <string.h>
+ #include <stdlib.h>
++#include <cstdlib>
+ 
+ #define BUFFERPOOLHEAD (((sizeof(BufferPoolHead)-1)/BUPMNG_ALIGNMENT)+1)*BUPMNG_ALIGNMENT
+ #define BUFFERHEAD (((sizeof(BufferHead)-1)/BUPMNG_ALIGNMENT)+1)*BUPMNG_ALIGNMENT

--- a/ports/databases/cego/dragonfly/patch-src_CegoClient.cc
+++ b/ports/databases/cego/dragonfly/patch-src_CegoClient.cc
@@ -1,0 +1,10 @@
+--- src/CegoClient.cc.orig	2016-07-26 08:38:32.000000000 +0300
++++ src/CegoClient.cc
+@@ -25,6 +25,7 @@
+ #include <string.h>
+ #include <readline/readline.h>
+ #include <readline/history.h>
++#include <cstdlib>
+ 
+ // LFC INCLUDES
+ #include <lfcbase/Chain.h>

--- a/ports/databases/cego/dragonfly/patch-src_CegoMain.cc
+++ b/ports/databases/cego/dragonfly/patch-src_CegoMain.cc
@@ -1,0 +1,10 @@
+--- src/CegoMain.cc.orig	2016-07-14 11:29:47.000000000 +0300
++++ src/CegoMain.cc
+@@ -22,6 +22,7 @@
+ #include <locale.h>
+ #include <stdlib.h>
+ #include <unistd.h>
++#include <cstdlib>
+ 
+ // LFC INCLUDES
+ #include <lfcbase/Sleeper.h>

--- a/ports/databases/cego/dragonfly/patch-src_CegoNet.cc
+++ b/ports/databases/cego/dragonfly/patch-src_CegoNet.cc
@@ -1,0 +1,10 @@
+--- src/CegoNet.cc.orig	2016-08-11 20:01:54.000000000 +0300
++++ src/CegoNet.cc
+@@ -20,6 +20,7 @@
+ 
+ // POSIX INCLUDES
+ #include <locale.h>
++#include <cstdlib>
+ 
+ // CEGO INCLUDES
+ #include "CegoNet.h"

--- a/ports/databases/cego/dragonfly/patch-src_CegoRecoveryManager.cc
+++ b/ports/databases/cego/dragonfly/patch-src_CegoRecoveryManager.cc
@@ -1,0 +1,10 @@
+--- src/CegoRecoveryManager.cc.orig	2016-07-20 17:07:27.000000000 +0300
++++ src/CegoRecoveryManager.cc
+@@ -30,6 +30,7 @@
+ 
+ #include <string.h>
+ #include <stdlib.h>
++#include <cstdlib>
+ 
+ CegoRecoveryManager::CegoRecoveryManager(CegoDistManager *pGTM, CegoRecoveryManager::RecoveryMode mode)
+ {


### PR DESCRIPTION
In new version getenv() was sprayed everywhere so we need <cstdlib>