### PR TITLE
misc/qt5-doc: Wild guess.

### DIFF
--- a/ports/misc/qt5-doc/Makefile.DragonFly
+++ b/ports/misc/qt5-doc/Makefile.DragonFly
@@ -1,1 +1,3 @@
-IGNORE=	takes very long time to fail (no idea what's wrong with it)
+# there are quite many warnings from makefiles, try gmake
+USES+= gmake
+MAKE_JOBS_UNSAFE=yes


### PR DESCRIPTION
dunno what is wrong in pou, swildner reported similar build failures,
yet on synth test no such problems so far.
Try using gmake, it gives less warngins on generated makefiles.
Also add make jobs unsage in MD too, maybe pou gets confused for it after
bsd.port.pre.mk