### PR TITLE
<cstdio> EOF in c++

### DIFF
--- a/ports/databases/libodbc++/dragonfly/patch-src_datastream.h
+++ b/ports/databases/libodbc++/dragonfly/patch-src_datastream.h
@@ -1,0 +1,13 @@
+Hmmm "virtual int_type overflow(int) {return EOF;}" OK...
+
+--- src/datastream.h.orig	2009-01-06 13:20:05.000000000 +0200
++++ src/datastream.h
+@@ -32,6 +32,8 @@
+ # include <streambuf.h>
+ #endif
+ 
++#include <cstdio> // for EOF
++
+ #if defined(ODBCXX_QT)
+ # include <qiodevice.h>
+ #endif

--- a/ports/devel/antlr/dragonfly/patch-lib_cpp_antlr_CharScanner.hpp
+++ b/ports/devel/antlr/dragonfly/patch-lib_cpp_antlr_CharScanner.hpp
@@ -1,10 +1,14 @@
---- lib/cpp/antlr/CharScanner.hpp.orig	2006-11-01 21:37:17.000000000 +0000
+--- lib/cpp/antlr/CharScanner.hpp.orig	2006-11-01 23:37:17.000000000 +0200
 +++ lib/cpp/antlr/CharScanner.hpp
-@@ -8,6 +8,7 @@
-  * $Id: //depot/code/org.antlr/release/antlr-2.7.7/lib/cpp/antlr/CharScanner.hpp#2 $
-  */
+@@ -18,6 +18,11 @@
+ #include <cctype>
+ #endif
  
-+#include <strings.h>
- #include <antlr/config.hpp>
- 
- #include <map>
++#include <cstdio>    // for EOF
++extern "C" {
++#include <strings.h> // for strcasecmp
++}
++
+ #if ( _MSC_VER == 1200 )
+ // VC6 seems to need this
+ // note that this is not a standard C++ include file.

--- a/ports/devel/ddd/Makefile.DragonFly
+++ b/ports/devel/ddd/Makefile.DragonFly
@@ -1,0 +1,4 @@
+
+# zrj nothing to see, just a hack
+pre-build:
+	${ECHO_CMD} "#include <cstdio>" >> ${WRKSRC}/ddd/config.h

--- a/ports/devel/glrparser/dragonfly/patch-glr_glrGrammar.h
+++ b/ports/devel/glrparser/dragonfly/patch-glr_glrGrammar.h
@@ -1,0 +1,10 @@
+--- glr/glrGrammar.h.orig	2003-03-26 11:03:08.000000000 +0200
++++ glr/glrGrammar.h
+@@ -6,6 +6,7 @@
+ #include <set>
+ #include <map>
+ #include <deque>
++#include <cstdio> // for EOF
+ 
+ using namespace std;
+ 

--- a/ports/devel/libbinio/dragonfly/patch-src_binwrap.cpp
+++ b/ports/devel/libbinio/dragonfly/patch-src_binwrap.cpp
@@ -1,0 +1,11 @@
+--- src/binwrap.cpp.orig	2003-03-08 18:02:34.000000000 +0200
++++ src/binwrap.cpp
+@@ -17,6 +17,8 @@
+  * Copyright (C) 2002, 2003 Simon Peter <dn.tlp@gmx.net>
+  */
+ 
++#include <stdio.h> // for EOF
++
+ #include "binwrap.h"
+ 
+ #if BINIO_ENABLE_IOSTREAM

--- a/ports/devel/xparam/dragonfly/patch-lib_antlr_antlr_CharScanner.hpp
+++ b/ports/devel/xparam/dragonfly/patch-lib_antlr_antlr_CharScanner.hpp
@@ -1,0 +1,10 @@
+--- lib/antlr/antlr/CharScanner.hpp.orig	2003-05-29 09:31:42.000000000 +0300
++++ lib/antlr/antlr/CharScanner.hpp
+@@ -42,6 +42,7 @@
+ #include "antlr/BitSet.hpp"
+ #include "antlr/LexerSharedInputState.hpp"
+ #include <map>
++#include <cstdio>  // for EOF
+ 
+ ANTLR_BEGIN_NAMESPACE(xparam_antlr)
+ 

--- a/ports/devel/xparam/dragonfly/patch-lib_sources_xp__loader.cpp
+++ b/ports/devel/xparam/dragonfly/patch-lib_sources_xp__loader.cpp
@@ -1,0 +1,10 @@
+--- lib/sources/xp_loader.cpp.orig	2002-04-03 14:11:15.000000000 +0200
++++ lib/sources/xp_loader.cpp
+@@ -34,6 +34,7 @@
+ #pragma warning (disable: 4786)
+ 
+ #include <iostream>
++#include <cstdio>  // for EOF
+ #include "../xparam/xp_loader.h"
+ #include "../xparam/xp_value_sink.h"
+ #include "../xparam/xp_parser.h"

--- a/ports/games/rtb/dragonfly/patch-team-framework_io_unixoutstreambuf.cpp
+++ b/ports/games/rtb/dragonfly/patch-team-framework_io_unixoutstreambuf.cpp
@@ -1,10 +1,11 @@
 --- team-framework/io/unixoutstreambuf.cpp.orig	2015-12-05 15:51:11.000000000 +0200
 +++ team-framework/io/unixoutstreambuf.cpp
-@@ -29,6 +29,7 @@
+@@ -29,6 +29,8 @@
  
  #include "unixoutstreambuf.h"
  #include <sstream>
-+#include <cstring>
++#include <cstring> // for strerror
++#include <cstdio>  // for EOF
  #include <errno.h>
  #include <sys/types.h>
  #include <unistd.h>

--- a/ports/games/shootingstar/dragonfly/patch-src_engine_dbg.cpp
+++ b/ports/games/shootingstar/dragonfly/patch-src_engine_dbg.cpp
@@ -1,0 +1,10 @@
+--- src/engine/dbg.cpp.orig	2003-04-06 22:56:45.000000000 +0300
++++ src/engine/dbg.cpp
+@@ -23,6 +23,7 @@
+ #include "dbg.h"
+ 
+ #include <iostream>
++#include <cstdio> // for EOF
+ #include <cstdlib>
+ #include <string>
+ #include <vector>

--- a/ports/graphics/panomatic/dragonfly/patch-panomatic_tclap_MultiArg.h
+++ b/ports/graphics/panomatic/dragonfly/patch-panomatic_tclap_MultiArg.h
@@ -1,0 +1,10 @@
+--- panomatic/tclap/MultiArg.h.intermediate	2016-09-02 18:20:53 UTC
++++ panomatic/tclap/MultiArg.h
+@@ -25,6 +25,7 @@
+ 
+ #include <string>
+ #include <vector>
++#include <cstdio> // for EOF
+ 
+ #include <tclap/Arg.h>
+ #include <tclap/Constraint.h>

--- a/ports/graphics/panomatic/dragonfly/patch-panomatic_tclap_ValueArg.h
+++ b/ports/graphics/panomatic/dragonfly/patch-panomatic_tclap_ValueArg.h
@@ -1,0 +1,10 @@
+--- panomatic/tclap/ValueArg.h.intermediate	2016-09-02 18:20:53 UTC
++++ panomatic/tclap/ValueArg.h
+@@ -25,6 +25,7 @@
+ 
+ #include <string>
+ #include <vector>
++#include <cstdio> // for EOF
+ 
+ #include <tclap/Arg.h>
+ #include <tclap/Constraint.h>

--- a/ports/textproc/scim-bridge/dragonfly/patch-agent_scim-bridge-agent-application.cpp
+++ b/ports/textproc/scim-bridge/dragonfly/patch-agent_scim-bridge-agent-application.cpp
@@ -1,0 +1,11 @@
+--- agent/scim-bridge-agent-application.cpp.orig	2009-01-17 19:04:20.000000000 +0200
++++ agent/scim-bridge-agent-application.cpp
+@@ -65,7 +65,7 @@ int main (int argc, char *argv[])
+     unsigned int tmp_uint;
+ 
+     int option = 0;
+-    while (option != EOF) {
++    while (option != -1) {
+         option = getopt_long (argc, argv, short_options, long_options, NULL);
+         switch (option) {
+             case 'v':

--- a/ports/www/bookmarkbridge/dragonfly/patch-bookmarkbridge_main.cpp
+++ b/ports/www/bookmarkbridge/dragonfly/patch-bookmarkbridge_main.cpp
@@ -1,0 +1,13 @@
+Ehem
+
+--- bookmarkbridge/main.cpp.orig	2005-09-21 03:21:48.000000000 +0300
++++ bookmarkbridge/main.cpp
+@@ -147,7 +147,7 @@ static bool ParseCmdLine(void)
+ 	extern	char	*optarg;
+ 	auto	int		optionC;
+ 
+-	while((optionC = getopt(qApp->argc(), qApp->argv(), "b:f:mrt")) != EOF)
++	while((optionC = getopt(qApp->argc(), qApp->argv(), "b:f:mrt")) != -1)
+ 	{
+ 		switch(optionC)
+ 		{

--- a/ports/www/swish++/dragonfly/patch-fdbuf.c
+++ b/ports/www/swish++/dragonfly/patch-fdbuf.c
@@ -1,0 +1,12 @@
+srsly? the .c ?
+
+--- fdbuf.c.orig	2005-01-02 22:10:26.000000000 +0200
++++ fdbuf.c
+@@ -22,6 +22,7 @@
+ // standard
+ #include <cerrno>
+ #include <cstring>
++#include <cstdio> // for EOF
+ #include <unistd.h>
+ 
+ // local


### PR DESCRIPTION
I would say .eof() should be used but hey,
also fix few cases where -1 should have been used (getopt())