### PR TITLE
audio/cmus: Fix build on version.

### DIFF
--- a/ports/audio/cmus/Makefile.DragonFly
+++ b/ports/audio/cmus/Makefile.DragonFly
@@ -1,0 +1,5 @@
+
+#zrj: prevent passing -D_POSIX_C_SOURCE=200112L -D_XOPEN_SOURCE=600 globally
+dfly-patch:
+	${REINPLACE_CMD} -e 's@\(NCURSES_CFLAGS=\).*@\1""@g'	\
+		${WRKSRC}/configure

--- a/ports/audio/cmus/dragonfly/patch-configure
+++ b/ports/audio/cmus/dragonfly/patch-configure
@@ -1,0 +1,11 @@
+--- configure.intermediate	2016-09-05 08:44:39 UTC
++++ configure
+@@ -21,7 +21,7 @@ check_cflags()
+ check_sndio()
+ {
+ 	case `uname -s` in
+-	OpenBSD|FreeBSD)
++	OpenBSD|FreeBSD|DragonFly)
+ 		check_library SNDIO "" "-lsndio"
+ 		return $?
+ 	esac


### PR DESCRIPTION
Now cmus configure uses pkg-config --cflags ncurses
and sets -D_POSIX_C_SOURCE=200112L -D_XOPEN_SOURCE=600 directly to CFLAGS
in turn hiding the visibility of strndup().
Fix by just ignoring ncurses cflags.