### PR TITLE
lang/cilkplus: Build fix.

### DIFF
--- a/ports/lang/cilkplus/dragonfly/patch-runtime_os-unix.c
+++ b/ports/lang/cilkplus/dragonfly/patch-runtime_os-unix.c
@@ -1,0 +1,19 @@
+--- runtime/os-unix.c.orig	2016-06-01 22:59:38.000000000 +0300
++++ runtime/os-unix.c
+@@ -432,6 +432,7 @@ COMMON_SYSDEP void __cilkrts_idle(void)
+ #elif defined(__MIC__)
+     _mm_delay_32(1024);
+ #elif defined(__linux__) || \
++      defined(__DragonFly__) || \
+       defined(__APPLE__) || \
+       defined(__CYGWIN__)
+       
+@@ -468,7 +469,7 @@ COMMON_SYSDEP void __cilkrts_yield(void)
+     // giving up the processor and latency starting up when work becomes
+     // available
+     _mm_delay_32(1024);
+-#elif defined(__linux__)
++#elif defined(__linux__) || defined(__DragonFly__)
+     // On Linux, call pthread_yield (which in turn will call sched_yield)
+     // to yield quantum.
+     pthread_yield();

--- a/ports/lang/cilkplus/dragonfly/patch-runtime_sysdep-unix.c
+++ b/ports/lang/cilkplus/dragonfly/patch-runtime_sysdep-unix.c
@@ -1,0 +1,13 @@
+--- runtime/sysdep-unix.c.orig	2016-06-01 22:59:39.000000000 +0300
++++ runtime/sysdep-unix.c
+@@ -97,6 +97,10 @@
+ #   define MAP_ANONYMOUS MAP_ANON
+ #endif
+ 
++#ifdef __DragonFly__
++#   include <sys/resource.h>
++#endif
++
+ #ifdef  __VXWORKS__
+ #   include <vxWorks.h>   
+ #   include <vxCpuLib.h>  


### PR DESCRIPTION
Just as I have in my gcc checkout. It builds passes most except
for CK runtime tests, problem in ld-elf.so (have a partial patch)
With rtld patch main body of cilk test works just still fails miserably in ld-elf.so when program is exiting (likely misses some destructor or calls them in wrong order or smth from c++ crap)
standalone testcase with gdb outputs: https://leaf.dragonflybsd.org/~zrj/cilk_fun/