### PR TITLE
editors/emacs: Fix build w/ gcc50 and C-x C-f browser.

### DIFF
--- a/ports/editors/emacs/Makefile.DragonFly
+++ b/ports/editors/emacs/Makefile.DragonFly
@@ -1,1 +1,10 @@
-USE_GCC=	NOT5
+#USE_GCC=	NOT5
+CFLAGS+= -fno-builtin-malloc # yay it is still needed :D (calloc opt)
+
+OPTIONS_DEFINE+=	GNULS
+OPTIONS_DEFAULT+=	GNULS
+
+GNULS_DESC=		Use gnu ls 'gls' for --dired flag support
+GNULS_EXTRA_PATCHES_OFF=	${FILESDIR}/../dragonfly/extra-ls_lisp_dired.el
+GNULS_EXTRA_PATCHES=		${FILESDIR}/../dragonfly/extra-gls_lisp_dired.el
+GNULS_RUN_DEPENDS=		gls:sysutils/coreutils

--- a/ports/editors/emacs/dragonfly/extra-gls_lisp_dired.el
+++ b/ports/editors/emacs/dragonfly/extra-gls_lisp_dired.el
@@ -1,0 +1,11 @@
+--- lisp/files.el.orig	2015-04-02 10:23:06.000000000 +0300
++++ lisp/files.el
+@@ -6094,7 +6094,7 @@ need to be passed verbatim to shell comm
+       pattern))))
+ 
+ 
+-(defvar insert-directory-program (purecopy "ls")
++(defvar insert-directory-program (purecopy "gls")
+   "Absolute or relative name of the `ls' program used by `insert-directory'.")
+ 
+ (defcustom directory-free-space-program (purecopy "df")

--- a/ports/editors/emacs/dragonfly/extra-ls_lisp_dired.el
+++ b/ports/editors/emacs/dragonfly/extra-ls_lisp_dired.el
@@ -1,0 +1,14 @@
+emacs is trying to get cute with its --dired addition to ls(1)
+but fails to parse lt_LT dates having '-' as separators.
+
+--- lisp/dired.el.orig	2015-04-02 10:23:06.000000000 +0300
++++ lisp/dired.el
+@@ -1192,6 +1192,8 @@ see `dired-use-ls-dired' for more detail
+     ;; We used to specify the C locale here, to force English month names;
+     ;; but this should not be necessary any more,
+     ;; with the new value of `directory-listing-before-filename-regexp'.
++    ;; Cause it doesn't properly handle the lt_LT date format "2016-10-01"
++    (setq process-environment (cons "LC_TIME=C" process-environment))
+     (if file-list
+ 	(dolist (f file-list)
+ 	  (let ((beg (point)))


### PR DESCRIPTION
Prevent calloc() optimization (just as for csh in base).

Also fix reports by emacs users that file viewer fails on special filenames.
Turns out emacs is very relying on ls having --dired flag support (gnu ls).
So if it fails it fallbacks to regexes on ls -l output that results in some
unselectable file entries.
Fix it by adding new option that uses gls from coreutils cause even swildner
doesn't like idea of adding --dired support in base ls. From gls(1):
       -D, --dired
              generate output designed for Emacs' dired mode
In case of GNULS=off, base ls is used, it works for standard filenames
(no whitespaces, special symbols or complicated symblinks --> ../../bin/../file)
so just enforce LC_TIME=C for ls -l invoke to ease up output for dodgy regexes.