### PR TITLE
sysutils/intel-pcm: Port to DragonFly.

### DIFF
--- a/ports/sysutils/intel-pcm/dragonfly/patch-Makefile
+++ b/ports/sysutils/intel-pcm/dragonfly/patch-Makefile
@@ -1,0 +1,14 @@
+--- Makefile.orig	2016-10-03 20:41:20 UTC
++++ Makefile
+@@ -31,6 +31,11 @@
+ LIB= -lpthread -lc++
+ CXXFLAGS += -std=c++0x
+ endif
++ifeq ($(UNAME), DragonFly)
++CXX=c++
++LIB= -lpthread -lc++
++CXXFLAGS += -std=c++0x
++endif
+ 
+ COMMON_OBJS = msr.o cpucounters.o pci.o client_bw.o utils.o
+ EXE_OBJS = $(EXE:.x=.o)

--- a/ports/sysutils/intel-pcm/dragonfly/patch-client_bw.cpp
+++ b/ports/sysutils/intel-pcm/dragonfly/patch-client_bw.cpp
@@ -1,0 +1,11 @@
+--- client_bw.cpp.orig	2016-09-18 20:23:33 UTC
++++ client_bw.cpp
+@@ -174,7 +174,7 @@
+ 
+ #else
+ 
+-#if defined(__linux__) || defined(__FreeBSD__)
++#if defined(__linux__) || defined(__FreeBSD__) || defined(__DragonFly__)
+ // Linux implementation
+ 
+ ClientBW::ClientBW() :

--- a/ports/sysutils/intel-pcm/dragonfly/patch-client_bw.h
+++ b/ports/sysutils/intel-pcm/dragonfly/patch-client_bw.h
@@ -1,0 +1,11 @@
+--- client_bw.h.orig	2016-09-18 20:21:43 UTC
++++ client_bw.h
+@@ -39,7 +39,7 @@
+ 
+ class ClientBW
+ {
+-#if defined(__linux__) || defined(__FreeBSD__)
++#if defined(__linux__) || defined(__FreeBSD__) || defined(__DragonFly__)
+     int32 fd;
+     char * mmapAddr;
+ #endif

--- a/ports/sysutils/intel-pcm/dragonfly/patch-cpucounters.cpp
+++ b/ports/sysutils/intel-pcm/dragonfly/patch-cpucounters.cpp
@@ -1,0 +1,56 @@
+--- cpucounters.cpp.orig	2016-10-03 20:32:05 UTC
++++ cpucounters.cpp
+@@ -63,7 +63,7 @@
+ 
+ #endif
+ 
+-#if defined (__FreeBSD__)
++#if defined (__FreeBSD__) || defined(__DragonFly__)
+ #include <sys/param.h>
+ #include <sys/module.h>
+ #include <sys/types.h>
+@@ -77,7 +77,7 @@
+ #undef PCM_UNCORE_PMON_BOX_CHECK_STATUS // debug only
+ 
+ // FreeBSD is much more restrictive about names for semaphores
+-#if defined (__FreeBSD__)
++#if defined (__FreeBSD__) || defined (__DragonFly__)
+ #define PCM_INSTANCE_LOCK_SEMAPHORE_NAME "/Intel_PCM_inst_lock"
+ #define PCM_NUM_INSTANCES_SEMAPHORE_NAME "/Intel_num_PCM_inst"
+ #else
+@@ -805,17 +805,25 @@
+     }
+     fclose(f_cpuinfo);
+ 
+-#elif defined(__FreeBSD__) 
++#elif defined(__FreeBSD__)  || defined(__DragonFly__)
+ 
+     size_t size = sizeof(num_cores);
+     cpuctl_cpuid_args_t cpuid_args_freebds;
+     int fd;
+ 
++#if defined(__DragonFly__)
++    if(0 != sysctlbyname("hw.ncpu", &num_cores, &size, NULL, 0))
++    {
++        std::cerr << "Unable to get hw.ncpu from sysctl." << std::endl;
++        return false;
++    }
++#else
+     if(0 != sysctlbyname("kern.smp.cpus", &num_cores, &size, NULL, 0))
+     {
+         std::cerr << "Unable to get kern.smp.cpus from sysctl." << std::endl;
+         return false;
+     }
++#endif
+ 
+     if (modfind("cpuctl") == -1)
+     {
+@@ -1018,7 +1026,7 @@
+ #elif defined(__linux__)
+         std::cerr << "Try to execute 'modprobe msr' as root user and then" << std::endl;
+         std::cerr << "you also must have read and write permissions for /dev/cpu/*/msr devices (/dev/msr* for Android). The 'chown' command can help." << std::endl;
+-#elif defined(__FreeBSD__)
++#elif defined(__FreeBSD__) || defined(__DragonFly__)
+         std::cerr << "Ensure cpuctl module is loaded and that you have read and write" << std::endl;
+         std::cerr << "permissions for /dev/cpuctl* devices (the 'chown' command can help)." << std::endl;
+ #endif

--- a/ports/sysutils/intel-pcm/dragonfly/patch-msr.cpp
+++ b/ports/sysutils/intel-pcm/dragonfly/patch-msr.cpp
@@ -1,0 +1,11 @@
+--- msr.cpp.orig	2016-09-18 20:21:51 UTC
++++ msr.cpp
+@@ -161,7 +161,7 @@
+     return driver->decrementNumInstances();
+ }
+ 
+-#elif (defined __FreeBSD__)
++#elif (defined __FreeBSD__) || (defined __DragonFly__)
+ 
+ #include <sys/ioccom.h>
+ #include <sys/cpuctl.h>

--- a/ports/sysutils/intel-pcm/dragonfly/patch-pci.cpp
+++ b/ports/sysutils/intel-pcm/dragonfly/patch-pci.cpp
@@ -1,0 +1,11 @@
+--- pci.cpp.orig	2016-09-18 20:19:21 UTC
++++ pci.cpp
+@@ -217,7 +217,7 @@
+     
+ }
+ 
+-#elif (defined __FreeBSD__)
++#elif (defined __FreeBSD__) || (defined __DragonFly__)
+ 
+ #include <sys/pciio.h>
+ 

--- a/ports/sysutils/intel-pcm/dragonfly/patch-pci.h
+++ b/ports/sysutils/intel-pcm/dragonfly/patch-pci.h
@@ -1,0 +1,11 @@
+--- pci.h.orig	2016-09-18 20:22:13 UTC
++++ pci.h
+@@ -75,7 +75,7 @@
+ #elif __APPLE__
+ // This may need to change if it can be implemented for OSX
+ typedef PciHandle PciHandleM;
+-#elif __FreeBSD__
++#elif defined(__FreeBSD__) || defined(__DragonFly__)
+ typedef PciHandle PciHandleM;
+ #else
+ 


### PR DESCRIPTION
* Works on master starting from a77600744cbcd5fad82397ef508492f6c2773ee3,
  and DragonFly_RELEASE_4_6 after 34476392dab2544324d112e6127a8b1ef1c4c258.

* On older master or 4.6 kernels it causes a kernel panic when running.