### PR TITLE
print/cups-filters: Mark the mess.

### DIFF
--- a/ports/print/cups-filters/Makefile.DragonFly
+++ b/ports/print/cups-filters/Makefile.DragonFly
@@ -1,0 +1,2 @@
+# libcups.so, libfontconfig.so, libpopper.so are compiled with pthread support
+MAKE_ENV+= LDVER=ld.bfd	# LDFLAGS+= -pthread # looks like more an ld.gold issue

--- a/ports/print/hplip/Makefile.DragonFly
+++ b/ports/print/hplip/Makefile.DragonFly
@@ -1,1 +1,4 @@
 USB_INCLUDE=	${LOCALBASE}/include
+
+# issue with c++ libgcc_pic.a and ld.gold
+MAKE_ENV+= LDVER=ld.bfd


### PR DESCRIPTION
This port is very dirty, absolute symlinks, plist problems etc:
===> Staging rc.d startup script(s)
====> Running Q/A tests (stage-qa)
Warning: Bad symlink '/usr/local/bin/foomatic-rip' pointing to an absolute pathname '/usr/local/libexec/cups/filter/foomatic-rip'
--------------------------------------------------------------------------------
--  Phase: check-plist
--------------------------------------------------------------------------------
====> Checking for pkg-plist issues (check-plist)
===> Parsing plist
===> Checking for items in STAGEDIR missing from pkg-plist
Error: Orphaned: /etc/init.d/cups-browsed
Error: Orphaned: /etc/rc0.d/K00cups-browsed
Error: Orphaned: /etc/rc2.d/K00cups-browsed
Error: Orphaned: /etc/rc2.d/S99cups-browsed
Error: Orphaned: /etc/rc3.d/K00cups-browsed
Error: Orphaned: /etc/rc3.d/S99cups-browsed
Error: Orphaned: /etc/rc5.d/K00cups-browsed
Error: Orphaned: /etc/rc5.d/S99cups-browsed
Error: Orphaned: @dir /etc/init.d
Error: Orphaned: @dir /etc/rc0.d
Error: Orphaned: @dir /etc/rc2.d
Error: Orphaned: @dir /etc/rc3.d
Error: Orphaned: @dir /etc/rc5.d
===> Checking for items in pkg-plist which are not in STAGEDIR
===> Error: Plist issues found.
*** Error code 1
As for libgcc_pic.a + c++ + ld.gold looks like binutils issue.