### PR TITLE
libgcc_pic.a pack on missing -pthread

### DIFF
--- a/ports/devel/grantlee5/Makefile.DragonFly
+++ b/ports/devel/grantlee5/Makefile.DragonFly
@@ -1,0 +1,3 @@
+# libgcc_pic.a + ld.gold + pthread issue
+MAKE_ENV+= LDVER=ld.bfd
+LDFLAGS+= -pthread # sorry

--- a/ports/devel/love07/Makefile.DragonFly
+++ b/ports/devel/love07/Makefile.DragonFly
@@ -1,0 +1,2 @@
+# libgcc_pic.a + ld.gold + pthread issue
+CONFIGURE_ENV+= LDVER=ld.bfd

--- a/ports/devel/love08/Makefile.DragonFly
+++ b/ports/devel/love08/Makefile.DragonFly
@@ -1,0 +1,2 @@
+# libgcc_pic.a + ld.gold + pthread issue
+CONFIGURE_ENV+= LDVER=ld.bfd

--- a/ports/devel/qca/Makefile.DragonFly
+++ b/ports/devel/qca/Makefile.DragonFly
@@ -1,0 +1,4 @@
+# libgcc_pic.a + ld.gold + pthread issue
+.if defined(PKGNAMESUFFIX)
+MAKE_ENV+= LDVER=ld.bfd
+.endif

--- a/ports/games/maxr/Makefile.DragonFly
+++ b/ports/games/maxr/Makefile.DragonFly
@@ -1,0 +1,2 @@
+# libgcc_pic.a + ld.gold + pthread issue
+MAKE_ENV+= LDVER=ld.bfd

--- a/ports/games/pipewalker/Makefile.DragonFly
+++ b/ports/games/pipewalker/Makefile.DragonFly
@@ -1,0 +1,2 @@
+# libgcc_pic.a + ld.gold + pthread issue
+MAKE_ENV+= LDVER=ld.bfd

--- a/ports/mail/trojita/Makefile.DragonFly
+++ b/ports/mail/trojita/Makefile.DragonFly
@@ -1,0 +1,2 @@
+# libgcc_pic.a + ld.gold + pthread issue
+MAKE_ENV+= LDVER=ld.bfd

--- a/ports/security/gpgme/Makefile.DragonFly
+++ b/ports/security/gpgme/Makefile.DragonFly
@@ -1,0 +1,4 @@
+# libgcc_pic.a + ld.gold + pthread issue
+.if defined(SLAVEPORT) && ${SLAVEPORT} == "qt5"
+CONFIGURE_ENV+= LDVER=ld.bfd
+.endif

--- a/ports/x11-toolkits/hs-wxc/Makefile.DragonFly
+++ b/ports/x11-toolkits/hs-wxc/Makefile.DragonFly
@@ -1,0 +1,2 @@
+# libgcc_pic.a + ld.gold + pthread issue
+MAKE_ENV+= LDVER=ld.bfd


### PR DESCRIPTION
These ports looks like missinng -pthread flags, they do not use -pthread
by themselves but they link against libs that do (mostly libSDL and qt5).
ld.bfd is behaves differently so for now use it for linking.
Makes a good testcase for further base changes testing.
Should -pthread be used in these by default?