### PR TITLE
comms/fldigi: Add -fermissive.

### DIFF
--- a/ports/comms/fldigi/Makefile.DragonFly
+++ b/ports/comms/fldigi/Makefile.DragonFly
@@ -1,0 +1,6 @@
+# SRC_DATA has const float in new audio/libsamplerate <samplerate.h>
+CFLAGS+= -fpermissive
+
+dfly-patch:
+	${REINPLACE_CMD} -e 's@FreeBSD@DragonFly@g'	\
+		${WRKSRC}/src/misc/newinstall.cxx


### PR DESCRIPTION
New audio/libsamplerate has const float in SRC_DATA stuct, yet here
it is used with non-c++ memset(that is C).

Also try: games/voxelands and mail/qmail-conf