### PR TITLE
lang/perl5-2.24: Add patch like in perl.5.20

### DIFF
--- a/ports/lang/perl5-devel/Makefile.DragonFly
+++ b/ports/lang/perl5-devel/Makefile.DragonFly
@@ -1,0 +1,4 @@
+
+dfly-patch:
+	${REINPLACE_CMD} -e 's@__FreeBSD_version > 410001@1@'	\
+		${WRKSRC}/mg.c

--- a/ports/lang/perl5.24/Makefile.DragonFly
+++ b/ports/lang/perl5.24/Makefile.DragonFly
@@ -1,0 +1,4 @@
+
+dfly-patch:
+	${REINPLACE_CMD} -e 's@__FreeBSD_version > 410001@1@'	\
+		${WRKSRC}/mg.c


### PR DESCRIPTION
In last PR forgot to git add perl5.24.
While there throw same patch for -devel version too.