### PR TITLE
devel/binutils: add target for MS pei support.

### DIFF
--- a/ports/devel/binutils/dragonfly/patch-bfd_config.bfd
+++ b/ports/devel/binutils/dragonfly/patch-bfd_config.bfd
@@ -1,0 +1,13 @@
+For loader.efi linking support.
+
+--- bfd/config.bfd.orig	2016-08-03 10:36:50.000000000 +0300
++++ bfd/config.bfd
+@@ -700,7 +700,7 @@ case "${targ}" in
+     ;;
+   x86_64-*-dragonfly*)
+     targ_defvec=x86_64_elf64_vec
+-    targ_selvecs="i386_elf32_vec iamcu_elf32_vec l1om_elf64_vec k1om_elf64_vec"
++    targ_selvecs="i386_elf32_vec iamcu_elf32_vec l1om_elf64_vec k1om_elf64_vec x86_64_pei_vec"
+     want64=true
+     ;;
+   x86_64-*-freebsd* | x86_64-*-kfreebsd*-gnu)


### PR DESCRIPTION
Base binutils are already patched by ivadasz.
No-op since --enable-targets=all but should be in binutils upstream so
that --enable-targets="x86_64-pc-dragonfly" would work out-of-the box.