### PR TITLE
devel/libclc: Use same version as mesa ports(clover)

### DIFF
--- a/ports/devel/libclc/Makefile.DragonFly
+++ b/ports/devel/libclc/Makefile.DragonFly
@@ -1,2 +1,0 @@
-# Use LLVM 3.8 everywhere we can
-LLVMVER= 38


### PR DESCRIPTION
OpenCL on r7 360 now started to give:
Unknown attribute kind (8).

LLVM bytecode generated by llvm37 work fine in OpenCL.