### PR TITLE
x11-toolkits/blt: Add extra -lm.

### DIFF
--- a/ports/x11-toolkits/blt/Makefile.DragonFly
+++ b/ports/x11-toolkits/blt/Makefile.DragonFly
@@ -1,0 +1,5 @@
+
+dfly-patch:
+	${REINPLACE_CMD} -e 's@\(SHLIB_LIB_SPECS =\)@\1 -lm @g'		\
+			 -e 's@\(TCL_ONLY_LIB_SPECS =\)@\1 -lm @g'	\
+		${WRKSRC}/generic/shared/Makefile.in


### PR DESCRIPTION
Linking against libtcl has circural deps and causes bunch of trig functions get
missing references. Avoid by explictly adding direct dep on -lm for main lib.