### PR TITLE
matc/clfft: Fix plist

### DIFF
--- a/ports/math/clfft/Makefile.DragonFly
+++ b/ports/math/clfft/Makefile.DragonFly
@@ -1,0 +1,3 @@
+
+# .pc file is only installed if compiler is GNUC, go figure
+PLIST_FILES+=	libdata/pkgconfig/clFFT.pc

--- a/ports/math/clfft/dragonfly/patch-src_library_CMakeLists.txt
+++ b/ports/math/clfft/dragonfly/patch-src_library_CMakeLists.txt
@@ -1,0 +1,16 @@
+--- src/library/CMakeLists.txt.orig	2016-09-01 00:46:51.000000000 +0300
++++ src/library/CMakeLists.txt
+@@ -95,8 +95,13 @@ if( CMAKE_COMPILER_IS_GNUCC )
+     configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/clFFT.pc.in
+                     ${CMAKE_CURRENT_BINARY_DIR}/clFFT.pc @ONLY )
+ 
++  if (CMAKE_SYSTEM_NAME STREQUAL "DragonFly")
++    install( FILES ${CMAKE_CURRENT_BINARY_DIR}/clFFT.pc
++             DESTINATION libdata/pkgconfig )
++  else ()
+     install( FILES ${CMAKE_CURRENT_BINARY_DIR}/clFFT.pc
+              DESTINATION lib${SUFFIX_LIB}/pkgconfig )
++  endif()
+ endif( )
+ 
+ # CPack configuration; include the executable into the package

--- a/ports/math/clfft/dragonfly/patch-src_statTimer_statisticalTimer.CPU.h
+++ b/ports/math/clfft/dragonfly/patch-src_statTimer_statisticalTimer.CPU.h
@@ -1,0 +1,11 @@
+--- src/statTimer/statisticalTimer.CPU.h.orig	2016-09-01 00:46:51.000000000 +0300
++++ src/statTimer/statisticalTimer.CPU.h
+@@ -21,7 +21,7 @@
+ #include <iosfwd>
+ #include <vector>
+ #include <algorithm>
+-#ifdef __FreeBSD__
++#if defined(__FreeBSD__) || defined(__DragonFly__)
+ #include <sys/timespec.h>
+ #endif
+ #include "statisticalTimer.h"


### PR DESCRIPTION
clFFT.pc is only installed when gnu compiler is used.
Also throw in fresh FreeBSD change, it is unclear whats happening there.