### PR TITLE
net-mgmt/bgpq3: Unbreak build.

### DIFF
--- a/ports/net-mgmt/bgpq3/dragonfly/patch-bgpq_expander.c
+++ b/ports/net-mgmt/bgpq3/dragonfly/patch-bgpq_expander.c
@@ -1,0 +1,10 @@
+--- bgpq_expander.ci.orig	2016-10-14 18:55:28.000000000 +0300
++++ bgpq_expander.c
+@@ -3,6 +3,7 @@
+ #endif
+ 
+ #include <sys/types.h>
++#include <sys/select.h> /* for select() */
+ #include <sys/socket.h>
+ 
+ #include <assert.h>

--- a/ports/net-mgmt/bgpq3/dragonfly/patch-sx_slentry.h
+++ b/ports/net-mgmt/bgpq3/dragonfly/patch-sx_slentry.h
@@ -1,0 +1,13 @@
+Use bundled sys/tree.h implementation, ours is not compatible.
+
+--- sx_slentry.h.orig	2016-10-14 18:55:28.000000000 +0300
++++ sx_slentry.h
+@@ -7,7 +7,7 @@
+ #include "sys_queue.h"
+ #endif
+ 
+-#if HAVE_SYS_TREE_H
++#if HAVE_SYS_TREE_H && !defined(__DragonFly__)
+ #include <sys/tree.h>
+ #else
+ #include "sys_tree.h"


### PR DESCRIPTION
Just use bundled sys/tree.h implementation.
Throw in sys/select.h for good measure too.

Synth test only