### PR TITLE
net-p2p/twister: Mark as using deprecated boost system api.

### DIFF
--- a/ports/net-p2p/twister/Makefile.DragonFly
+++ b/ports/net-p2p/twister/Makefile.DragonFly
@@ -1,0 +1,4 @@
+
+# zrj: needs deprecated boost system api in libtorrent
+CFLAGS+= -DBOOST_SYSTEM_NEEDS_DEPRECATED
+


### PR DESCRIPTION
There will be more cases like this.. oopsie