### PR TITLE
audio/sox: Disable implicit use of -fopenmp.

### DIFF
--- a/ports/audio/sox/Makefile.DragonFly
+++ b/ports/audio/sox/Makefile.DragonFly
@@ -1,0 +1,3 @@
+
+# zrj: disable use of -fopenmp (little gains, but propagates to other ports)
+CONFIGURE_ARGS+= --disable-openmp


### PR DESCRIPTION
Just because configure found that -fopenmp is usable doesn't imply that it was
requested, there should be OPENMP option. Doesn't clang support -fopenmp?

Now synth test audio/sox passes.