### PR TITLE
devel/boost-libs: Disable implicit support for FLOAT128.

### DIFF
--- a/ports/devel/boost-libs/dragonfly/patch-boost_math_tools_config.hpp
+++ b/ports/devel/boost-libs/dragonfly/patch-boost_math_tools_config.hpp
@@ -1,8 +1,11 @@
 
 While there is support for long double on DragonFly (just like OpenBSD)
 these functions long double functions wasn't tested so far for c++ in boost
-and previously wasn't packed anyway (orphans on plist).
+and previously wasn't packed anyway (orphans on plist, now enabled in FreeBSD).
 For now explicitly disable them (+ they are slow and unreliable anyway).
+
+Also disable implicit support for FLOAT128 unless program actually needs them.
+In efforts to make boost-libs a bit more robust and performant.
 
 --- boost/math/tools/config.hpp.orig	2016-12-07 15:43:17 UTC
 +++ boost/math/tools/config.hpp
@@ -15,3 +18,11 @@ For now explicitly disable them (+ they are slow and unreliable anyway).
     || (defined(__hppa) && !defined(__OpenBSD__)) || (defined(__NO_LONG_DOUBLE_MATH) && (DBL_MANT_DIG != LDBL_MANT_DIG))) \
     && !defined(BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS)
  #  define BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
+@@ -268,6 +268,7 @@
+ // And then the actual configuration:
+ //
+ #if defined(_GLIBCXX_USE_FLOAT128) && defined(BOOST_GCC) && !defined(__STRICT_ANSI__) \
++   && !defined(__DragonFly__) \
+    && !defined(BOOST_MATH_DISABLE_FLOAT128) || defined(BOOST_MATH_USE_FLOAT128)
+ //
+ // Only enable this when the compiler really is GCC as clang and probably 


### PR DESCRIPTION
Only packages that require this should do it explicitly.
Will help a lot while FreeBSD devs are messing up with clang 3.9.0 until
they come to certain conclusions about certain things.

Unbreaks devel/synfig after boot-libs update.