### PR TITLE
astro/gpsd: Work around scons logic for binutils 2.27.

### DIFF
--- a/ports/astro/gpsd/Makefile.DragonFly
+++ b/ports/astro/gpsd/Makefile.DragonFly
@@ -1,0 +1,4 @@
+
+# this scons is strange with binutils227
+LDFLAGS+=	-lm
+MAKE_ENV+=	LINKFLAGS="${LDFLAGS}"


### PR DESCRIPTION
I'm a bit lost here, maybe because of no dbus build.

Synth test passes