### PR TITLE
editors/calligra: Fix build after icu update.

### DIFF
--- a/ports/editors/calligra/dragonfly/patch-libs_db_drivers_sqlite_icu_CMakeLists.txt
+++ b/ports/editors/calligra/dragonfly/patch-libs_db_drivers_sqlite_icu_CMakeLists.txt
@@ -1,0 +1,11 @@
+--- libs/db/drivers/sqlite/icu/CMakeLists.txt.orig	2016-02-02 21:53:15.000000000 +0200
++++ libs/db/drivers/sqlite/icu/CMakeLists.txt
+@@ -2,6 +2,8 @@ kde4_add_plugin(kexidb_sqlite3_icu icu.c
+ 
+ include_directories(${ICU_INCLUDE_DIRS})
+ 
++# icu has c++'y "//" style comments
++set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
+ target_link_libraries(kexidb_sqlite3_icu
+                       ${SQLITE_LIBRARIES}
+                       ${ICU_LIBRARIES}


### PR DESCRIPTION
-std=c90 does not accept c++ style comments ("//"), use -std=c99