### PR TITLE
fix issues found by binutils 2.27 ld.gold pt2

### DIFF
--- a/ports/net/samba43/Makefile.DragonFly
+++ b/ports/net/samba43/Makefile.DragonFly
@@ -1,3 +1,8 @@
+# uses -jN (all cores) during stage
+# zrj: disable because of things it does (ld.gold binutils 2.27)
+#CONFIGURE_ARGS+= --without-cluster-support # etc but thats plist changes, so..
+MAKE_ENV+= LDVER=ld.bfd  # needed only for mail/libmapi (that we dont have)
+
 dfly-patch:
 	${REINPLACE_CMD} -e "s|'md'|'md-disable'|" \
 		-e "s|'sys/md5.h'|'sys/md5-disable.h'|" \

--- a/ports/net/zebra-server/Makefile.DragonFly
+++ b/ports/net/zebra-server/Makefile.DragonFly
@@ -1,0 +1,7 @@
+
+# zrj: add missing link against -lyaz, -lxslt in libidzebra-2.0.so
+# NOTYPE  GLOBAL DEFAULT  UND {yaz*, xml*}
+# fixes net/zebra-server build (binutils 2.27 ld.gold is unhappy)
+dfly-patch:
+	${REINPLACE_CMD} -e '/libidzebra_2_0_la_LINK) -rpath/s/$$/ $$(YAZLALIB)/g'	\
+		${WRKSRC}/index/Makefile.in

--- a/ports/science/InsightToolkit/dragonfly/patch-Modules_ThirdParty_NrrdIO_src_NrrdIO_CMakeLists.txt
+++ b/ports/science/InsightToolkit/dragonfly/patch-Modules_ThirdParty_NrrdIO_src_NrrdIO_CMakeLists.txt
@@ -1,0 +1,14 @@
++# zrj: add missing link against -lm in libITKNrrdIO-4.10.so
++# NOTYPE  GLOBAL DEFAULT  UND sqrt
++# fixes science/InsightToolkit (binutils 2.27 ld.gold is unhappy)
+--- Modules/ThirdParty/NrrdIO/src/NrrdIO/CMakeLists.txt.orig	2016-10-04 18:32:22.000000000 +0300
++++ Modules/ThirdParty/NrrdIO/src/NrrdIO/CMakeLists.txt
+@@ -64,7 +64,7 @@ ENDIF(QNANHIBIT)
+ ADD_DEFINITIONS(-DTEEM_ZLIB=1)
+ 
+ ADD_LIBRARY(ITKNrrdIO ${nrrdio_SRCS} )
+-TARGET_LINK_LIBRARIES(ITKNrrdIO ${ITKZLIB_LIBRARIES})
++TARGET_LINK_LIBRARIES(ITKNrrdIO ${ITKZLIB_LIBRARIES} m)
+ 
+ IF(ITK_LIBRARY_PROPERTIES)
+   SET_TARGET_PROPERTIES(ITKNrrdIO PROPERTIES ${ITK_LIBRARY_PROPERTIES})

--- a/ports/textproc/lttoolbox/Makefile.DragonFly
+++ b/ports/textproc/lttoolbox/Makefile.DragonFly
@@ -1,0 +1,7 @@
+
+# zrj: add missing link against -lxml2 in liblttoolbox3.so
+# NOTYPE  GLOBAL DEFAULT  UND {xml*}
+# fixes textproc/apertium build (binutils 2.27 ld.gold is unhappy)
+dfly-patch:
+	${REINPLACE_CMD} -e '/liblttoolbox3_la_LINK) -rpath/s/$$/ $$(LTTOOLBOX_LIBS)/g'	\
+		${WRKSRC}/lttoolbox/Makefile.in


### PR DESCRIPTION
mainly xml stuff and git add forgotten net/samba43 too

force-rebuilt (non bumped deps on shared libs)
textproc/lttoolbox

from previous pack:
astro/cfitsio
audio/id3lib
x11/gnustep-app
devel/dcmtk
devel/gorm
devel/hs-QuickCheck
devel/hs-text
graphics/freeimage
graphics/gexiv2
graphics/libsvg-cairo
graphics/libsvg
graphics/togl
mail/gnumail
security/hs-crypto-random
security/cryptonite
textproc/tinyxml
x11-toolkits/libgnomeprintui
x11/libXcm
