### PR TITLE
databases/gtksql: Fix build after freebsd-ports update.

### DIFF
--- a/ports/databases/gtksql/Makefile.DragonFly
+++ b/ports/databases/gtksql/Makefile.DragonFly
@@ -1,0 +1,2 @@
+# unbreak after x11-toolkits/scintilla update on freebsd-ports
+CFLAGS+= -DINCLUDE_DEPRECATED_FEATURES


### PR DESCRIPTION
x11-toolkits/scintilla was updated to 371 and now needs deprecated defines.
Should be broken on freebsd-ports too (thus just adding compat define)