### PR TITLE
sysutils/freefilesync: Fix build issues.

### DIFF
--- a/ports/sysutils/freefilesync/Makefile.DragonFly
+++ b/ports/sysutils/freefilesync/Makefile.DragonFly
@@ -1,0 +1,12 @@
+
+# zrj: some heavy stuff up ahead..
+dfly-patch:
+	${REINPLACE_CMD} -e "s@__GNUC__ < 5@__GNUC__ < 7@g"	\
+		${WRKSRC}/../../zen/scope_guard.h
+	${REINPLACE_CMD} -e "/ZEN_LINUX \/\/handle still un-owned/s@ZEN_LINUX@FREEBSD@g"	\
+		${WRKSRC}/../../zen/file_io.cpp
+	${REINPLACE_CMD} -e "s@FreeBSD@DragonFly@g"	\
+		${WRKSRC}/ui/version_check.cpp
+	${REINPLACE_CMD} -e "s@::posix_fallocate(fh,@::ftruncate(fh,@g"	\
+			 -e "/0,           \/\/off_t offset/d"		\
+		${WRKSRC}/fs/native.cpp


### PR DESCRIPTION
Heavy patches, keep anyway, uses c++14, so makes a good testcase.
Very heavy GUI utility, it seem to run, but didn't tried sync bit.