### PR TITLE
devel/boost-libs: uncriple the boost-libs

### DIFF
--- a/ports/devel/boost-all/diffs/compiled.mk.diff
+++ b/ports/devel/boost-all/diffs/compiled.mk.diff
@@ -1,0 +1,11 @@
+--- compiled.mk.orig	2016-11-23 18:28:19.000000000 +0200
++++ compiled.mk
+@@ -18,7 +18,7 @@ MAKE_ARGS=	--layout=system \
+ # Our compiler-flags will be added AFTER those set by bjam. We remove
+ # the optimization level, because Boost sets it itself (to -O3 in case
+ # of gcc/g++):
+-MAKE_ARGS+=    cxxflags="${CXXFLAGS:N-O*}" cflags="${CFLAGS:N-O*}"
++MAKE_ARGS+=    cxxflags="${CXXFLAGS:N-O*} -std=c++11" cflags="${CFLAGS:N-O*}"
+ 
+ MAKE_ARGS+=	--toolset=${CHOSEN_COMPILER_TYPE} \
+ 		${_MAKE_JOBS}

--- a/ports/devel/boost-libs/diffs/pkg-plist.diff
+++ b/ports/devel/boost-libs/diffs/pkg-plist.diff
@@ -1,9 +1,18 @@
-It's not immediately clear why the long double versions of these
-boost-libs aren't building on DF.
+Do not compile in long double support but provide fiber one.
 
 --- pkg-plist.orig	2016-12-07 16:53:28 UTC
 +++ pkg-plist
-@@ -12299,18 +12299,12 @@ lib/libboost_math_c99.so.%%BOOST_SHARED_
+@@ -12275,6 +12275,9 @@ lib/libboost_date_time.a
+ lib/libboost_date_time.so
+ lib/libboost_date_time.so.%%BOOST_SHARED_LIB_VER%%
+ lib/libboost_exception.a
++lib/libboost_fiber.a
++lib/libboost_fiber.so
++lib/libboost_fiber.so.%%BOOST_SHARED_LIB_VER%%
+ lib/libboost_filesystem.a
+ lib/libboost_filesystem.so
+ lib/libboost_filesystem.so.%%BOOST_SHARED_LIB_VER%%
+@@ -12299,18 +12302,12 @@ lib/libboost_math_c99.so.%%BOOST_SHARED_
  lib/libboost_math_c99f.a
  lib/libboost_math_c99f.so
  lib/libboost_math_c99f.so.%%BOOST_SHARED_LIB_VER%%


### PR DESCRIPTION
Maybe it would be better if was done on freebsd-ports side, dunno but:

Must use at least -std=c++11 while compiling the libs (partially wrong abi)
boost headers has no safe-guards when compiled w/ -std=c++98, while most of
packages rely on -std=c++11 while using these boost headers.
Explains why certain things doesn't seem right here and there.

 @@ -291,19 +301,19 @@ Performing configuration checks
      - sparc                    : no
      - x86                      : yes
      - symlinks supported       : yes
 -    - C++11 mutex              : no
 +    - C++11 mutex              : yes
      - lockfree boost::atomic_flag : yes
 -    - Boost.Config Feature Check: cxx11_auto_declarations : no
 -    - Boost.Config Feature Check: cxx11_constexpr : no
 -    - Boost.Config Feature Check: cxx11_defaulted_functions : no
 +    - Boost.Config Feature Check: cxx11_auto_declarations : yes
 +    - Boost.Config Feature Check: cxx11_constexpr : yes
 +    - Boost.Config Feature Check: cxx11_defaulted_functions : yes
      - Boost.Config Feature Check: cxx11_final : yes
 -    - Boost.Config Feature Check: cxx11_hdr_tuple : no
 -    - Boost.Config Feature Check: cxx11_lambdas : no
 -    - Boost.Config Feature Check: cxx11_noexcept : no
 -    - Boost.Config Feature Check: cxx11_nullptr : no
 -    - Boost.Config Feature Check: cxx11_rvalue_references : no
 -    - Boost.Config Feature Check: cxx11_template_aliases : no
 -    - Boost.Config Feature Check: cxx11_thread_local : no
 +    - Boost.Config Feature Check: cxx11_hdr_tuple : yes
 +    - Boost.Config Feature Check: cxx11_lambdas : yes
 +    - Boost.Config Feature Check: cxx11_noexcept : yes
 +    - Boost.Config Feature Check: cxx11_nullptr : yes
 +    - Boost.Config Feature Check: cxx11_rvalue_references : yes
 +    - Boost.Config Feature Check: cxx11_template_aliases : yes
 +    - Boost.Config Feature Check: cxx11_thread_local : yes
      - Boost.Config Feature Check: cxx11_variadic_templates : yes
      - has_icu builds           : yes