### PR TITLE
net/freerdp: Fix dports libcrypto.so detection.

### DIFF
--- a/ports/net/freerdp/dragonfly/patch-winpr_tools_makecert_CMakeLists.txt
+++ b/ports/net/freerdp/dragonfly/patch-winpr_tools_makecert_CMakeLists.txt
@@ -1,0 +1,11 @@
+--- winpr/tools/makecert/CMakeLists.txt.intermediate	2016-12-16 17:07:46.000000000 +0200
++++ winpr/tools/makecert/CMakeLists.txt
+@@ -37,7 +37,7 @@ if(OPENSSL_FOUND)
+ 	else()
+ 		# if ${OPENSSL_LIBRARIES} libssl and libcrypto is linked
+ 		# therefor explicitly link against libcrypto
+-		list(APPEND ${MODULE_PREFIX}_LIBS crypto)
++		list(APPEND ${MODULE_PREFIX}_LIBS ${OPENSSL_CRYPTO_LIBRARY})
+ 	endif()
+ endif()
+ 


### PR DESCRIPTION
Might need to be converted to extra patch because of release-4.6
