### PR TITLE
graphics/aqsis: Fix for updated boost-libs.

### DIFF
--- a/ports/graphics/aqsis/Makefile.DragonFly
+++ b/ports/graphics/aqsis/Makefile.DragonFly
@@ -1,0 +1,6 @@
+USE_CXXSTD=	c++11
+
+# zrj: some checks onf ifstream file..
+dfly-patch:
+	${REINPLACE_CMD} -e "s@( file != NULL )@(file.is_open())@g"	\
+		${WRKSRC}/libs/core/texturing_old/shadowmap_old.cpp


### PR DESCRIPTION
Use c++11 (there is no outrunning this one), and small code bug.
There are two more patches from arch to investigate but maybe later.