### PR TITLE
converters/rubygem-bsdconv: Unbreak package.

### DIFF
--- a/ports/converters/rubygem-bsdconv/Makefile.DragonFly
+++ b/ports/converters/rubygem-bsdconv/Makefile.DragonFly
@@ -1,0 +1,2 @@
+# zrj: unbreak package
+GEM_NAME?=	${DISTNAME}


### PR DESCRIPTION
Is it broken on freebsd-ports too?