### PR TITLE
sysutils/metricbeat: Unbreak build

### DIFF
--- a/ports/sysutils/metricbeat/Makefile.DragonFly
+++ b/ports/sysutils/metricbeat/Makefile.DragonFly
@@ -1,0 +1,5 @@
+
+# zrj: docker part build fix?
+dfly-patch:
+	${REINPLACE_CMD} -e "s@Mtimespec@Mtim@g"	\
+		${WRKSRC}/metricbeat/module/docker/vendor/github.com/fsouza/go-dockerclient/external/github.com/docker/docker/pkg/system/stat_unsupported.go


### PR DESCRIPTION
Fails on Mtimespec vs Mtim in docker, not sure of any of these.
build fix only.