### PR TITLE
comms/sdr-wspr: Fix -lportaudio search.

### DIFF
--- a/ports/comms/sdr-wspr/Makefile.DragonFly
+++ b/ports/comms/sdr-wspr/Makefile.DragonFly
@@ -1,0 +1,5 @@
+
+# help to use full path instead wrong -lportaudio (broken cmake/FindPortAudio.cmake)
+dfly-patch:
+	${REINPLACE_CMD} -e "s@[$$]{PORTAUDIO_LIBRARIES}@\"${LOCALBASE}/lib/libportaudio.so\"/@g" \
+		${WRKSRC}/CMakeLists.txt


### PR DESCRIPTION
Even Darwin case just hardcodes full path..