### PR TITLE
math/wxMaxima: Must use -std=c++11.

### DIFF
--- a/ports/math/wxMaxima/Makefile.DragonFly
+++ b/ports/math/wxMaxima/Makefile.DragonFly
@@ -1,0 +1,2 @@
+# otherwise it fails configure tests for linkage with wxWidgets
+USE_CXXSTD=	c++11


### PR DESCRIPTION
silent failure on configure while linking with wxWidgets.
Synth test only