### PR TITLE
audio/shairport-sync: Workaround LDFLAGS issue.

### DIFF
--- a/ports/audio/shairport-sync/Makefile.DragonFly
+++ b/ports/audio/shairport-sync/Makefile.DragonFly
@@ -1,0 +1,2 @@
+# MF has plain -lcrypto in LDFLAGS and that fails at early configure
+USES+= localbase

--- a/ports/audio/shairport-sync/dragonfly/patch-common.h
+++ b/ports/audio/shairport-sync/dragonfly/patch-common.h
@@ -1,0 +1,11 @@
+--- common.h.orig	2016-10-10 21:06:57.000000000 +0300
++++ common.h
+@@ -18,7 +18,7 @@
+ #endif
+ #endif
+ 
+-#if defined(__linux__) || defined(__FreeBSD__) || defined(__CYGWIN__)
++#if defined(__linux__) || defined(__FreeBSD__) || defined(__CYGWIN__) || defined(__DragonFly__)
+ /* Linux and FreeBSD */
+ #define COMPILE_FOR_LINUX_AND_FREEBSD_AND_CYGWIN 1
+ #endif


### PR DESCRIPTION
It is likely better to move it to MF, but with avahi plain
-L${LOCALBASE}/lib in LDFLAGS might not be good on freebsd