### PR TITLE
binutils 2.27 ld.gold workarounds pt2

### DIFF
--- a/ports/devel/hs-hslua/dragonfly/patch-hslua.cabal
+++ b/ports/devel/hs-hslua/dragonfly/patch-hslua.cabal
@@ -1,0 +1,13 @@
+# zrj: add missing link against -lm in libHShslua-*.so
+# NOTYPE  GLOBAL DEFAULT  UND {acos, asin, ...}
+# fixes textproc/hs-pandoc (binutils 2.27 ld.gold is unhappy)
+--- hslua.cabal.orig	2015-05-29 17:26:15.000000000 +0300
++++ hslua.cabal
+@@ -41,6 +41,7 @@ flag luajit
+   default:              False
+ 
+ library
++  extra-libraries: m
+   build-depends:        base == 4.*, bytestring >= 0.10 && < 0.11
+   exposed-modules:      Scripting.Lua, Scripting.Lua.Raw
+   hs-source-dirs:       src

--- a/ports/graphics/hs-JuicyPixels/dragonfly/patch-JuicyPixels.cabal
+++ b/ports/graphics/hs-JuicyPixels/dragonfly/patch-JuicyPixels.cabal
@@ -1,0 +1,13 @@
+# zrj: add missing link against -lm in libHSJuicyPixels-*.so
+# NOTYPE  GLOBAL DEFAULT  UND {cosf, log, powf, sqrtf}
+# fixes textproc/hs-pandoc (binutils 2.27 ld.gold is unhappy)
+--- JuicyPixels.cabali.orig	2015-08-17 21:14:41.000000000 +0300
++++ JuicyPixels.cabal
+@@ -35,6 +35,7 @@ Flag Mmap
+     Default: False
+ 
+ Library
++  extra-libraries: m
+   hs-source-dirs: src
+   Default-Language: Haskell2010
+   Exposed-modules:  Codec.Picture,

--- a/ports/graphics/hs-dia-functions/dragonfly/patch-dia-functions.cabal
+++ b/ports/graphics/hs-dia-functions/dragonfly/patch-dia-functions.cabal
@@ -1,0 +1,13 @@
+# zrj: add missing link against -lm in libHSdia-functions-*.so
+# NOTYPE  GLOBAL DEFAULT  UND sqrt
+# fixes www/hs-activehs (binutils 2.27 ld.gold is unhappy)
+--- dia-functions.cabal.orig	2015-05-07 01:28:40.000000000 +0300
++++ dia-functions.cabal
+@@ -19,6 +19,7 @@ cabal-version:       >=1.2
+ build-type:          Simple
+ 
+ library
++  extra-libraries: m
+   GHC-Options: -Wall -fwarn-tabs -fno-warn-unused-matches -fno-warn-name-shadowing 
+ 
+   Exposed-Modules:

--- a/ports/math/hs-mwc-random/dragonfly/patch-mwc-random.cabal
+++ b/ports/math/hs-mwc-random/dragonfly/patch-mwc-random.cabal
@@ -1,0 +1,13 @@
++# zrj: add missing link against -lm in libHSmwc-random-*.so
++# NOTYPE  GLOBAL DEFAULT  UND {exp, log, pow, sqrt}
++# fixes www/hs-wai-app-static (binutils 2.27 ld.gold is unhappy)
+--- mwc-random.cabal.orig	2015-03-30 00:25:02.000000000 +0300
++++ mwc-random.cabal
+@@ -36,6 +36,7 @@ extra-source-files:
+   test/visual.hs
+ 
+ library
++  extra-libraries: m
+   exposed-modules:
+     System.Random.MWC
+     System.Random.MWC.Distributions


### PR DESCRIPTION
Explicitly link with libm to allow building rest of Haskell ports.

Before incremental remove these 4 binary txz:
hs-hslua-*.txz hs-JuicyPixels-*.txz hs-dia-functions-*.txz hs-mwc-random-*.txz