### PR TITLE
devel/subversion: Do not provide freebsd template by default.

### DIFF
--- a/ports/devel/subversion/diffs/Makefile.diff
+++ b/ports/devel/subversion/diffs/Makefile.diff
@@ -1,0 +1,11 @@
+--- /data/freebsd-ports/devel/subversion/Makefile	2016-11-17 15:56:03.000000000 +0200
++++ Makefile	2016-12-18 13:29:10.000000000 +0200
+@@ -26,7 +26,7 @@ OPTIONS_DEFINE=	\
+ 		TEST		\
+ 		TOOLS
+ 
+-OPTIONS_DEFAULT=FREEBSD_TEMPLATE \
++OPTIONS_DEFAULT= \
+ 		SERF TOOLS
+ 
+ FREEBSD_TEMPLATE_DESC=	FreeBSD Project log template


### PR DESCRIPTION
User request: the way template is contructed causes issues with python tools.

I didn't asked for more details, but given that files/extra-patch-fbsd-template
performs direct subversion code modification it is better to ship original.