### PR TITLE
Fix shm permission problem of rspamd on DragonFly

### DIFF
--- a/ports/mail/rspamd/dragonfly/patch-src_libutil_http.c
+++ b/ports/mail/rspamd/dragonfly/patch-src_libutil_http.c
@@ -1,0 +1,16 @@
+--- src/libutil/http.c.orig	2017-01-06 11:21:23 UTC
++++ src/libutil/http.c
+@@ -2371,7 +2371,13 @@ rspamd_http_message_set_body (struct rsp
+ 		storage->shared.name = g_slice_alloc (sizeof (*storage->shared.name));
+ 		REF_INIT_RETAIN (storage->shared.name, rspamd_http_shname_dtor);
+ #ifdef HAVE_SANE_SHMEM
++#if defined(__DragonFly__)
++		// DragonFly uses regular files for shm. User rspamd is not allowed to create
++		// files in the root.
++		storage->shared.name->shm_name = g_strdup ("/tmp/rhm.XXXXXXXXXXXXXXXXXXXX");
++#else
+ 		storage->shared.name->shm_name = g_strdup ("/rhm.XXXXXXXXXXXXXXXXXXXX");
++#endif
+ 		storage->shared.shm_fd = rspamd_shmem_mkstemp (storage->shared.name->shm_name);
+ #else
+ 		/* XXX: assume that tempdir is /tmp */


### PR DESCRIPTION
Rspamd tried to call shm_open(3) with a path in the root filesystem
(e.g. /rhm.3f0fd440d46fac91e1b4). Obviously, this fails due to wrong
permissions, and in effect this makes rspamd very slow and probably it
cannot perform it's job (spam filtering) at all.

Lots of lines like the following were found in
/var/log/rspamd/rspamd.log before this patch:

    rspamd_shmem_mkstemp: /usr/obj/dports/mail/rspamd/rspamd-1.4.1/src
      /libutil/util.c:1970: failed to create temp shmem
      /rhm.3f0fd440d46fac91e1b4: Permission denied

This patch fixes the problem by creating the shm files in /tmp. With
this patch applied, these lines are gone from the log.