### PR TITLE
devel/liblxqt: Move patch to another port.

### DIFF
--- a/ports/devel/lxqt-build-tools/dragonfly/patch-cmake_modules_LXQtCreatePkgConfigFile.cmake
+++ b/ports/devel/lxqt-build-tools/dragonfly/patch-cmake_modules_LXQtCreatePkgConfigFile.cmake
@@ -1,0 +1,11 @@
+--- cmake/modules/LXQtCreatePkgConfigFile.cmake.orig	2017-01-01 23:46:43.000000000 +0200
++++ cmake/modules/LXQtCreatePkgConfigFile.cmake
+@@ -233,7 +233,7 @@ function(lxqt_create_pkgconfig_file)
+     if (DEFINED USER_INSTALL)
+         # FreeBSD loves to install files to different locations
+         # http://www.freebsd.org/doc/handbook/dirstructure.html
+-        if(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
++        if(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD" OR ${CMAKE_SYSTEM_NAME} STREQUAL "DragonFly")
+             set(_PKGCONFIG_INSTALL_DESTINATION "libdata/pkgconfig")
+         else()
+             set(_PKGCONFIG_INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")


### PR DESCRIPTION
Location override of .pc install dir were moved to another port.
Now they are in devel/lxqt-build-tools, so just move the patch.