### PR TITLE
graphics/jogamp-jogl: push /usr/local/includes down.

### DIFF
--- a/ports/graphics/jogamp-jogl/Makefile.DragonFly
+++ b/ports/graphics/jogamp-jogl/Makefile.DragonFly
@@ -1,0 +1,7 @@
+
+# zrj: be naughty (include dir search ordering)
+dfly-patch:
+	${REINPLACE_CMD} -e 's@BITS=32@BITS=64@g'	\
+			 -e "s@-fno-rtti@-isystem ${LOCALBASE}/include@g"	\
+		${WRKSRC}/../jogl/make/build-oculusvr.xml	\
+		${WRKSRC}/../gluegen/Makefile

--- a/ports/graphics/jogamp-jogl/dragonfly/patch-gluegen_make_gluegen-cpptasks-base.xml
+++ b/ports/graphics/jogamp-jogl/dragonfly/patch-gluegen_make_gluegen-cpptasks-base.xml
@@ -9,3 +9,21 @@
      </condition>
      <condition property="isAndroid">
        <os name="Android" />
+@@ -919,6 +919,8 @@
+         <define name="DEBUG"    if="c.compiler.use-debug"/>
+         <define name="NDEBUG"   unless="c.compiler.use-debug"/>
+       </defineset>
++      <compilerarg value="-isystem"/>
++      <compilerarg value="/usr/local/include" />
+     </compiler>
+ 
+     <compiler id="compiler.cfg.linux" name="${gcc.compat.compiler}">
+@@ -991,6 +993,8 @@
+         <define name="DEBUG"    if="c.compiler.use-debug"/>
+         <define name="NDEBUG"   unless="c.compiler.use-debug"/>
+       </defineset>
++      <compilerarg value="-isystem"/>
++      <compilerarg value="/usr/local/include" />
+     </compiler>
+ 
+     <compiler id="compiler.cfg.hpux" name="aCC">


### PR DESCRIPTION
Activate freebsd-clang mode. Alternative is to write full-blown native
DragonFly handling but that will not be done by me.