### PR TITLE
security/cyrus-sasl2-gssapi: Work around messy heimdal.

### DIFF
--- a/ports/security/cyrus-sasl2-gssapi/Makefile.DragonFly
+++ b/ports/security/cyrus-sasl2-gssapi/Makefile.DragonFly
@@ -1,1 +1,7 @@
+# issue with heimdal
+.if 1
 OPTIONS_DEFAULT= GSSAPI_HEIMDAL
+CONFIGURE_ENV+= LDVER=ld.bfd
+.else
+OPTIONS_DEFAULT= GSSAPI_MIT
+.endif


### PR DESCRIPTION
I think it is just better to use GSSAPI_MIT here.
Nothing depends on this lib.