### PR TITLE
games/fishsupper: Fix patching for broken libc++.

### DIFF
--- a/ports/games/fishsupper/Makefile.DragonFly
+++ b/ports/games/fishsupper/Makefile.DragonFly
@@ -1,0 +1,3 @@
+# zrj: out libstdc++ is fine but follow free and enforce c++11
+USE_CXXSTD=	c++11
+CXXFLAGS+=	-fpermissive # 'constexpr' needed for in-class init of static member


### PR DESCRIPTION
This port is not ready for -std=c++11 but given that free
removed their specific .if ${OPSYS} == FreeBSD to limit patching
just follow along, and force -std=c++11 while adding -fpermissive.