### PR TITLE
www/libhpack: Rip out malloc_size() and malloc_usable_size()

### DIFF
--- a/ports/www/libhpack/dragonfly/patch-CMakeLists.txt
+++ b/ports/www/libhpack/dragonfly/patch-CMakeLists.txt
@@ -1,0 +1,11 @@
+--- CMakeLists.txt.intermediate	2017-01-13 16:14:38 UTC
++++ CMakeLists.txt
+@@ -188,7 +188,7 @@ endif()
+ if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+     DEF_SET (OSX TRUE)
+ endif()
+-if (CMAKE_SYSTEM_NAME MATCHES "(FreeBSD|OpenBSD|NetBSD)")
++if (CMAKE_SYSTEM_NAME MATCHES "(FreeBSD|OpenBSD|NetBSD|DragonFly)")
+     DEF_SET (BSD TRUE)
+ endif()
+ if (CMAKE_SYSTEM_NAME MATCHES "(Solaris|SunOS)")

--- a/ports/www/libhpack/dragonfly/patch-libchula_buffer.c
+++ b/ports/www/libhpack/dragonfly/patch-libchula_buffer.c
@@ -1,0 +1,19 @@
+--- libchula/buffer.c.orig	2014-07-10 00:59:50.000000000 +0300
++++ libchula/buffer.c
+@@ -191,6 +191,8 @@ chula_buffer_fake (chula_buffer_t *buf,
+     buf->size = len + 1;
+ }
+ 
++/* explicitly disabled on DragonFly */
++#ifndef __DragonFly__
+ ret_t
+ chula_buffer_import (chula_buffer_t *buf, char *str, uint32_t len)
+ {
+@@ -210,6 +212,7 @@ chula_buffer_import (chula_buffer_t *buf
+     buf->size = s;
+     return ret_ok;
+ }
++#endif
+ 
+ 
+ ret_t

--- a/ports/www/libhpack/dragonfly/patch-libchula_buffer.h
+++ b/ports/www/libhpack/dragonfly/patch-libchula_buffer.h
@@ -1,0 +1,24 @@
+--- libchula/buffer.h.orig	2014-07-10 00:59:50.000000000 +0300
++++ libchula/buffer.h
+@@ -47,6 +47,10 @@
+ #include <limits.h>
+ #include <stdint.h>
+ 
++#ifdef __DragonFly__
++#include <netinet/in.h> // for htons() and htonl()
++#endif
++
+ typedef struct {
+ 	uint8_t  *buf;        /**< Memory chunk           */
+ 	uint32_t  size;       /**< Total amount of memory */
+@@ -72,7 +76,10 @@ ret_t chula_buffer_free
+ ret_t chula_buffer_init                 (chula_buffer_t  *buf);
+ ret_t chula_buffer_mrproper             (chula_buffer_t  *buf);
+ void  chula_buffer_fake                 (chula_buffer_t  *buf, const char *str, uint32_t len);
++/* explicitly disabled on DragonFly */
++#ifndef __DragonFly__
+ ret_t chula_buffer_import               (chula_buffer_t  *buf, char *str, uint32_t len);
++#endif
+ 
+ void  chula_buffer_clean                (chula_buffer_t  *buf);
+ ret_t chula_buffer_dup                  (chula_buffer_t  *buf, chula_buffer_t **dup);

--- a/ports/www/libhpack/dragonfly/patch-libchula_test_buffer__test.c
+++ b/ports/www/libhpack/dragonfly/patch-libchula_test_buffer__test.c
@@ -1,0 +1,28 @@
+--- libchula/test/buffer_test.c.orig	2014-07-10 00:59:50.000000000 +0300
++++ libchula/test/buffer_test.c
+@@ -1972,6 +1972,8 @@ START_TEST (print_cstr)
+ }
+ END_TEST
+ 
++/* explicitly disabled on DragonFly */
++#ifndef __DragonFly__
+ START_TEST (_import)
+ {
+     ret_t           ret;
+@@ -1998,6 +2000,7 @@ START_TEST (_import)
+     ch_assert_str_eq (buf.buf, "hola caracola");
+ }
+ END_TEST
++#endif
+ 
+ 
+ int
+@@ -2066,6 +2069,8 @@ buffer_tests (void)
+     check_add (s1, cnt_cspn);
+     check_add (s1, print_debug);
+     check_add (s1, print_cstr);
++#ifndef __DragonFly__
+     check_add (s1, _import);
++#endif
+     run_test (s1);
+ }

--- a/ports/www/libhpack/dragonfly/patch-libchula_test_util__test.c
+++ b/ports/www/libhpack/dragonfly/patch-libchula_test_util__test.c
@@ -1,0 +1,28 @@
+--- libchula/test/util_test.c.orig	2017-01-13 15:58:26.000000000 +0200
++++ libchula/test/util_test.c
+@@ -890,6 +890,8 @@ START_TEST (_syslog)
+ }
+ END_TEST
+ 
++/* explicitly disabled on DragonFly */
++#ifndef __DragonFly__
+ START_TEST (_malloc_size)
+ {
+     ret_t   ret;
+@@ -924,6 +926,7 @@ START_TEST (_malloc_size)
+     ch_assert (ptr[size-1] == 9);
+ }
+ END_TEST
++#endif
+ 
+ 
+ int
+@@ -973,6 +976,8 @@ util_tests (void)
+     check_add (s1, set_closexec);
+     check_add (s1, set_reuseaddr);
+     check_add (s1, _syslog);
++#ifndef __DragonFly__
+     check_add (s1, _malloc_size);
++#endif
+     run_test (s1);
+ }

--- a/ports/www/libhpack/dragonfly/patch-libchula_util.c
+++ b/ports/www/libhpack/dragonfly/patch-libchula_util.c
@@ -1,0 +1,16 @@
+--- libchula/util.c.orig	2014-07-10 00:59:50.000000000 +0300
++++ libchula/util.c
+@@ -2034,6 +2034,8 @@ chula_tmp_dir_copy (chula_buffer_t *buff
+ }
+ 
+ 
++/* explicitly disabled on DragonFly */
++#ifndef __DragonFly__
+ ret_t
+ chula_malloc_size (const void *ptr, size_t *size)
+ {
+@@ -2050,3 +2052,4 @@ chula_malloc_size (const void *ptr, size
+ #endif
+     return ret_error;
+ }
++#endif

--- a/ports/www/libhpack/dragonfly/patch-libchula_util.h
+++ b/ports/www/libhpack/dragonfly/patch-libchula_util.h
@@ -1,0 +1,13 @@
+--- libchula/util.h.orig	2014-07-10 00:59:50.000000000 +0300
++++ libchula/util.h
+@@ -74,7 +74,10 @@ ret_t   chula_atoi           (const char
+ ret_t   chula_atol           (const char *str, long *ret_value);
+ ret_t   chula_atob           (const char *str, bool *ret_value);
+ int     chula_string_is_ipv6 (chula_buffer_t *ip);
++/* explicitly disabled on DragonFly */
++#ifndef __DragonFly__
+ ret_t   chula_malloc_size    (const void *ptr, size_t *size);
++#endif
+ 
+ /* Files and Directories
+  */


### PR DESCRIPTION
Programs should be tracking this, not rely on third party.
While there fix missing defs for htonls.

There are few tests failing on getgrnam().