### PR TITLE
sysutils/ipmitool: Use __BSD_VISIBILE on new version.

### DIFF
--- a/ports/sysutils/ipmitool/dragonfly/patch-configure
+++ b/ports/sysutils/ipmitool/dragonfly/patch-configure
@@ -1,0 +1,11 @@
+--- configure.orig	2016-10-08 11:11:34.000000000 +0300
++++ configure
+@@ -12595,7 +12595,7 @@ solaris*)
+ 	xenable_intf_lipmi=no
+ 	xenable_ipmishell=no
+ 	;;
+-*freebsd*)
++*freebsd*|*dragonfly*)
+ 	xenable_intf_imb=no
+ 	xenable_intf_lipmi=no
+ 	CFLAGS="$CFLAGS -D__BSD_VISIBLE"


### PR DESCRIPTION
As for compilation warnings, well it does use -Wpedantic