### PR TITLE
devel/unittest-cpp: Fix .pc file install location.

### DIFF
--- a/ports/devel/unittest-cpp/dragonfly/patch-CMakeLists.txt
+++ b/ports/devel/unittest-cpp/dragonfly/patch-CMakeLists.txt
@@ -1,0 +1,11 @@
+--- CMakeLists.txt.intermediate	2017-01-25 10:22:45 UTC
++++ CMakeLists.txt
+@@ -106,7 +106,7 @@ set(exec_prefix ${CMAKE_INSTALL_PREFIX}/
+ set(libdir      ${CMAKE_INSTALL_PREFIX}/lib)
+ set(includedir  ${CMAKE_INSTALL_PREFIX}/include/UnitTest++)
+ configure_file("UnitTest++.pc.in" "UnitTest++.pc" @ONLY)
+-if(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
++if(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD" OR ${CMAKE_SYSTEM_NAME} STREQUAL "DragonFly")
+     set(pkgconfdir  ${CMAKE_INSTALL_PREFIX}/libdata/pkgconfig)
+ else()
+     set(pkgconfdir  ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig)


### PR DESCRIPTION
Just expand freebsd patch to include DragonFly too.