### PR TITLE
x11-toolkits/fox17: Include <pthread_np.h>

### DIFF
--- a/ports/x11-toolkits/fox17/dragonfly/patch-include_xincs.h
+++ b/ports/x11-toolkits/fox17/dragonfly/patch-include_xincs.h
@@ -1,0 +1,12 @@
+--- include/xincs.h.orig	2016-11-10 02:47:58.000000000 +0200
++++ include/xincs.h
+@@ -201,6 +201,9 @@
+ #include <semaphore.h>
+ #endif
+ #if defined(HAVE_PTHREAD_SETAFFINITY_NP)
++#if defined(__DragonFly__)
++#include <pthread_np.h>
++#endif
+ #if defined(__FreeBSD__)
+ #include <osreldate.h>
+ #if __FreeBSD_version >= 702000

--- a/ports/x11-toolkits/fox17/dragonfly/patch-lib_FXThread.cpp
+++ b/ports/x11-toolkits/fox17/dragonfly/patch-lib_FXThread.cpp
@@ -1,0 +1,11 @@
+--- lib/FXThread.cpp.orig	2016-01-07 03:46:26.000000000 +0200
++++ lib/FXThread.cpp
+@@ -402,7 +402,7 @@ FXint FXThread::processors(){
+     return result;
+     }
+   return 1;
+-#elif defined(__APPLE__) || defined(__FreeBSD__)
++#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__DragonFly__)
+   int result=1;
+   size_t len=sizeof(result);
+   if(sysctlbyname("hw.ncpu",&result,&len,NULL,0)!=-1){


### PR DESCRIPTION
Needed after base changes and port detecting presence of
pthread_setaffinity_np().