### PR TITLE
lang/ruby23: Fix missing entry in plist.

### DIFF
--- a/ports/lang/ruby23/diffs/pkg-plist.diff
+++ b/ports/lang/ruby23/diffs/pkg-plist.diff
@@ -1,0 +1,7 @@
+--- pkg-plist.orig	2017-01-26 10:00:11.000000000 +0200
++++ pkg-plist
+@@ -1,3 +1,4 @@
++%%IF_DEFAULT%%bin/erb
+ bin/erb%%RUBY_SUFFIX%%
+ %%IF_DEFAULT%%bin/irb
+ bin/irb%%RUBY_SUFFIX%%


### PR DESCRIPTION
Noticed while playing with deforaos build.