### PR TITLE
lang/julia: Somewhat fix rpath override.

### DIFF
--- a/ports/lang/julia/dragonfly/patch-zzz_rpath
+++ b/ports/lang/julia/dragonfly/patch-zzz_rpath
@@ -1,0 +1,11 @@
+--- Makefile.intermediate	2017-01-26 14:35:46 UTC
++++ Makefile
+@@ -403,7 +403,7 @@ ifeq ($(OS), Darwin)
+ 	done
+ else
+ 	for julia in $(DESTDIR)$(bindir)/julia* ; do \
+-		patchelf --set-rpath '$$ORIGIN/$(private_libdir_rel):$$ORIGIN/$(libdir_rel)' $$julia; \
++		patchelf --set-rpath '$$ORIGIN/$(private_libdir_rel):$$ORIGIN/$(libdir_rel)'":`cc -print-file-name=`" $$julia; \
+ 	done
+ endif
+ endif


### PR DESCRIPTION
Julia plays with patchelf on soon to be installed execs and libraries.
Try to recover at least for base libstdc++.so.

Reported-by: profmakx@