### PR TITLE
net-mgmt/driftnet: Drop inline attribute for few functions.

### DIFF
--- a/ports/net-mgmt/driftnet/Makefile.DragonFly
+++ b/ports/net-mgmt/driftnet/Makefile.DragonFly
@@ -1,0 +1,11 @@
+
+# drop inline attributes(funtions used outside source scope too)
+# XXX investigate how that even works with clang
+dfly-patch:
+	${REINPLACE_CMD} -e '/get_tmpdir/s@inline const@const@g'	\
+		${WRKSRC}/src/tmpdir.c	\
+		${WRKSRC}/src/tmpdir.h
+	${REINPLACE_CMD} -e '/get_default_interface/s@inline char@char@g'	\
+			 -e '/packetcapture_dispatch/s@inline void@void@g'	\
+		${WRKSRC}/src/packetcapture.c	\
+		${WRKSRC}/src/packetcapture.h


### PR DESCRIPTION
These functions are used in other sources and being marked as inline so gcc
does the right job by not emiting the symbol.
Strange how clang fails to inline them.