### PR TITLE
x11-themes/adwaita-*: Fix isnan for non leaky compiler.

### DIFF
--- a/ports/x11-themes/adwaita-common/Makefile.DragonFly
+++ b/ports/x11-themes/adwaita-common/Makefile.DragonFly
@@ -1,0 +1,6 @@
+
+.if ${PKGNAMESUFFIX} == -qt5 || ${PKGNAMESUFFIX} == -qt4
+dfly-patch:
+	${REINPLACE_CMD} -e "s@[[:<:]]isnan[[:>:]]@std::isnan@g"	\
+		${WRKSRC}/style/adwaitahelper.h
+.endif


### PR DESCRIPTION
Force rebuild all three (-qt4 and -qt5 uses main Makefile w/ USES=metaport):
x11-themes/adwaita-common
x11-themes/adwaita-qt4
x11-themes/adwaita-qt5