### PR TITLE
devel/llvm40: Add usual patches.

### DIFF
--- a/ports/devel/llvm40/Makefile.DragonFly
+++ b/ports/devel/llvm40/Makefile.DragonFly
@@ -1,0 +1,17 @@
+# ninja once again can't relink properly..
+USES:= ${USES:Nninja}
+
+# prune few strange predefs from cpp
+CLANG_EXTRA_PATCHES+= ${DFLY_PATCHDIR}/clang-patch-wrong_predefs
+# add basic -flto support for DragonFly, strange why llvm devs do not test these
+CLANG_EXTRA_PATCHES+= ${DFLY_PATCHDIR}/clang-patch-add_flto_support
+
+# few simple patches, again, libomp.so works, but libgomp.so is way faster/robust
+# also for some reason plain -fopenmp does not propagate any lib to the linker
+OPENMP_EXTRA_PATCHES+= ${DFLY_PATCHDIR}/openmp-patch-tools_openmp_runtime_cmake_LibompMicroTests.cmake
+OPENMP_EXTRA_PATCHES+= ${DFLY_PATCHDIR}/openmp-patch-tools_openmp_runtime_src_kmp.h
+OPENMP_EXTRA_PATCHES+= ${DFLY_PATCHDIR}/openmp-patch-tools_openmp_runtime_src_kmp__ftn__entry.h
+OPENMP_EXTRA_PATCHES+= ${DFLY_PATCHDIR}/openmp-patch-tools_openmp_runtime_src_kmp__platform.h
+OPENMP_EXTRA_PATCHES+= ${DFLY_PATCHDIR}/openmp-patch-tools_openmp_runtime_src_kmp__runtime.cpp
+OPENMP_EXTRA_PATCHES+= ${DFLY_PATCHDIR}/openmp-patch-tools_openmp_runtime_src_kmp__wrapper__malloc.h
+OPENMP_EXTRA_PATCHES+= ${DFLY_PATCHDIR}/openmp-patch-tools_openmp_runtime_src_z__Linux__util.cpp

--- a/ports/devel/llvm40/dragonfly/clang-patch-add_flto_support
+++ b/ports/devel/llvm40/dragonfly/clang-patch-add_flto_support
@@ -1,0 +1,56 @@
+--- tools/clang/lib/Driver/ToolChains.cpp.orig	2017-01-10 23:13:08.000000000 +0200
++++ tools/clang/lib/Driver/ToolChains.cpp
+@@ -4860,7 +4860,7 @@ DragonFly::DragonFly(const Driver &D, co
+ 
+   getFilePaths().push_back(getDriver().Dir + "/../lib");
+   getFilePaths().push_back("/usr/lib");
+-  getFilePaths().push_back("/usr/lib/gcc50");
++  getFilePaths().push_back("/usr/lib/gcc50"); // XXX how to deal with up upcoming gcc 7.0?
+ }
+ 
+ Tool *DragonFly::buildAssembler() const {
+@@ -4871,6 +4871,8 @@ Tool *DragonFly::buildLinker() const {
+   return new tools::dragonfly::Linker(*this);
+ }
+ 
++bool DragonFly::HasNativeLLVMSupport() const { return true; }
++
+ /// CUDA toolchain.  Our assembler is ptxas, and our "linker" is fatbinary,
+ /// which isn't properly a linker but nonetheless performs the step of stitching
+ /// together object files from the assembler into a single blob.
+--- tools/clang/lib/Driver/ToolChains.h.orig	2017-01-05 18:52:29.000000000 +0200
++++ tools/clang/lib/Driver/ToolChains.h
+@@ -854,6 +854,8 @@ public:
+   DragonFly(const Driver &D, const llvm::Triple &Triple,
+             const llvm::opt::ArgList &Args);
+ 
++  bool HasNativeLLVMSupport() const override;
++
+   bool IsMathErrnoDefault() const override { return false; }
+ 
+ protected:
+--- tools/clang/lib/Driver/Tools.cpp.intermediate	2017-01-31 11:14:08 UTC
++++ tools/clang/lib/Driver/Tools.cpp
+@@ -10764,17 +10764,20 @@ void dragonfly::Linker::ConstructJob(Com
+           Args.MakeArgString(getToolChain().GetFilePath("crtbegin.o")));
+   }
+ 
++  if (D.isUsingLTO())
++    AddGoldPlugin(getToolChain(), Args, CmdArgs, D.getLTOMode() == LTOK_Thin, D);
++
+   Args.AddAllArgs(CmdArgs,
+                   {options::OPT_L, options::OPT_T_Group, options::OPT_e});
+ 
+   AddLinkerInputs(getToolChain(), Inputs, Args, CmdArgs, JA);
+ 
+   if (!Args.hasArg(options::OPT_nostdlib, options::OPT_nodefaultlibs)) {
+-    CmdArgs.push_back("-L/usr/lib/gcc50");
++    CmdArgs.push_back("-L/usr/lib/gcc50"); // XXX solve better for gcc 7.0 import
+ 
+     if (!Args.hasArg(options::OPT_static)) {
+       CmdArgs.push_back("-rpath");
+-      CmdArgs.push_back("/usr/lib/gcc50");
++      CmdArgs.push_back("/usr/lib/gcc50"); // XXX solve better for gcc 7.0 import
+     }
+ 
+     if (D.CCCIsCXX()) {

--- a/ports/devel/llvm40/dragonfly/clang-patch-wrong_predefs
+++ b/ports/devel/llvm40/dragonfly/clang-patch-wrong_predefs
@@ -1,0 +1,13 @@
+--- tools/clang/lib/Basic/Targets.cpp.orig	2017-01-10 08:02:12.000000000 +0200
++++ tools/clang/lib/Basic/Targets.cpp
+@@ -302,10 +302,7 @@ protected:
+                     MacroBuilder &Builder) const override {
+     // DragonFly defines; list based off of gcc output
+     Builder.defineMacro("__DragonFly__");
+-    Builder.defineMacro("__DragonFly_cc_version", "100001");
+     Builder.defineMacro("__ELF__");
+-    Builder.defineMacro("__KPRINTF_ATTRIBUTE__");
+-    Builder.defineMacro("__tune_i386__");
+     DefineStd(Builder, "unix", Opts);
+   }
+ public:

--- a/ports/devel/llvm40/dragonfly/openmp-patch-tools_openmp_runtime_cmake_LibompMicroTests.cmake
+++ b/ports/devel/llvm40/dragonfly/openmp-patch-tools_openmp_runtime_cmake_LibompMicroTests.cmake
@@ -1,0 +1,12 @@
+--- tools/openmp/runtime/cmake/LibompMicroTests.cmake.orig	2016-12-08 11:22:24.000000000 +0200
++++ tools/openmp/runtime/cmake/LibompMicroTests.cmake
+@@ -176,6 +176,9 @@ if(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+ elseif(CMAKE_SYSTEM_NAME MATCHES "NetBSD")
+   set(libomp_expected_library_deps libc.so.12 libpthread.so.1 libm.so.0)
+   libomp_append(libomp_expected_library_deps libhwloc.so.5 LIBOMP_USE_HWLOC)
++elseif(CMAKE_SYSTEM_NAME MATCHES "DragonFly")
++  set(libomp_expected_library_deps libc.so.8 libpthread.so.0 libm.so.4)
++  libomp_append(libomp_expected_library_deps libhwloc.so.5 LIBOMP_USE_HWLOC)
+ elseif(APPLE)
+   set(libomp_expected_library_deps /usr/lib/libSystem.B.dylib)
+ elseif(WIN32)

--- a/ports/devel/llvm40/dragonfly/openmp-patch-tools_openmp_runtime_src_kmp.h
+++ b/ports/devel/llvm40/dragonfly/openmp-patch-tools_openmp_runtime_src_kmp.h
@@ -1,0 +1,13 @@
+--- tools/openmp/runtime/src/kmp.h.orig	2016-12-15 01:01:24.000000000 +0200
++++ tools/openmp/runtime/src/kmp.h
+@@ -974,6 +974,10 @@ extern int __kmp_place_num_threads_per_c
+ /* TODO: tune for KMP_OS_NETBSD */
+ #  define KMP_INIT_WAIT  1024U          /* initial number of spin-tests   */
+ #  define KMP_NEXT_WAIT   512U          /* susequent number of spin-tests */
++#elif KMP_OS_DRAGONFLY
++/* TODO: tune for KMP_OS_DRAGONFLY */
++#  define KMP_INIT_WAIT  1024U          /* initial number of spin-tests   */
++#  define KMP_NEXT_WAIT   512U          /* susequent number of spin-tests */
+ #endif
+ 
+ #if KMP_ARCH_X86 || KMP_ARCH_X86_64

--- a/ports/devel/llvm40/dragonfly/openmp-patch-tools_openmp_runtime_src_kmp__ftn__entry.h
+++ b/ports/devel/llvm40/dragonfly/openmp-patch-tools_openmp_runtime_src_kmp__ftn__entry.h
@@ -1,0 +1,11 @@
+--- tools/openmp/runtime/src/kmp_ftn_entry.h.orig	2016-11-14 23:08:35.000000000 +0200
++++ tools/openmp/runtime/src/kmp_ftn_entry.h
+@@ -406,7 +406,7 @@ xexpand(FTN_GET_THREAD_NUM)( void )
+     #else
+         int gtid;
+ 
+-        #if KMP_OS_DARWIN || KMP_OS_FREEBSD || KMP_OS_NETBSD
++        #if KMP_OS_DARWIN || KMP_OS_FREEBSD || KMP_OS_NETBSD || KMP_OS_DRAGONFLY
+             gtid = __kmp_entry_gtid();
+         #elif KMP_OS_WINDOWS
+             if (!__kmp_init_parallel ||

--- a/ports/devel/llvm40/dragonfly/openmp-patch-tools_openmp_runtime_src_kmp__platform.h
+++ b/ports/devel/llvm40/dragonfly/openmp-patch-tools_openmp_runtime_src_kmp__platform.h
@@ -1,0 +1,36 @@
+--- tools/openmp/runtime/src/kmp_platform.h.orig	2016-12-08 11:22:24.000000000 +0200
++++ tools/openmp/runtime/src/kmp_platform.h
+@@ -17,6 +17,7 @@
+ /* ---------------------- Operating system recognition ------------------- */
+ 
+ #define KMP_OS_LINUX    0
++#define KMP_OS_DRAGONFLY 0
+ #define KMP_OS_FREEBSD  0
+ #define KMP_OS_NETBSD   0
+ #define KMP_OS_DARWIN   0
+@@ -45,6 +46,11 @@
+ #else
+ #endif
+ 
++#if ( defined __DragonFly__ )
++# undef KMP_OS_DRAGONFLY
++# define KMP_OS_DRAGONFLY 1
++#endif
++
+ #if ( defined __FreeBSD__ )
+ # undef KMP_OS_FREEBSD
+ # define KMP_OS_FREEBSD 1
+@@ -60,11 +66,11 @@
+ # define KMP_OS_CNK 1
+ #endif
+ 
+-#if (1 != KMP_OS_LINUX + KMP_OS_FREEBSD + KMP_OS_NETBSD + KMP_OS_DARWIN + KMP_OS_WINDOWS)
++#if (1 != KMP_OS_LINUX + KMP_OS_DRAGONFLY + KMP_OS_FREEBSD + KMP_OS_NETBSD + KMP_OS_DARWIN + KMP_OS_WINDOWS)
+ # error Unknown OS
+ #endif
+ 
+-#if KMP_OS_LINUX || KMP_OS_FREEBSD || KMP_OS_NETBSD || KMP_OS_DARWIN
++#if KMP_OS_LINUX || KMP_OS_DRAGONFLY || KMP_OS_FREEBSD || KMP_OS_NETBSD || KMP_OS_DARWIN
+ # undef KMP_OS_UNIX
+ # define KMP_OS_UNIX 1
+ #endif

--- a/ports/devel/llvm40/dragonfly/openmp-patch-tools_openmp_runtime_src_kmp__runtime.cpp
+++ b/ports/devel/llvm40/dragonfly/openmp-patch-tools_openmp_runtime_src_kmp__runtime.cpp
@@ -1,0 +1,11 @@
+--- tools/openmp/runtime/src/kmp_runtime.cpp.orig	2016-12-15 01:01:24.000000000 +0200
++++ tools/openmp/runtime/src/kmp_runtime.cpp
+@@ -7567,7 +7567,7 @@ __kmp_determine_reduction_method( ident_
+ 
+         #if KMP_ARCH_X86_64 || KMP_ARCH_PPC64 || KMP_ARCH_AARCH64 || KMP_ARCH_MIPS64
+ 
+-            #if KMP_OS_LINUX || KMP_OS_FREEBSD || KMP_OS_NETBSD || KMP_OS_WINDOWS || KMP_OS_DARWIN
++            #if KMP_OS_LINUX || KMP_OS_DRAGONFLY || KMP_OS_FREEBSD || KMP_OS_NETBSD || KMP_OS_WINDOWS || KMP_OS_DARWIN
+ 
+ 	    int teamsize_cutoff = 4;
+ 

--- a/ports/devel/llvm40/dragonfly/openmp-patch-tools_openmp_runtime_src_kmp__wrapper__malloc.h
+++ b/ports/devel/llvm40/dragonfly/openmp-patch-tools_openmp_runtime_src_kmp__wrapper__malloc.h
@@ -1,0 +1,11 @@
+--- tools/openmp/runtime/src/kmp_wrapper_malloc.h.orig	2015-09-21 23:02:45.000000000 +0300
++++ tools/openmp/runtime/src/kmp_wrapper_malloc.h
+@@ -103,7 +103,7 @@
+ #if KMP_OS_WINDOWS
+     #include <malloc.h>        // Windows* OS: _alloca() declared in "malloc.h".
+     #define alloca _alloca     // Allow to use alloca() with no underscore.
+-#elif KMP_OS_FREEBSD || KMP_OS_NETBSD
++#elif KMP_OS_DRAGONFLY || KMP_OS_FREEBSD || KMP_OS_NETBSD
+     // Declared in "stdlib.h".
+ #elif KMP_OS_UNIX
+     #include <alloca.h>        // Linux* OS and OS X*: alloc() declared in "alloca".

--- a/ports/devel/llvm40/dragonfly/openmp-patch-tools_openmp_runtime_src_z__Linux__util.cpp
+++ b/ports/devel/llvm40/dragonfly/openmp-patch-tools_openmp_runtime_src_z__Linux__util.cpp
@@ -1,0 +1,77 @@
+--- tools/openmp/runtime/src/z_Linux_util.cpp.orig	2016-12-15 01:01:24.000000000 +0200
++++ tools/openmp/runtime/src/z_Linux_util.cpp
+@@ -24,7 +24,7 @@
+ #include "kmp_wait_release.h"
+ #include "kmp_affinity.h"
+ 
+-#if !KMP_OS_FREEBSD && !KMP_OS_NETBSD
++#if !KMP_OS_DRAGONFLY && !KMP_OS_FREEBSD && !KMP_OS_NETBSD
+ # include <alloca.h>
+ #endif
+ #include <unistd.h>
+@@ -52,7 +52,7 @@
+ #elif KMP_OS_DARWIN
+ # include <sys/sysctl.h>
+ # include <mach/mach.h>
+-#elif KMP_OS_FREEBSD
++#elif KMP_OS_DRAGONFLY || KMP_OS_FREEBSD
+ # include <pthread_np.h>
+ #endif
+ 
+@@ -539,7 +539,7 @@ static kmp_int32
+ __kmp_set_stack_info( int gtid, kmp_info_t *th )
+ {
+     int            stack_data;
+-#if KMP_OS_LINUX || KMP_OS_FREEBSD || KMP_OS_NETBSD
++#if KMP_OS_LINUX || KMP_OS_DRAGONFLY || KMP_OS_FREEBSD || KMP_OS_NETBSD
+     /* Linux* OS only -- no pthread_getattr_np support on OS X* */
+     pthread_attr_t attr;
+     int            status;
+@@ -554,7 +554,7 @@ __kmp_set_stack_info( int gtid, kmp_info
+         /* Fetch the real thread attributes */
+         status = pthread_attr_init( &attr );
+         KMP_CHECK_SYSFAIL( "pthread_attr_init", status );
+-#if KMP_OS_FREEBSD || KMP_OS_NETBSD
++#if KMP_OS_DRAGONFLY || KMP_OS_FREEBSD || KMP_OS_NETBSD
+         status = pthread_attr_get_np( pthread_self(), &attr );
+         KMP_CHECK_SYSFAIL( "pthread_attr_get_np", status );
+ #else
+@@ -594,7 +594,7 @@ __kmp_launch_worker( void *thr )
+     sigset_t    new_set, old_set;
+ #endif /* KMP_BLOCK_SIGNALS */
+     void *exit_val;
+-#if KMP_OS_LINUX || KMP_OS_FREEBSD || KMP_OS_NETBSD
++#if KMP_OS_LINUX || KMP_OS_DRAGONFLY || KMP_OS_FREEBSD || KMP_OS_NETBSD
+     void * volatile padding = 0;
+ #endif
+     int gtid;
+@@ -645,7 +645,7 @@ __kmp_launch_worker( void *thr )
+     KMP_CHECK_SYSFAIL( "pthread_sigmask", status );
+ #endif /* KMP_BLOCK_SIGNALS */
+ 
+-#if KMP_OS_LINUX || KMP_OS_FREEBSD || KMP_OS_NETBSD
++#if KMP_OS_LINUX || KMP_OS_DRAGONFLY || KMP_OS_FREEBSD || KMP_OS_NETBSD
+     if ( __kmp_stkoffset > 0 && gtid > 0 ) {
+         padding = KMP_ALLOCA( gtid * __kmp_stkoffset );
+     }
+@@ -1957,7 +1957,7 @@ __kmp_get_xproc( void ) {
+ 
+     int r = 0;
+ 
+-    #if KMP_OS_LINUX || KMP_OS_FREEBSD || KMP_OS_NETBSD
++    #if KMP_OS_LINUX || KMP_OS_DRAGONFLY || KMP_OS_FREEBSD || KMP_OS_NETBSD
+ 
+         r = sysconf( _SC_NPROCESSORS_ONLN );
+ 
+@@ -2240,9 +2240,9 @@ __kmp_is_address_mapped( void * addr ) {
+             found = 1;
+         }; // if
+ 
+-    #elif KMP_OS_FREEBSD || KMP_OS_NETBSD
++    #elif KMP_OS_DRAGONFLY || KMP_OS_FREEBSD || KMP_OS_NETBSD
+ 
+-        // FIXME(FreeBSD, NetBSD): Implement this
++        // FIXME(DragonFly, FreeBSD, NetBSD): Implement this
+         found = 1;
+ 
+     #else


### PR DESCRIPTION
Same ones as llvm39 for OpenMP implementation as libomp.so.
While there remove few strange predefs for DragonFly.
Also throw in proper support for -flto handling in the toolchain,
mainly to pass LLVMgold.so to the linker to be used as plugin.