### PR TITLE
net/opal: Make size_t visibility explicit.

### DIFF
--- a/ports/net/opal/dragonfly/patch-plugins_video_common_platform.h
+++ b/ports/net/opal/dragonfly/patch-plugins_video_common_platform.h
@@ -1,0 +1,10 @@
+--- plugins/video/common/platform.h.orig	2013-02-20 04:18:05.000000000 +0200
++++ plugins/video/common/platform.h
+@@ -63,6 +63,7 @@
+   #include "stdint.h"
+ #else
+   #include "plugin-config.h"
++  #include <stddef.h>
+   #include <stdint.h>
+   #include <semaphore.h>
+   #include <dlfcn.h>


### PR DESCRIPTION
Will be needed for upcoming base headers namespace cleanup.
No functional change.