### PR TITLE
devel/linux-kernel: Prefer to build x86_64.

### DIFF
--- a/ports/devel/linux-kernel/Makefile.DragonFly
+++ b/ports/devel/linux-kernel/Makefile.DragonFly
@@ -1,0 +1,6 @@
+
+# undo freebsd'isms, we want 64-bit version, not 32-bit one
+dfly-patch:
+	${REINPLACE_CMD} -e 's@amd64@x86_64@g'	\
+		${WRKSRC}/Makefile \
+		${WRKSRC}/arch/x86/Makefile


### PR DESCRIPTION
There is something strange, this fails to build with lang/gcc6-aux
over on video_mode.c -m16 with reg not being multiple of 8.
For now just use gcc 4.9.