### PR TITLE
emulators/qemu-devel: Re enable curses backend support.

### DIFF
--- a/ports/emulators/qemu-devel/Makefile.DragonFly
+++ b/ports/emulators/qemu-devel/Makefile.DragonFly
@@ -1,3 +1,4 @@
+USES+= ncurses
 LDFLAGS+= -lcrypto
 
 OPTIONS_DEFINE:=	${OPTIONS_DEFINE} VKNET

--- a/ports/emulators/qemu-devel/dragonfly/patch-configure
+++ b/ports/emulators/qemu-devel/dragonfly/patch-configure
@@ -1,0 +1,21 @@
+Adding missing ncurses cflags passing from .pc
+
+--- configure.intermediate	2017-02-13 17:11:06 UTC
++++ configure
+@@ -2920,6 +2920,7 @@ if test "$curses" != "no" ; then
+   if test "$mingw32" = "yes" ; then
+     curses_list="$($pkg_config --libs ncurses 2>/dev/null):-lpdcurses"
+   else
++    curses_cflags=`$pkg_config --cflags ncurses 2>/dev/null`
+     curses_list="$($pkg_config --libs ncurses 2>/dev/null):-lncurses:-lcurses"
+   fi
+   curses_found=no
+@@ -2934,7 +2935,7 @@ EOF
+   IFS=:
+   for curses_lib in $curses_list; do
+     unset IFS
+-    if compile_prog "" "$curses_lib" ; then
++    if compile_prog "$curses_cflags" "$curses_lib" ; then
+       curses_found=yes
+       libs_softmmu="$curses_lib $libs_softmmu"
+       break


### PR DESCRIPTION
This brings back the qemu-system-x86_64 -m 4G -hda /zzz/qemu.img -curses