### PR TITLE
security/doas: Fix build in DragonFly

### DIFF
--- a/ports/security/doas/dragonfly/patch-env.c
+++ b/ports/security/doas/dragonfly/patch-env.c
@@ -1,0 +1,12 @@
+--- env.c.orig	2017-02-14 23:32:32.947014000 +0100
++++ env.c	2017-02-14 23:33:45.766652000 +0100
+@@ -49,6 +49,9 @@
+ {
+ 	return strcmp(a->key, b->key);
+ }
++#ifdef __DragonFly__
++RB_PROTOTYPE_STATIC(envtree, envnode, node, envcmp);
++#endif
+ RB_GENERATE_STATIC(envtree, envnode, node, envcmp)
+ 
+ struct env *createenv(char **);


### PR DESCRIPTION
Build log:

```
j1900# make
===>  License ISCL accepted by the user
===>   doas-5.9p7 depends on file: /usr/local/sbin/pkg - found
===> Fetching all distfiles required by doas-5.9p7 for building
===>  Extracting for doas-5.9p7
=> SHA256 Checksum OK for slicer69-doas-5.9p7-a15e6ed_GH0.tar.gz.
===>  Patching for doas-5.9p7
===>  Applying dragonfly patches for doas-5.9p7
===>   doas-5.9p7 depends on executable: gmake - found
===>  Configuring for doas-5.9p7
===>  Building for doas-5.9p7
gmake[1]: Entering directory '/usr/obj/dports/security/doas/doas-a15e6ed'
cc -pipe -O2 -fno-strict-aliasing -DUSE_PAM -DDOAS_CONF=\"/usr/local/etc/doas.conf\"   -c -o doas.o doas.c
cc -pipe -O2 -fno-strict-aliasing -DUSE_PAM -DDOAS_CONF=\"/usr/local/etc/doas.conf\"   -c -o env.o env.c
cc -pipe -O2 -fno-strict-aliasing -DUSE_PAM -DDOAS_CONF=\"/usr/local/etc/doas.conf\"   -c -o execvpe.o execvpe.c
cc -pipe -O2 -fno-strict-aliasing -DUSE_PAM -DDOAS_CONF=\"/usr/local/etc/doas.conf\"   -c -o reallocarray.o reallocarray.c
yacc parse.y
cc -pipe -O2 -fno-strict-aliasing -DUSE_PAM -DDOAS_CONF=\"/usr/local/etc/doas.conf\" -c y.tab.c
cc -o doas doas.o env.o execvpe.o reallocarray.o y.tab.o  -lpam
gmake[1]: Leaving directory '/usr/obj/dports/security/doas/doas-a15e6ed'
===>  Staging for doas-5.9p7
===>   Generating temporary packing list
install   -m 4755 /usr/obj/dports/security/doas/doas-a15e6ed/doas /usr/obj/dports/security/doas/stage/usr/local/bin
install  -m 444 /usr/obj/dports/security/doas/doas-a15e6ed/doas.1 /usr/obj/dports/security/doas/stage/usr/local/man/man1
install  -m 444 /usr/obj/dports/security/doas/doas-a15e6ed/doas.conf.5 /usr/obj/dports/security/doas/stage/usr/local/man/man5
====> Compressing man pages (compress-man)

```