### PR TITLE
x11-drivers/xf86-video-ati: Move back to be a newport.

### DIFF
--- a/ports/x11-drivers/xf86-video-ati/STATUS
+++ b/ports/x11-drivers/xf86-video-ati/STATUS
@@ -1,3 +1,3 @@
-PORT
+DPORT
 Last attempt: 7.8.0,1
 Last success: 7.8.0,1

--- a/ports/x11-drivers/xf86-video-ati/newport/Makefile
+++ b/ports/x11-drivers/xf86-video-ati/newport/Makefile
@@ -1,0 +1,23 @@
+# $FreeBSD$
+
+PORTNAME=	xf86-video-ati
+PORTVERSION=	7.8.0
+PORTEPOCH=	1
+CATEGORIES=	x11-drivers
+
+MAINTAINER=	x11@FreeBSD.org
+COMMENT=	X.Org ati display driver
+
+LICENSE=	MIT
+LICENSE_FILE=	${WRKSRC}/COPYING
+
+LIB_DEPENDS=	libpciaccess.so:devel/libpciaccess \
+		libdrm_radeon.so:graphics/libdrm
+
+USE_GL=		gl
+XORG_CAT=	driver
+USE_XORG=	pciaccess
+
+CONFIGURE_ARGS+=--disable-udev
+
+.include <bsd.port.mk>

--- a/ports/x11-drivers/xf86-video-ati/newport/Makefile.DragonFly
+++ b/ports/x11-drivers/xf86-video-ati/newport/Makefile.DragonFly
@@ -1,0 +1,2 @@
+# Force enable just in case.
+CONFIGURE_ARGS+= --enable-glamor

--- a/ports/x11-drivers/xf86-video-ati/newport/distinfo
+++ b/ports/x11-drivers/xf86-video-ati/newport/distinfo
@@ -1,0 +1,3 @@
+TIMESTAMP = 1479393377
+SHA256 (xorg/driver/xf86-video-ati-7.8.0.tar.bz2) = 401f5de772928f3dc4ce43a885adb0a47a2f61aa4a9e45d2ab3d184136a9d6fa
+SIZE (xorg/driver/xf86-video-ati-7.8.0.tar.bz2) = 845702

--- a/ports/x11-drivers/xf86-video-ati/newport/files/patch-src__radeon_kms.c
+++ b/ports/x11-drivers/xf86-video-ati/newport/files/patch-src__radeon_kms.c
@@ -1,0 +1,27 @@
+--- src/radeon_kms.c.orig	2016-11-17 02:23:37 UTC
++++ src/radeon_kms.c
+@@ -30,6 +30,8 @@
+ 
+ #include <errno.h>
+ #include <sys/ioctl.h>
++#include <sys/param.h>
++#include <sys/linker.h>
+ /* Driver data structures */
+ #include "radeon.h"
+ #include "radeon_drm_queue.h"
+@@ -1405,6 +1407,15 @@ static int radeon_get_drm_master_fd(Scrn
+     XNFasprintf(&busid, "pci:%04x:%02x:%02x.%d",
+                 dev->domain, dev->bus, dev->dev, dev->func);
+ 
++    fd = kldload("radeonkms");
++    if (fd == -1 && errno != EEXIST) {
++	xf86DrvMsg(pScrn->scrnIndex, X_ERROR,
++		   "[drm] Failed to load kernel module for %s: %s\n",
++		   busid, strerror(errno));
++	free(busid);
++	return fd;
++    }
++
+     fd = drmOpen(NULL, busid);
+     if (fd == -1)
+ 	xf86DrvMsg(pScrn->scrnIndex, X_ERROR,

--- a/ports/x11-drivers/xf86-video-ati/newport/pkg-descr
+++ b/ports/x11-drivers/xf86-video-ati/newport/pkg-descr
@@ -1,0 +1,1 @@
+This package contains the X.Org xf86-video-ati driver.

--- a/ports/x11-drivers/xf86-video-ati/newport/pkg-plist
+++ b/ports/x11-drivers/xf86-video-ati/newport/pkg-plist
@@ -1,0 +1,4 @@
+lib/xorg/modules/drivers/ati_drv.so
+lib/xorg/modules/drivers/radeon_drv.so
+man/man4/ati.4x.gz
+man/man4/radeon.4x.gz


### PR DESCRIPTION
There are several issues, one of them is the git patch I need to exclude
(reported by ftigeot that on his r600 card glamor causes issues) and
I do not want more surprises. So it is best to keep both ati and intel29
to be handled consistency. As for mesa update, so far i915 gpu hangs on
anything that involves OpenGL, in ftigeot case it was hard reset.