### PR TITLE
ports-mgmt/poudriere-devel: Change default DPorts.git location.

### DIFF
--- a/ports/ports-mgmt/poudriere-devel/newport/files/patch-src_etc_poudriere.conf.sample
+++ b/ports/ports-mgmt/poudriere-devel/newport/files/patch-src_etc_poudriere.conf.sample
@@ -1,0 +1,11 @@
+--- src/etc/poudriere.conf.sample.orig	2015-12-17 12:38:30.000000000 +0200
++++ src/etc/poudriere.conf.sample
+@@ -116,7 +116,7 @@ DISTFILES_CACHE=/usr/distfiles
+ DFLY_GIT_URL=git://git.dragonflybsd.org/dragonfly.git
+ 
+ # Set the URL for the dports git repository
+-DPORTS_URL=git://github.com/jrmarino/DPorts.git
++DPORTS_URL=git://github.com/DragonFlyBSD/DPorts.git
+ 
+ # Set the localhost path for rsync (cpdup) to update dports repository
+ # DPORTS_RSYNC_LOC=/home/automaton/merged-ports


### PR DESCRIPTION
swildner reported some strange differences between pou and direct from ports
compilation in logs like.
While comparing build logs i noticed that devel/m4 is compiled with
LIBSIGSEGV=on while dports not.
Turns out it is fetched by poudriere ports -c