### PR TITLE
security/stunnel: update patches for v5.41

### DIFF
--- a/ports/security/stunnel/dragonfly/patch-src_common.h
+++ b/ports/security/stunnel/dragonfly/patch-src_common.h
@@ -1,4 +1,4 @@
---- src/common.h.orig	2016-06-27 07:29:32 UTC
+--- src/common.h.orig	2017-01-02 14:27:26 UTC
 +++ src/common.h
 @@ -448,7 +448,7 @@ extern char *sys_errlist[];
  #define OPENSSL_NO_TLS1_2

--- a/ports/security/stunnel/dragonfly/patch-src_ctx.c
+++ b/ports/security/stunnel/dragonfly/patch-src_ctx.c
@@ -1,6 +1,15 @@
---- src/ctx.c.orig	2016-06-21 15:06:14 UTC
+--- src/ctx.c.orig	2017-03-26 20:25:00 UTC
 +++ src/ctx.c
-@@ -366,7 +366,7 @@ NOEXPORT int ecdh_init(SERVICE_OPTIONS *
+@@ -295,7 +295,7 @@ NOEXPORT int matches_wildcard(char *serv
+ 
+ #ifndef OPENSSL_NO_DH
+ 
+-#if OPENSSL_VERSION_NUMBER<0x10100000L
++#if OPENSSL_VERSION_NUMBER<0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ NOEXPORT STACK_OF(SSL_CIPHER) *SSL_CTX_get_ciphers(const SSL_CTX *ctx) {
+     return ctx->cipher_list;
+ }
+@@ -398,7 +398,7 @@ NOEXPORT int ecdh_init(SERVICE_OPTIONS *
  /**************************************** initialize OpenSSL CONF */
  
  NOEXPORT int conf_init(SERVICE_OPTIONS *section) {

--- a/ports/security/stunnel/dragonfly/patch-src_prototypes.h
+++ b/ports/security/stunnel/dragonfly/patch-src_prototypes.h
@@ -1,6 +1,6 @@
---- src/prototypes.h.orig	2016-07-05 21:27:57 UTC
+--- src/prototypes.h.orig	2017-03-26 20:25:00 UTC
 +++ src/prototypes.h
-@@ -650,13 +650,13 @@ typedef enum {
+@@ -657,13 +657,13 @@ typedef enum {
  #endif /* OPENSSL_NO_DH */
      STUNNEL_LOCKS                           /* number of locks */
  } LOCK_TYPE;

--- a/ports/security/stunnel/dragonfly/patch-src_ssl.c
+++ b/ports/security/stunnel/dragonfly/patch-src_ssl.c
@@ -1,6 +1,15 @@
---- src/ssl.c.orig	2016-06-02 13:43:49 UTC
+--- src/ssl.c.orig	2017-03-26 20:25:00 UTC
 +++ src/ssl.c
-@@ -78,7 +78,7 @@ int ssl_init(void) { /* init SSL before 
+@@ -51,7 +51,7 @@ int index_ssl_cli, index_ssl_ctx_opt;
+ int index_session_authenticated, index_session_connect_address;
+ 
+ int ssl_init(void) { /* init TLS before parsing configuration file */
+-#if OPENSSL_VERSION_NUMBER>=0x10100000L
++#if OPENSSL_VERSION_NUMBER>=0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+     OPENSSL_init_ssl(OPENSSL_INIT_LOAD_SSL_STRINGS |
+         OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
+ #else
+@@ -86,7 +86,7 @@ int ssl_init(void) { /* init TLS before
  }
  
  #ifndef OPENSSL_NO_DH

--- a/ports/security/stunnel/dragonfly/patch-src_sthreads.c
+++ b/ports/security/stunnel/dragonfly/patch-src_sthreads.c
@@ -1,15 +1,15 @@
---- src/sthreads.c.orig	2016-05-03 18:35:03 UTC
+--- src/sthreads.c.orig	2017-01-19 08:51:32 UTC
 +++ src/sthreads.c
-@@ -45,7 +45,7 @@
- 
+@@ -47,7 +47,7 @@
  STUNNEL_RWLOCK stunnel_locks[STUNNEL_LOCKS];
+ #endif
  
 -#if OPENSSL_VERSION_NUMBER<0x10100004L
 +#if OPENSSL_VERSION_NUMBER<0x10100004L || defined(LIBRESSL_VERSION_NUMBER)
  #define CRYPTO_THREAD_lock_new() CRYPTO_get_new_dynlockid()
  #endif
  
-@@ -203,7 +203,7 @@ int create_client(SOCKET ls, SOCKET s, C
+@@ -205,7 +205,7 @@ int create_client(SOCKET ls, SOCKET s, C
  
  #ifdef USE_PTHREAD
  
@@ -18,7 +18,7 @@
  
  struct CRYPTO_dynlock_value {
      pthread_rwlock_t rwlock;
-@@ -263,16 +263,18 @@ unsigned long stunnel_thread_id(void) {
+@@ -265,16 +265,18 @@ unsigned long stunnel_thread_id(void) {
  #endif
  }
  
@@ -39,7 +39,7 @@
      /* initialize the OpenSSL dynamic locking */
      CRYPTO_set_dynlock_create_callback(dyn_create_function);
      CRYPTO_set_dynlock_lock_callback(dyn_lock_function);
-@@ -345,7 +347,7 @@ int create_client(SOCKET ls, SOCKET s, C
+@@ -347,7 +349,7 @@ int create_client(SOCKET ls, SOCKET s, C
   * but it is unsupported on Windows XP (and earlier versions of Windows):
   * https://msdn.microsoft.com/en-us/library/windows/desktop/aa904937%28v=vs.85%29.aspx */
  
@@ -48,8 +48,8 @@
  
  struct CRYPTO_dynlock_value {
      CRITICAL_SECTION mutex;
-@@ -398,7 +400,7 @@ unsigned long stunnel_thread_id(void) {
- int sthreads_init(void) {
+@@ -401,7 +403,7 @@ int sthreads_init(void) {
+ #ifndef USE_FORK
      int i;
  
 -#if OPENSSL_VERSION_NUMBER<0x10100004L

--- a/ports/security/stunnel/dragonfly/patch-src_verify.c
+++ b/ports/security/stunnel/dragonfly/patch-src_verify.c
@@ -1,4 +1,4 @@
---- src/verify.c.orig	2016-07-05 21:27:57 UTC
+--- src/verify.c.orig	2017-03-26 20:25:00 UTC
 +++ src/verify.c
 @@ -178,14 +178,14 @@ NOEXPORT void auth_warnings(SERVICE_OPTI
      if(section->option.verify_peer) /* verify_peer does not depend on PKI */
@@ -10,14 +10,14 @@
              return;
  #endif /* OPENSSL_VERSION_NUMBER>=0x10002000L */
          s_log(LOG_WARNING,
-             "Service [%s] uses \"verify = 2\" without subject checks",
+             "Service [%s] uses \"verifyChain\" without subject checks",
              section->servname);
 -#if OPENSSL_VERSION_NUMBER<0x10002000L
 +#if OPENSSL_VERSION_NUMBER<0x10002000L || defined(LIBRESSL_VERSION_NUMBER)
          s_log(LOG_WARNING,
              "Rebuild your stunnel against OpenSSL version 1.0.2 or higher");
  #endif /* OPENSSL_VERSION_NUMBER<0x10002000L */
-@@ -277,7 +277,7 @@ NOEXPORT int cert_check(CLI *c, X509_STO
+@@ -284,7 +284,7 @@ NOEXPORT int cert_check(CLI *c, X509_STO
      }
  
      if(depth==0) { /* additional peer certificate checks */
@@ -26,7 +26,7 @@
          if(!cert_check_subject(c, callback_ctx))
              return 0; /* reject */
  #endif /* OPENSSL_VERSION_NUMBER>=0x10002000L */
-@@ -288,7 +288,7 @@ NOEXPORT int cert_check(CLI *c, X509_STO
+@@ -295,7 +295,7 @@ NOEXPORT int cert_check(CLI *c, X509_STO
      return 1; /* accept */
  }
  
@@ -35,30 +35,12 @@
  NOEXPORT int cert_check_subject(CLI *c, X509_STORE_CTX *callback_ctx) {
      X509 *cert=X509_STORE_CTX_get_current_cert(callback_ctx);
      NAME_LIST *ptr;
-@@ -340,7 +340,7 @@ NOEXPORT int cert_check_local(X509_STORE
-     STACK_OF(X509) *sk;
-     int i;
- #endif
--#if OPENSSL_VERSION_NUMBER<0x10100000L
-+#if OPENSSL_VERSION_NUMBER<0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
-     X509_OBJECT obj;
-     int success;
- #endif
-@@ -349,7 +349,7 @@ NOEXPORT int cert_check_local(X509_STORE
+@@ -352,7 +352,7 @@ NOEXPORT int cert_check_local(X509_STORE
+     cert=X509_STORE_CTX_get_current_cert(callback_ctx);
      subject=X509_get_subject_name(cert);
  
- #if OPENSSL_VERSION_NUMBER>=0x10000000L
 -#if OPENSSL_VERSION_NUMBER<0x10100006L
 +#if OPENSSL_VERSION_NUMBER<0x10100006L || defined(LIBRESSL_VERSION_NUMBER)
  #define X509_STORE_CTX_get1_certs X509_STORE_get1_certs
  #endif
      /* modern API allows retrieving multiple matching certificates */
-@@ -364,7 +364,7 @@ NOEXPORT int cert_check_local(X509_STORE
-     }
- #endif
- 
--#if OPENSSL_VERSION_NUMBER<0x10100000L
-+#if OPENSSL_VERSION_NUMBER<0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
-     /* pre-1.0.0 API only returns a single matching certificate */
-     /* we also invoke it for other OpenSSL versions before 1.1.0 */
-     memset((char *)&obj, 0, sizeof obj);


### PR DESCRIPTION
* Current DPorts has security/stunnel v5.40, original patches applied,
  but failed to build with LibreSSL v2.5.4;
* Upstream FreeBSD Ports has security/stunnel v5.41, original patches
  failed to apply;
* Update the dfly-specific patches to match security/stunnel v5.41,
  also fix the build issues with LibreSSL v2.5.4;
* Tested on DFly-4.9-DEVELOPMENT.