### PR TITLE
special: Add support for -s in relative_link.sh wrapper.

### DIFF
--- a/special/Mk/diffs/Scripts_relative_link.sh.diff
+++ b/special/Mk/diffs/Scripts_relative_link.sh.diff
@@ -1,6 +1,6 @@
---- Scripts/relative_link.sh.orig	2017-05-03 17:22:31 UTC
+--- Scripts/relative_link.sh.orig	2017-07-24 16:34:20.000000000 +0300
 +++ Scripts/relative_link.sh
-@@ -0,0 +1,34 @@
+@@ -0,0 +1,46 @@
 +#!/bin/sh
 +#
 +# Mimics install -l rs functionality
@@ -14,9 +14,21 @@
 +# limitation: Since realpath cannot be performed against an non-existent file,
 +#             The paths of the two arguments are assumed to be comparable
 +
-+if [ $# -ne 2 ]; then
-+   echo "Usage of relative_link.sh: <path to existing file> <symlink to be created>"
++if [ $# -ne 2 -a $# -ne 3 ]; then
++   echo "Usage of relative_link.sh: [-s] <path to existing file> <symlink to be created>"
 +   exit 1;
++fi
++
++SRC=${1}
++DEST=${2}
++
++if [ $# -eq 3 ]; then
++  SRC=${2}
++  DEST=${3}
++  if [ "${1}" != "-s" ]; then
++    echo "Error: relative_link.sh supports only -s dummy flag"
++    exit 1;
++  fi
 +fi
 +
 +AWKPROG='BEGIN { split(existing,comp,"/"); lenc=length(comp) }\
@@ -32,6 +44,6 @@
 +  }\
 +}'
 +
-+symlink=$(echo ${2} | awk -v existing="${1}" -F "/" "${AWKPROG}")
++symlink=$(echo ${DEST} | awk -v existing="${SRC}" -F "/" "${AWKPROG}")
 +
-+ln -sf "${symlink}" "${2}"
++ln -sf "${symlink}" "${DEST}"


### PR DESCRIPTION
Just ignore the flag and add a warning if any other flags would be passed.
No idea why would one want to strip when creating symlinks, but hey.