### PR TITLE
databases/redis-devel: added support of kqueue, fixed build with lua

### DIFF
--- a/ports/databases/redis-devel/dragonfly/patch-src-config.h
+++ b/ports/databases/redis-devel/dragonfly/patch-src-config.h
@@ -1,0 +1,20 @@
+--- redis-devel/redis-4.0.1/src/config.h	2017-09-22 20:32:36.607128000 +0300
++++ redis-devel.new/redis-4.0.1/src/config.h	2017-09-22 20:32:14.037121000 +0300
+@@ -62,7 +62,7 @@
+ #endif
+ 
+ /* Test for backtrace() */
+-#if defined(__APPLE__) || (defined(__linux__) && defined(__GLIBC__)) || defined(__FreeBSD__)
++#if defined(__APPLE__) || (defined(__linux__) && defined(__GLIBC__)) || defined(__FreeBSD__) || defined(__DragonFly__)
+ #define HAVE_BACKTRACE 1
+ #endif
+ 
+@@ -76,7 +76,7 @@
+ #define HAVE_EPOLL 1
+ #endif
+ 
+-#if (defined(__APPLE__) && defined(MAC_OS_X_VERSION_10_6)) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined (__NetBSD__)
++#if (defined(__APPLE__) && defined(MAC_OS_X_VERSION_10_6)) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined (__NetBSD__) || defined(__DragonFly__)
+ #define HAVE_KQUEUE 1
+ #endif
+ 

--- a/ports/databases/redis-devel/dragonfly/patch-src-lua_cjson.c
+++ b/ports/databases/redis-devel/dragonfly/patch-src-lua_cjson.c
@@ -1,0 +1,11 @@
+--- redis-devel/redis-4.0.1/src/lua_cjson.c	2017-09-22 20:32:36.607128000 +0300
++++ redis-devel.new/redis-4.0.1/src/lua_cjson.c	2017-09-22 20:25:42.967004000 +0300
+@@ -46,7 +46,7 @@
+ #include "strbuf.h"
+ #include "fpconv.h"
+ 
+-#include "../../../src/solarisfixes.h"
++#include "solarisfixes.h"
+ 
+ #ifndef CJSON_MODNAME
+ #define CJSON_MODNAME   "cjson"


### PR DESCRIPTION
Fixed build when redis is  configured to use lua or luajit from dports.
Added checks for DragonFly to use kqueue multiplexing API instead of select.