### PR TITLE
This fixes yarn on DragonFly

### DIFF
--- a/ports/www/yarn/diffs/Makefile.diff
+++ b/ports/www/yarn/diffs/Makefile.diff
@@ -1,0 +1,11 @@
+--- Makefile.orig	2017-11-08 10:26:44 UTC
++++ Makefile
+@@ -37,7 +37,7 @@ post-patch:
+ 	@${REINPLACE_CMD} -i '' \
+ 		-e 's|"installationMethod": "tar"|"installationMethod": "pkg"|g' \
+ 		${WRKSRC}/package.json
+-	@${REINPLACE_CMD} -i '' -e 's%Linux)%Linux|FreeBSD)%g' \
++	@${REINPLACE_CMD} -i '' -e 's%Linux)%Linux|FreeBSD|DragonFly)%g' \
+ 		${WRKSRC}/bin/yarn
+ 
+ do-install:


### PR DESCRIPTION
Before this patch, when calling "yarn", the following bug occurs:

    > yarn
    module.js:473
	  throw err;
	  ^

    Error: Cannot find module '/usr/home/lib/node_modules/yarn/bin/yarn.js'
	at Function.Module._resolveFilename (module.js:527:15)
	at Function.Module._load (module.js:453:25)
	at Function.Module.runMain (module.js:665:10)
	at startup (bootstrap_node.js:187:16)
	at bootstrap_node.js:607:3