### PR TITLE
net/shadowsocks-libev: Remove DragonFly-specific Makefile

### DIFF
--- a/ports/net/shadowsocks-libev/Makefile.DragonFly
+++ b/ports/net/shadowsocks-libev/Makefile.DragonFly
@@ -1,2 +1,0 @@
-dfly-patch:
-	${REINPLACE_CMD} -e "s|-Werror ||" ${WRKSRC}/src/Makefile.in


### PR DESCRIPTION
The DragonFly-specific Makefile only disables the ``-Werror`` compiler flag, but it is no longer needed.

I've tested with the latest ``net/shadowsocks-libev`` (v3.1.0 from FreeBSD Ports) on DragonFly-5.1.