### PR TITLE
graphics/inkscape: Add ${PREFIX}/lib/inkscape to ldconfig search path.

### DIFF
--- a/ports/graphics/inkscape/Makefile.DragonFly
+++ b/ports/graphics/inkscape/Makefile.DragonFly
@@ -1,0 +1,1 @@
+USE_LDCONFIG+= ${PREFIX}/lib/inkscape


### PR DESCRIPTION
This fixes the problem with graphics/inkscape not finding lib/inkscape/libinkscape_base.so. 

The problem is that although inkscape is linked with rpath, the linking options are wrong. In addition to

-Wl,-rpath,"\$ORIGIN/../lib/inkscape:/usr/local/lib"

they should also contain -Wl,-z,origin: 

-Wl,-rpath,"\$ORIGIN/../lib/inkscape:/usr/local/lib" -Wl,-z,origin

Thanks to zrj for pointing this out. I verified that it produces a working binary; it adds "(FLAGS)              ORIGIN" and "(FLAGS_1) Flags: ORIGIN" to the binary. So the proper solution would be to add a patch upstream.

However, I ran a quick test and it appears that DragonFly differs from FreeBSD and Linux in that the latter two do not need to set "FLAGS" and "FLAGS_1" in the binary. ORIGIN in rpath is parsed w/o the flags set. 

Should DragonFly follow FreeBSD and Linux in this? It'd reduce the number of patches we need.

Background: similar discussion on FreeBSD and libreoffice. It does not apply any more though since FreeBSD does not care of whether FLAGS, FLAGS_1 is set.

https://bugs.documentfoundation.org/show_bug.cgi?id=54015
