### PR TITLE
Fix the problem with graphics/inkscape not finding lib/inkscape_base.so

### DIFF
--- a/ports/graphics/inkscape/Makefile.DragonFly
+++ b/ports/graphics/inkscape/Makefile.DragonFly
@@ -1,0 +1,1 @@
+LDFLAGS+=	"-Wl,-z,origin"


### PR DESCRIPTION
The issue is fixed by adding "-Wl,-z,origin" to LDFLAGS.