### PR TITLE
devel/rubygem-childprocess - Fix support for DragonFly BSD

### DIFF
--- a/ports/devel/rubygem-childprocess/dragonfly/patch-lib_childprocess.rb
+++ b/ports/devel/rubygem-childprocess/dragonfly/patch-lib_childprocess.rb
@@ -1,0 +1,11 @@
+--- lib/childprocess.rb.orig	2018-02-22 00:27:07 UTC
++++ lib/childprocess.rb
+@@ -113,7 +113,7 @@ module ChildProcess
+           :cygwin
+         when /solaris|sunos/
+           :solaris
+-        when /bsd/
++        when /bsd|dragonfly/
+           :bsd
+         when /aix/
+           :aix


### PR DESCRIPTION
- This fix makes it possible to run vagrant on dfly
- If we ever get https://github.com/enkessler/childprocess/pull/135 upstream this
  patch can be removed.