### PR TITLE
multimedia/x265: Properly use internal bundled md5 c++ implementation.

### DIFF
--- a/ports/math/octave-forge-video/Makefile.DragonFly
+++ b/ports/math/octave-forge-video/Makefile.DragonFly
@@ -1,1 +1,0 @@
-IGNORE=		new(?) issue with libmd during configure

--- a/ports/multimedia/x265/Makefile.DragonFly
+++ b/ports/multimedia/x265/Makefile.DragonFly
@@ -1,0 +1,3 @@
+USES:=		${USES:Ncmake} cmake:noninja
+# libmd is not needed if internal c++ implementation of md5 is used
+CMAKE_ARGS:=	${CMAKE_ARGS:N-DPLATFORM_LIBS=md}

--- a/ports/multimedia/x265/diffs/Makefile.diff
+++ b/ports/multimedia/x265/diffs/Makefile.diff
@@ -1,20 +1,7 @@
---- Makefile.orig	2018-02-24 02:45:15 UTC
+--- Makefile.orig	2018-03-04 18:27:57 UTC
 +++ Makefile
-@@ -16,7 +16,7 @@ LICENSE_FILE=	${WRKSRC}/../COPYING
- 
- BUILD_DEPENDS=	yasm:devel/yasm
- 
--USES=		cmake compiler:c++14-lang pathfix
-+USES=		cmake:noninja compiler:c++14-lang pathfix
- 
- OPTIONS_DEFINE=		DEBUG OPTIMIZED_FLAGS
- OPTIONS_DEFINE_amd64=	HI10P HI12P
-@@ -35,10 +35,9 @@ HI12P_DESC=	Enable HI12P Support (64-bit
- OPTIMIZED_FLAGS_DESC=	Enable O3 optimization
- 
- USE_LDCONFIG=	yes
--CMAKE_ARGS=	-DENABLE_PIC=on -DPLATFORM_LIBS=md -DENABLE_TESTS=on
-+CMAKE_ARGS=	-DENABLE_PIC=on -DPLATFORM_LIBS=md -DENABLE_TESTS=on -DPLATFORM_LIBS=md
+@@ -39,7 +39,6 @@ USE_LDCONFIG=	yes
+ CMAKE_ARGS=	-DENABLE_PIC=on -DPLATFORM_LIBS=md -DENABLE_TESTS=on
  CFLAGS_mips=	-DNO_ATOMICS # cannot use lang/gcc
  CFLAGS_mips64=	-DNO_ATOMICS # cannot use lang/gcc
 -EXTRACT_AFTER_ARGS+=	--exclude "md5*"


### PR DESCRIPTION
Internal c++ implementation is safe enough, has its own X265_NS namespace
different calling argument order etc.
Avoids including -lmd and implicit -lcrypto as deps and unbreaks at least
math/octave-forge-video that uses ffmpeg libavcodec.so

While there, move most of the overrides from MF to MD
(except for extract args hack that should be done as patch: target).

Synth test passes, TestBench seems to be ok.