### PR TITLE
security/krb5-116: Copy over the patches from krb5-115

### DIFF
--- a/ports/security/krb5-116/dragonfly/patch-config_shlib.conf
+++ b/ports/security/krb5-116/dragonfly/patch-config_shlib.conf
@@ -1,0 +1,11 @@
+--- config/shlib.conf.orig	2015-08-05 14:07:38 UTC
++++ config/shlib.conf
+@@ -311,7 +311,7 @@ mips-*-netbsd*)
+ 	PROFFLAGS=-pg
+ 	;;
+ 
+-*-*-freebsd*)
++*-*-freebsd* | *-*-dragonfly*)
+ 	case $krb5_cv_host in
+ 		sparc64-*)
+ 			PICFLAGS=-fPIC

--- a/ports/security/krb5-116/dragonfly/patch-include_gssrpc_rpc.h
+++ b/ports/security/krb5-116/dragonfly/patch-include_gssrpc_rpc.h
@@ -1,0 +1,10 @@
+--- include/gssrpc/rpc.h.orig	2017-03-02 22:06:02 UTC
++++ include/gssrpc/rpc.h
+@@ -39,6 +39,7 @@
+ #ifndef GSSRPC_RPC_H
+ #define GSSRPC_RPC_H
+ 
++#include <sys/socket.h>
+ #include <gssrpc/types.h>		/* some typedefs */
+ #include <netinet/in.h>
+ 

--- a/ports/security/krb5-116/dragonfly/patch-include_krb5_krb5.hin
+++ b/ports/security/krb5-116/dragonfly/patch-include_krb5_krb5.hin
@@ -1,0 +1,20 @@
+--- include/krb5/krb5.hin.orig	2015-05-08 23:27:02 UTC
++++ include/krb5/krb5.hin
+@@ -106,7 +106,7 @@
+ 
+ KRB5INT_BEGIN_DECLS
+ 
+-#if TARGET_OS_MAC
++#if defined(TARGET_OS_MAC) && TARGET_OS_MAC
+ #    pragma pack(push,2)
+ #endif
+ 
+@@ -8161,7 +8161,7 @@ krb5_set_trace_callback(krb5_context con
+ krb5_error_code KRB5_CALLCONV
+ krb5_set_trace_filename(krb5_context context, const char *filename);
+ 
+-#if TARGET_OS_MAC
++#if defined(TARGET_OS_MAC) && TARGET_OS_MAC
+ #    pragma pack(pop)
+ #endif
+ 

--- a/ports/security/krb5-116/dragonfly/patch-lib_gssapi_generic_gssapi.hin
+++ b/ports/security/krb5-116/dragonfly/patch-lib_gssapi_generic_gssapi.hin
@@ -1,0 +1,20 @@
+--- lib/gssapi/generic/gssapi.hin.orig	2015-05-08 23:27:02 UTC
++++ lib/gssapi/generic/gssapi.hin
+@@ -39,7 +39,7 @@
+ extern "C" {
+ #endif /* __cplusplus */
+ 
+-#if TARGET_OS_MAC
++#if defined(TARGET_OS_MAC) && TARGET_OS_MAC
+ #    pragma pack(push,2)
+ #endif
+ 
+@@ -815,7 +815,7 @@ gss_set_neg_mechs(
+     gss_cred_id_t,      /* cred_handle */
+     const gss_OID_set); /* mech_set */
+ 
+-#if TARGET_OS_MAC
++#if defined(TARGET_OS_MAC) && TARGET_OS_MAC
+ #    pragma pack(pop)
+ #endif
+ 

--- a/ports/security/krb5-devel/dragonfly/patch-config_shlib.conf
+++ b/ports/security/krb5-devel/dragonfly/patch-config_shlib.conf
@@ -1,0 +1,11 @@
+--- config/shlib.conf.orig	2015-08-05 14:07:38 UTC
++++ config/shlib.conf
+@@ -311,7 +311,7 @@ mips-*-netbsd*)
+ 	PROFFLAGS=-pg
+ 	;;
+ 
+-*-*-freebsd*)
++*-*-freebsd* | *-*-dragonfly*)
+ 	case $krb5_cv_host in
+ 		sparc64-*)
+ 			PICFLAGS=-fPIC

--- a/ports/security/krb5-devel/dragonfly/patch-include_gssrpc_rpc.h
+++ b/ports/security/krb5-devel/dragonfly/patch-include_gssrpc_rpc.h
@@ -1,0 +1,10 @@
+--- include/gssrpc/rpc.h.orig	2017-03-02 22:06:02 UTC
++++ include/gssrpc/rpc.h
+@@ -39,6 +39,7 @@
+ #ifndef GSSRPC_RPC_H
+ #define GSSRPC_RPC_H
+ 
++#include <sys/socket.h>
+ #include <gssrpc/types.h>		/* some typedefs */
+ #include <netinet/in.h>
+ 

--- a/ports/security/krb5-devel/dragonfly/patch-include_krb5_krb5.hin
+++ b/ports/security/krb5-devel/dragonfly/patch-include_krb5_krb5.hin
@@ -1,0 +1,20 @@
+--- include/krb5/krb5.hin.orig	2015-05-08 23:27:02 UTC
++++ include/krb5/krb5.hin
+@@ -106,7 +106,7 @@
+ 
+ KRB5INT_BEGIN_DECLS
+ 
+-#if TARGET_OS_MAC
++#if defined(TARGET_OS_MAC) && TARGET_OS_MAC
+ #    pragma pack(push,2)
+ #endif
+ 
+@@ -8161,7 +8161,7 @@ krb5_set_trace_callback(krb5_context con
+ krb5_error_code KRB5_CALLCONV
+ krb5_set_trace_filename(krb5_context context, const char *filename);
+ 
+-#if TARGET_OS_MAC
++#if defined(TARGET_OS_MAC) && TARGET_OS_MAC
+ #    pragma pack(pop)
+ #endif
+ 

--- a/ports/security/krb5-devel/dragonfly/patch-lib_gssapi_generic_gssapi.hin
+++ b/ports/security/krb5-devel/dragonfly/patch-lib_gssapi_generic_gssapi.hin
@@ -1,0 +1,20 @@
+--- lib/gssapi/generic/gssapi.hin.orig	2015-05-08 23:27:02 UTC
++++ lib/gssapi/generic/gssapi.hin
+@@ -39,7 +39,7 @@
+ extern "C" {
+ #endif /* __cplusplus */
+ 
+-#if TARGET_OS_MAC
++#if defined(TARGET_OS_MAC) && TARGET_OS_MAC
+ #    pragma pack(push,2)
+ #endif
+ 
+@@ -815,7 +815,7 @@ gss_set_neg_mechs(
+     gss_cred_id_t,      /* cred_handle */
+     const gss_OID_set); /* mech_set */
+ 
+-#if TARGET_OS_MAC
++#if defined(TARGET_OS_MAC) && TARGET_OS_MAC
+ #    pragma pack(pop)
+ #endif
+ 


### PR DESCRIPTION
Same patches apply to new version that was made deafult for krb5.

Synth test, make check passes
(in synth env had to create /etc/hosts file for local hostname lookup)
only one test fails:
./addrinfo-test -p telnet
getaddrinfo(hostname (null), service telnet,
            hints { no-flags }):
        error => servname not supported for ai_socktype