### PR TITLE
net/isc-dhcp44-server: Use localbase.

### DIFF
--- a/ports/net/isc-dhcp44-server/Makefile.DragonFly
+++ b/ports/net/isc-dhcp44-server/Makefile.DragonFly
@@ -1,0 +1,2 @@
+# to help find ssl
+USES+=	localbase


### PR DESCRIPTION
Needed to find implicit -lssl.