### PR TITLE
Fix infinite loop when parsing VIM files

### DIFF
--- a/ports/devel/ctags/dragonfly/patch-vim.c
+++ b/ports/devel/ctags/dragonfly/patch-vim.c
@@ -1,0 +1,13 @@
+--- vim.c.orig	2018-03-26 22:39:12 UTC
++++ vim.c
+@@ -394,6 +394,10 @@ static boolean parseCommand (const unsig
+ 			while (*cp && !isspace ((int) *cp))
+ 				++cp; 
+ 		}
++		else
++		{
++			++cp;	
++		}
+ 	} while ( *cp &&  !isalnum ((int) *cp) );
+ 
+ 	if ( ! *cp )


### PR DESCRIPTION
This is a custom patch to our tree which helps our grok indexing. We can't submit it upstream because the project seems dead.
Maybe FreeBSD could benefit from it as well.