### PR TITLE
Prep for <sgtty.h> removal from base.

### DIFF
--- a/ports/devel/xxgdb/Makefile.DragonFly
+++ b/ports/devel/xxgdb/Makefile.DragonFly
@@ -2,6 +2,7 @@
 # zrj: union wait removal
 dfly-patch:
 	${REINPLACE_CMD} -e 's@\(defined(__FreeBSD__)\)@(\1||defined(__DragonFly__))@g'	\
+		${WRKSRC}/calldbx.c						\
 		${WRKSRC}/command.c						\
 		${WRKSRC}/filemenu.c						\
 		${WRKSRC}/signals.c

--- a/ports/editors/aee/dragonfly/patch-create.mk.aee
+++ b/ports/editors/aee/dragonfly/patch-create.mk.aee
@@ -1,0 +1,20 @@
+--- create.mk.aee.intermediate	2018-04-17 12:36:20.000000000 +0000
++++ create.mk.aee
+@@ -187,7 +187,7 @@ fi
+ if false
+ then
+ 	echo "Neither terminfo or termcap are on this system!  "
+-	if [ -f /usr/include/curses.h ]
++	if [ -f /usr/include/curses.h -o -f /usr/local/include/ncurses/ncurses.h ]
+ 	then
+ 		echo "Relying on local curses implementation."
+ 	else
+@@ -214,7 +214,7 @@ fi
+ if [ -z "$termio" -a -z "$sgtty" ]
+ then
+ 	echo "Neither termio.h or sgtty.h are on this system!  "
+-	if [ -f /usr/include/curses.h ]
++	if [ -f /usr/include/curses.h -o -f /usr/local/include/ncurses/ncurses.h ]
+ 	then
+ 		echo "Relying on local curses implementation."
+ 	else


### PR DESCRIPTION
devel/xxgdb was missing source to patch
editors/aee already has USES=ncurses