### PR TITLE
emulators/qemu - Fix build

### DIFF
--- a/ports/emulators/qemu/dragonfly/patch-disas_libvixl_vixl_utils.h
+++ b/ports/emulators/qemu/dragonfly/patch-disas_libvixl_vixl_utils.h
@@ -1,0 +1,16 @@
+--- disas/libvixl/vixl/utils.h.orig	2016-05-11 18:56:07.000000000 +0300
++++ disas/libvixl/vixl/utils.h
+@@ -42,6 +42,13 @@ namespace vixl {
+ #define PRINTF_CHECK(format_index, varargs_index)
+ #endif
+ 
++#ifndef INT64_C
++#define INT32_C(c) c
++#define INT64_C(c) (c ## LL)
++#define UINT32_C(c) (c ## U)
++#define UINT64_C(c) (c ## ULL)
++#endif
++
+ // Check number width.
+ inline bool is_intn(unsigned n, int64_t x) {
+   VIXL_ASSERT((0 < n) && (n < 64));

--- a/ports/emulators/qemu/dragonfly/patch-hw-ppc_newworld.c
+++ b/ports/emulators/qemu/dragonfly/patch-hw-ppc_newworld.c
@@ -1,0 +1,14 @@
+--- hw/ppc/mac_newworld.c
++++ hw/ppc/mac_newworld.c
+@@ -68,6 +68,11 @@
+ #include "hw/usb.h"
+ #include "blockdev.h"
+ 
++/* FreeBSD headers define this */
++#ifdef round_page
++#undef round_page
++#endif
++
+ #define MAX_IDE_BUS 2
+ #define CFG_ADDR 0xf0000510
+ 

--- a/ports/emulators/qemu/dragonfly/patch-hw_ppc_mac__oldworld.c
+++ b/ports/emulators/qemu/dragonfly/patch-hw_ppc_mac__oldworld.c
@@ -1,0 +1,14 @@
+--- hw/ppc/mac_oldworld.c.orig	2015-04-27 14:08:24 UTC
++++ hw/ppc/mac_oldworld.c
+@@ -49,6 +49,11 @@
+ #define CLOCKFREQ 266000000UL
+ #define BUSFREQ 66000000UL
+ 
++/* FreeBSD headers define this */
++#ifdef round_page
++#undef round_page
++#endif
++
+ static void fw_cfg_boot_set(void *opaque, const char *boot_device,
+                             Error **errp)
+ {


### PR DESCRIPTION
- Please note in order to build emulators/qemu, net/vde2 is required and this
  only builds on latest master/release branches where the BIOCFEEDBACK ioctls
  have been added.