### PR TITLE
Adjust for IPSEC removal.

### DIFF
--- a/ports/net/p5-Socket6/dragonfly/patch-Socket6.xs
+++ b/ports/net/p5-Socket6/dragonfly/patch-Socket6.xs
@@ -1,0 +1,11 @@
+--- Socket6.xs.orig	2016-04-11 03:27:34.000000000 +0000
++++ Socket6.xs
+@@ -64,7 +64,7 @@ const struct in6_addr in6addr_loopback =
+ # include <net/route.h>
+ # if defined(__FreeBSD__) && __FreeBSD_version >= 700048
+ #  include <netipsec/ipsec.h>
+-# elif !defined(__OpenBSD__)
++# elif !defined(__OpenBSD__) && !defined(__DragonFly__)
+ #  include <netinet6/ipsec.h>
+ # endif
+ #endif

--- a/ports/security/ike/Makefile.DragonFly
+++ b/ports/security/ike/Makefile.DragonFly
@@ -1,0 +1,1 @@
+BROKEN=	requires IPSEC

--- a/ports/security/racoon2/Makefile.DragonFly
+++ b/ports/security/racoon2/Makefile.DragonFly
@@ -1,0 +1,1 @@
+BROKEN=	requires IPSEC

--- a/ports/security/strongswan/Makefile.DragonFly
+++ b/ports/security/strongswan/Makefile.DragonFly
@@ -1,0 +1,1 @@
+BROKEN=	requires IPSEC


### PR DESCRIPTION
Mask out security/ ones.
The net/p5-Socket6 does not need the header.