### PR TITLE
Mask out FreeBSD binary ports for raids.

### DIFF
--- a/ports/sysutils/areca-cli/Makefile.DragonFly
+++ b/ports/sysutils/areca-cli/Makefile.DragonFly
@@ -1,0 +1,1 @@
+IGNORE=	This is FreeBSD binary

--- a/ports/sysutils/hptcli/Makefile.DragonFly
+++ b/ports/sysutils/hptcli/Makefile.DragonFly
@@ -1,0 +1,1 @@
+IGNORE=	This is FreeBSD binary

--- a/ports/sysutils/megacli/Makefile.DragonFly
+++ b/ports/sysutils/megacli/Makefile.DragonFly
@@ -1,0 +1,1 @@
+IGNORE=	This is FreeBSD binary

--- a/ports/sysutils/tw_cli/Makefile.DragonFly
+++ b/ports/sysutils/tw_cli/Makefile.DragonFly
@@ -1,0 +1,1 @@
+IGNORE=	This is FreeBSD binary


### PR DESCRIPTION
Statically linked.

Reported-by: swildner