### PR TITLE
Remove all references to fdescfs(5).

### DIFF
--- a/ports/devel/9base/diffs/pkg-message.diff
+++ b/ports/devel/9base/diffs/pkg-message.diff
@@ -1,0 +1,11 @@
+--- pkg-message.orig	2017-07-24 14:14:53 UTC
++++ pkg-message
+@@ -1,7 +1,5 @@
+ ======================================================
+ 
+-Some of 9base tools require fdescfs to be mounted.
+-Please refer manpages fdescfs(5) and fstab(5) to 
+-mount it.
++                      Have fun!
+ 
+ ======================================================

--- a/ports/java/openjdk7/diffs/pkg-message.diff
+++ b/ports/java/openjdk7/diffs/pkg-message.diff
@@ -1,0 +1,22 @@
+--- pkg-message.orig	2015-06-29 09:46:23 UTC
++++ pkg-message
+@@ -1,16 +1,14 @@
+ ======================================================================
+ 
+-This OpenJDK implementation requires fdescfs(5) mounted on /dev/fd and
+-procfs(5) mounted on /proc for some functionality.
++This OpenJDK implementation requires procfs(5) mounted on /proc for
++some functionality.
+ 
+ If you have not done it yet, please do the following:
+ 
+-	mount -t fdescfs fdesc /dev/fd
+ 	mount -t procfs proc /proc
+ 
+-To make it permanent, you need the following lines in /etc/fstab:
++To make it permanent, you need the following line in /etc/fstab:
+ 
+-	fdesc	/dev/fd		fdescfs		rw	0	0
+ 	proc	/proc		procfs		rw	0	0
+ 
+ ======================================================================

--- a/ports/java/openjdk8/diffs/pkg-message.diff
+++ b/ports/java/openjdk8/diffs/pkg-message.diff
@@ -1,0 +1,21 @@
+--- pkg-message.orig	2015-06-29 09:46:24 UTC
++++ pkg-message
+@@ -1,16 +1,13 @@
+ ======================================================================
+ 
+-This OpenJDK implementation requires fdescfs(5) mounted on /dev/fd and
+-procfs(5) mounted on /proc.
++This OpenJDK implementation requires procfs(5) mounted on /proc.
+ 
+ If you have not done it yet, please do the following:
+ 
+-	mount -t fdescfs fdesc /dev/fd
+ 	mount -t procfs proc /proc
+ 
+-To make it permanent, you need the following lines in /etc/fstab:
++To make it permanent, you need the following line in /etc/fstab:
+ 
+-	fdesc	/dev/fd		fdescfs		rw	0	0
+ 	proc	/proc		procfs		rw	0	0
+ 
+ ======================================================================

--- a/ports/mail/spamd/diffs/files_pkg-message.in.diff
+++ b/ports/mail/spamd/diffs/files_pkg-message.in.diff
@@ -1,0 +1,21 @@
+--- files/pkg-message.in.orig	2015-06-29 09:46:33 UTC
++++ files/pkg-message.in
+@@ -13,17 +13,7 @@ To enable spamd you need:
+    spamd.conf.sample file.  Copy then to spamd.conf file and
+    edit to suit your needs.
+ 
+-3) mount fdescfs to /dev/fd with the following line in /etc/fstab
+-	fdescfs  	/dev/fd  	fdescfs rw 	0 	0
+-
+-   Note for XEN users:
+-   The XEN kernel ships without modules, therefore you have to add
+-   the following lines to the kernel config and build a new kernel.
+-	options FDESCFS
+-	device	pf
+-	device	pflog
+-
+-4) Add following lines to the pf.conf(5)
++3) Add following lines to the pf.conf(5)
+ 
+   table <spamd-white> persist
+   no rdr inet proto tcp from <spamd-white> to any \

--- a/ports/shells/bash/diffs/files_pkg-message.in.diff
+++ b/ports/shells/bash/diffs/files_pkg-message.in.diff
@@ -1,0 +1,17 @@
+--- files/pkg-message.in.orig	2017-07-04 12:58:13 UTC
++++ files/pkg-message.in
+@@ -1,13 +1,5 @@
+ ======================================================================
+ 
+-bash requires fdescfs(5) mounted on /dev/fd
+-
+-If you have not done it yet, please do the following:
+-
+-	mount -t fdescfs fdescfs /dev/fd
+-
+-To make it permanent, you need the following lines in /etc/fstab:
+-
+-	fdescfs	/dev/fd		fdescfs		rw,late	0	0
++                               Have fun!
+ 
+ ======================================================================

--- a/ports/textproc/cdif/diffs/pkg-descr.diff
+++ b/ports/textproc/cdif/diffs/pkg-descr.diff
@@ -1,0 +1,9 @@
+--- pkg-descr.orig	2017-07-04 12:58:20 UTC
++++ pkg-descr
+@@ -6,6 +6,4 @@ cdif reads that file (stdin if no file)
+ Lines those don't look like diff output are simply ignored and
+ printed.
+ 
+-Note that this requires fdescfs(5) mounted.
+-
+ WWW: https://github.com/kaz-utashiro/cdif


### PR DESCRIPTION
It was removed long ago and just confuses the users.