### PR TITLE
security/py-cryptography: Add LibreSSL 2.7 support

### DIFF
--- a/ports/security/py-cryptography/dragonfly/patch-issue4168
+++ b/ports/security/py-cryptography/dragonfly/patch-issue4168
@@ -1,0 +1,111 @@
+$OpenBSD: patch-src__cffi_src_openssl_x509_py,v 1.1 2018/02/18 13:44:41 sthen Exp $
+
+Index: src/_cffi_src/openssl/x509.py
+--- src/_cffi_src/openssl/x509.py.orig
++++ src/_cffi_src/openssl/x509.py
+@@ -255,8 +255,7 @@ int X509_get_signature_nid(const X509 *);
+ 
+ const X509_ALGOR *X509_get0_tbs_sigalg(const X509 *);
+ 
+-/* in 1.1.0 becomes const ASN1_BIT_STRING, const X509_ALGOR */
+-void X509_get0_signature(ASN1_BIT_STRING **, X509_ALGOR **, X509 *);
++void X509_get0_signature(const ASN1_BIT_STRING **, const X509_ALGOR **, const X509 *);
+ 
+ long X509_get_version(X509 *);
+ 
+@@ -339,7 +338,8 @@ void X509_REQ_get0_signature(const X509_REQ *, const A
+ CUSTOMIZATIONS = """
+ /* Added in 1.0.2 beta but we need it in all versions now due to the great
+    opaquing. */
+-#if CRYPTOGRAPHY_OPENSSL_LESS_THAN_102
++#if CRYPTOGRAPHY_OPENSSL_LESS_THAN_102 && \
++    (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
+ /* from x509/x_x509.c version 1.0.2 */
+ void X509_get0_signature(ASN1_BIT_STRING **psig, X509_ALGOR **palg,
+                          const X509 *x)
+@@ -383,9 +383,11 @@ X509_REVOKED *Cryptography_X509_REVOKED_dup(X509_REVOK
+    opaquing. */
+ #if CRYPTOGRAPHY_OPENSSL_LESS_THAN_110
+ 
++#if (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
+ int X509_up_ref(X509 *x) {
+    return CRYPTO_add(&x->references, 1, CRYPTO_LOCK_X509);
+ }
++#endif
+ 
+ const X509_ALGOR *X509_get0_tbs_sigalg(const X509 *x)
+ {
+$OpenBSD: patch-src__cffi_src_openssl_x509_vfy_py,v 1.7 2018/02/22 18:49:16 sthen Exp $
+
+Index: src/_cffi_src/openssl/x509_vfy.py
+--- src/_cffi_src/openssl/x509_vfy.py.orig
++++ src/_cffi_src/openssl/x509_vfy.py
+@@ -204,7 +204,7 @@ int sk_X509_OBJECT_num(Cryptography_STACK_OF_X509_OBJE
+ X509_OBJECT *sk_X509_OBJECT_value(Cryptography_STACK_OF_X509_OBJECT *, int);
+ X509_VERIFY_PARAM *X509_STORE_get0_param(X509_STORE *);
+ Cryptography_STACK_OF_X509_OBJECT *X509_STORE_get0_objects(X509_STORE *);
+-X509 *X509_OBJECT_get0_X509(X509_OBJECT *);
++X509 *X509_OBJECT_get0_X509(const X509_OBJECT *);
+ int X509_OBJECT_get_type(const X509_OBJECT *);
+ 
+ /* added in 1.1.0 */
+@@ -220,14 +220,11 @@ static const long Cryptography_HAS_102_VERIFICATION_ER
+ static const long Cryptography_HAS_102_VERIFICATION_PARAMS = 1;
+ #else
+ static const long Cryptography_HAS_102_VERIFICATION_ERROR_CODES = 0;
++#if LIBRESSL_VERSION_NUMBER >= 0x2070000fL
++static const long Cryptography_HAS_102_VERIFICATION_PARAMS = 1;
++#else
+ static const long Cryptography_HAS_102_VERIFICATION_PARAMS = 0;
+ 
+-static const long X509_V_ERR_SUITE_B_INVALID_VERSION = 0;
+-static const long X509_V_ERR_SUITE_B_INVALID_ALGORITHM = 0;
+-static const long X509_V_ERR_SUITE_B_INVALID_CURVE = 0;
+-static const long X509_V_ERR_SUITE_B_INVALID_SIGNATURE_ALGORITHM = 0;
+-static const long X509_V_ERR_SUITE_B_LOS_NOT_ALLOWED = 0;
+-static const long X509_V_ERR_SUITE_B_CANNOT_SIGN_P_384_WITH_P_256 = 0;
+ /* These 3 defines are unavailable in LibreSSL 2.5.x, but may be added
+    in the future... */
+ #ifndef X509_V_ERR_HOSTNAME_MISMATCH
+@@ -240,12 +237,6 @@ static const long X509_V_ERR_EMAIL_MISMATCH = 0;
+ static const long X509_V_ERR_IP_ADDRESS_MISMATCH = 0;
+ #endif
+ 
+-/* X509_V_FLAG_TRUSTED_FIRST is also new in 1.0.2+, but it is added separately
+-   below because it shows up in some earlier 3rd party OpenSSL packages. */
+-static const long X509_V_FLAG_SUITEB_128_LOS_ONLY = 0;
+-static const long X509_V_FLAG_SUITEB_192_LOS = 0;
+-static const long X509_V_FLAG_SUITEB_128_LOS = 0;
+-
+ int (*X509_VERIFY_PARAM_set1_host)(X509_VERIFY_PARAM *, const char *,
+                                    size_t) = NULL;
+ int (*X509_VERIFY_PARAM_set1_email)(X509_VERIFY_PARAM *, const char *,
+@@ -257,6 +248,19 @@ void (*X509_VERIFY_PARAM_set_hostflags)(X509_VERIFY_PA
+                                         unsigned int) = NULL;
+ #endif
+ 
++static const long X509_V_ERR_SUITE_B_INVALID_VERSION = 0;
++static const long X509_V_ERR_SUITE_B_INVALID_ALGORITHM = 0;
++static const long X509_V_ERR_SUITE_B_INVALID_CURVE = 0;
++static const long X509_V_ERR_SUITE_B_INVALID_SIGNATURE_ALGORITHM = 0;
++static const long X509_V_ERR_SUITE_B_LOS_NOT_ALLOWED = 0;
++static const long X509_V_ERR_SUITE_B_CANNOT_SIGN_P_384_WITH_P_256 = 0;
++/* X509_V_FLAG_TRUSTED_FIRST is also new in 1.0.2+, but it is added separately
++   below because it shows up in some earlier 3rd party OpenSSL packages. */
++static const long X509_V_FLAG_SUITEB_128_LOS_ONLY = 0;
++static const long X509_V_FLAG_SUITEB_192_LOS = 0;
++static const long X509_V_FLAG_SUITEB_128_LOS = 0;
++#endif
++
+ /* OpenSSL 1.0.2+ or Solaris's backport */
+ #ifdef X509_V_FLAG_PARTIAL_CHAIN
+ static const long Cryptography_HAS_X509_V_FLAG_PARTIAL_CHAIN = 1;
+@@ -292,7 +296,7 @@ X509 *X509_STORE_CTX_get0_cert(X509_STORE_CTX *ctx)
+     return ctx->cert;
+ }
+ 
+-X509 *X509_OBJECT_get0_X509(X509_OBJECT *x) {
++X509 *X509_OBJECT_get0_X509(const X509_OBJECT *x) {
+     return x->data.x509;
+ }
+ #endif


### PR DESCRIPTION
Unblocks of all things - cmake.
Taken-from: HardenedBSD-ports
https://github.com/HardenedBSD/hardenedbsd-ports/commit/dcf62dd3