### PR TITLE
x11-themes/plasma5-breeze: Exclude wayland component.

### DIFF
--- a/ports/x11-themes/plasma5-breeze/Makefile.DragonFly
+++ b/ports/x11-themes/plasma5-breeze/Makefile.DragonFly
@@ -1,0 +1,1 @@
+USE_KDE:=	${USE_KDE:Nwayland*}


### PR DESCRIPTION
The KF5-wayland is optional component.
Unbreaks x11-themes/plasma5-breeze-kde4 that uses its distfile.