### PR TITLE
security/py-cryptography: Adjust for openssl.

### DIFF
--- a/ports/security/py-cryptography/dragonfly/patch-issue4168
+++ b/ports/security/py-cryptography/dragonfly/patch-issue4168
@@ -27,7 +27,7 @@ Index: src/_cffi_src/openssl/x509.py
     opaquing. */
  #if CRYPTOGRAPHY_OPENSSL_LESS_THAN_110
  
-+#if (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
++#if !(defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x2070000fL)
  int X509_up_ref(X509 *x) {
     return CRYPTO_add(&x->references, 1, CRYPTO_LOCK_X509);
  }


### PR DESCRIPTION
Unbreaks net-im/papyon when built against dports/security/openssl