### PR TITLE
net/freerdp: Fix segfault on DragonFly

### DIFF
--- a/ports/net/freerdp/dragonfly/patch-libfreerdp_core_tcp.c
+++ b/ports/net/freerdp/dragonfly/patch-libfreerdp_core_tcp.c
@@ -1,0 +1,11 @@
+--- libfreerdp/core/tcp.c.orig	2018-07-02 13:30:51 UTC
++++ libfreerdp/core/tcp.c
+@@ -53,7 +53,7 @@
+ #include <sys/filio.h>
+ #endif
+ 
+-#if defined(__FreeBSD__) || defined(__OpenBSD__)
++#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
+ #ifndef SOL_TCP
+ #define SOL_TCP	IPPROTO_TCP
+ #endif

--- a/ports/net/freerdp/dragonfly/patch-winpr_libwinpr_winsock_winsock.c
+++ b/ports/net/freerdp/dragonfly/patch-winpr_libwinpr_winsock_winsock.c
@@ -1,0 +1,20 @@
+--- winpr/libwinpr/winsock/winsock.c.orig	2018-07-02 19:26:00 UTC
++++ winpr/libwinpr/winsock/winsock.c
+@@ -1102,10 +1102,15 @@ int _recvfrom(SOCKET s, char* buf, int l
+ {
+ 	int status;
+ 	int fd = (int) s;
+-	socklen_t s_fromlen = (socklen_t) *fromlen;
++	socklen_t s_fromlen;
++
++	if (fromlen)
++		s_fromlen = *fromlen;
+ 
+ 	status = (int) recvfrom(fd, (void*) buf, (size_t) len, flags, from, &s_fromlen);
+-	*fromlen = (int) s_fromlen;
++
++	if (fromlen)
++		*fromlen = (int) s_fromlen;
+ 
+ 	return status;
+ }


### PR DESCRIPTION
Just by running the 'xfreerdp' binary there is a segfault, the program is unusable. With the patches on this PR a RDP connection to a Windows 7 box can be established and seems usable.