### PR TITLE
devel/libcxxrt - Resurrect libcxxrt

### DIFF
--- a/ports/devel/libcxxrt/newport/libcxxrt/Makefile
+++ b/ports/devel/libcxxrt/newport/libcxxrt/Makefile
@@ -1,0 +1,27 @@
+# $FreeBSD$
+
+PORTNAME=	libcxxrt
+PORTVERSION=	20180311
+CATEGORIES=	devel
+
+MAINTAINER=	mmokhi@FreeBSD.org
+COMMENT=	Implementation of the Code Sourcery C++ ABI
+
+LICENSE=	BSD2CLAUSE
+
+USES=		cmake compiler:c++11-lang
+
+USE_GITHUB=	yes
+GH_ACCOUNT=	pathscale
+GH_TAGNAME=	f96846e
+
+USE_LDCONFIG=	yes
+CXXFLAGS+=	-nostdlib
+
+do-install:
+	${INSTALL_LIB} ${WRKSRC}/lib/libcxxrt.so ${STAGEDIR}${PREFIX}/lib
+	${INSTALL_DATA} ${WRKSRC}/lib/libcxxrt.a ${STAGEDIR}${PREFIX}/lib
+	@${MKDIR} ${STAGEDIR}${PREFIX}/include/cxxrt
+	${INSTALL_DATA} ${WRKSRC}/src/*.h ${STAGEDIR}${PREFIX}/include/cxxrt
+
+.include <bsd.port.mk>

--- a/ports/devel/libcxxrt/newport/libcxxrt/distinfo
+++ b/ports/devel/libcxxrt/newport/libcxxrt/distinfo
@@ -1,0 +1,3 @@
+TIMESTAMP = 1533890297
+SHA256 (pathscale-libcxxrt-20180311-f96846e_GH0.tar.gz) = c79c79f00fcb5d5467b4e9c74706e9d1c95938c88ceca82caed9a97c1f8bfa6d
+SIZE (pathscale-libcxxrt-20180311-f96846e_GH0.tar.gz) = 73778

--- a/ports/devel/libcxxrt/newport/libcxxrt/pkg-descr
+++ b/ports/devel/libcxxrt/newport/libcxxrt/pkg-descr
@@ -1,0 +1,8 @@
+This library implements the Code Sourcery C++ ABI, as documented here:
+
+WWW: http://www.codesourcery.com/public/cxx-abi/abi.html
+
+It is intended to sit below an STL implementation, and provide features required
+by the compiler for implementation of the C++ language.
+
+WWW: https://github.com/pathscale/libcxxrt

--- a/ports/devel/libcxxrt/newport/libcxxrt/pkg-plist
+++ b/ports/devel/libcxxrt/newport/libcxxrt/pkg-plist
@@ -1,0 +1,11 @@
+include/cxxrt/abi_namespace.h
+include/cxxrt/atomic.h
+include/cxxrt/cxxabi.h
+include/cxxrt/dwarf_eh.h
+include/cxxrt/stdexcept.h
+include/cxxrt/typeinfo.h
+include/cxxrt/unwind-arm.h
+include/cxxrt/unwind-itanium.h
+include/cxxrt/unwind.h
+lib/libcxxrt.a
+lib/libcxxrt.so


### PR DESCRIPTION
- It will be used to build devel/libc++ which in turn will be used
  to build newer chromium versions.