### PR TITLE
emulators/qemu - Disable the stack protector for now.

### DIFF
--- a/ports/emulators/qemu/Makefile.DragonFly
+++ b/ports/emulators/qemu/Makefile.DragonFly
@@ -1,1 +1,2 @@
 NCURSES_USES=		ncurses
+CONFIGURE_ARGS+=        --disable-stack-protector


### PR DESCRIPTION
If built with gcc80 (which is the default now), qemu will SIGABRT
when booting from an ISO/IMG. There seems to be a bug which we can't
quite find yet so this is a workaround.
Note that when building with gcc50 we don't see this problem.