### PR TITLE
net/freerdp - Fix build

### DIFF
--- a/ports/net/freerdp/dragonfly/patch-CMakeLists.txt
+++ b/ports/net/freerdp/dragonfly/patch-CMakeLists.txt
@@ -1,0 +1,37 @@
+--- CMakeLists.txt.orig	2018-10-18 22:53:01 UTC
++++ CMakeLists.txt
+@@ -204,10 +204,10 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "DragonF
+ 	set(FREEBSD TRUE)
+ endif()
+ 
+-if(FREEBSD)
+-	find_path(EPOLLSHIM_INCLUDE_DIR NAMES sys/epoll.h sys/timerfd.h HINTS /usr/local/include/libepoll-shim)
+-	find_library(EPOLLSHIM_LIBS NAMES epoll-shim libepoll-shim HINTS /usr/local/lib)
+-endif()
++#if(FREEBSD)
++#	find_path(EPOLLSHIM_INCLUDE_DIR NAMES sys/epoll.h sys/timerfd.h HINTS /usr/local/include/libepoll-shim)
++#	find_library(EPOLLSHIM_LIBS NAMES epoll-shim libepoll-shim HINTS /usr/local/lib)
++#endif()
+ 
+ # Configure MSVC Runtime
+ if(MSVC)
+@@ -654,13 +654,13 @@ if(UNIX OR CYGWIN)
+ 	if (HAVE_SYS_EVENTFD_H)
+ 		check_symbol_exists(eventfd_read sys/eventfd.h WITH_EVENTFD_READ_WRITE)
+ 	endif()
+-	if (FREEBSD)
+-		list(APPEND CMAKE_REQUIRED_INCLUDES ${EPOLLSHIM_INCLUDE_DIR})
+-	endif()
++#	if (FREEBSD)
++#		list(APPEND CMAKE_REQUIRED_INCLUDES ${EPOLLSHIM_INCLUDE_DIR})
++#	endif()
+ 	check_include_files(sys/timerfd.h HAVE_SYS_TIMERFD_H)
+-	if (FREEBSD)
+-		list(REMOVE_ITEM CMAKE_REQUIRED_INCLUDES ${EPOLLSHIM_INCLUDE_DIR})
+-	endif()
++#	if (FREEBSD)
++#		list(REMOVE_ITEM CMAKE_REQUIRED_INCLUDES ${EPOLLSHIM_INCLUDE_DIR})
++#	endif()
+ 	check_include_files(poll.h HAVE_POLL_H)
+ 	list(APPEND CMAKE_REQUIRED_LIBRARIES m)
+ 	check_symbol_exists(ceill math.h HAVE_MATH_C99_LONG_DOUBLE)


### PR DESCRIPTION
Please note that this only fixes the build, it will not actually work since
it requires a waitable timer to work. There are several options:

1) Port deve/libepoll-shim to DragonFly (requires quite some work)
2) Have POSIX timers implemented in DragonFly (there is some work done already)
3) Implement InitializeWaitableTimer() with kevent(2)

We will likely go for option 3, this patch will make it easier to build and
test patches.

    [ERROR][com.winpr.synch.timer] - InitializeWaitableTimer: os specific
                                     implementation is missing