### PR TITLE
www/webkit-gtk2: Add -fno-delete-null-pointer-checks to CXXFLAGS

### DIFF
--- a/ports/www/webkit-gtk2/Makefile.DragonFly
+++ b/ports/www/webkit-gtk2/Makefile.DragonFly
@@ -1,6 +1,8 @@
 # zrj: too noisy on gcc80
+# tuxillo: Added -fno-delete-null-pointer-checks (see: https://bugzilla.redhat.com/show_bug.cgi?id=1320240)
 .if exists (/usr/libexec/gcc80/CC)
 CXXFLAGS+=	-Wno-expansion-to-defined -Wno-class-memaccess
+CXXFLAGS+=	-fno-delete-null-pointer-checks
 .endif
 
 dfly-patch:


### PR DESCRIPTION
- Fixes a crash during startup for www/midori.
- Seen in: https://bugzilla.redhat.com/show_bug.cgi?id=1320240