### PR TITLE
devel/libvirt: Fix QEMU option

### DIFF
--- a/ports/devel/libvirt/dragonfly/patch-configure
+++ b/ports/devel/libvirt/dragonfly/patch-configure
@@ -1,0 +1,28 @@
+--- configure.orig	2018-10-01 15:16:11 UTC
++++ configure
+@@ -58178,6 +58178,7 @@ case $host in
+   *-*-linux*) with_linux=yes ;;
+   *-*-darwin*) with_osx=yes ;;
+   *-*-freebsd*) with_freebsd=yes ;;
++  *-*-dragonfly*) with_freebsd=yes ;;
+   *-*-mingw* | *-*-msvc* ) with_win=yes ;;
+   *-*-cygwin*) with_cygwin=yes ;;
+ esac
+@@ -60695,7 +60696,7 @@ done
+ 
+ 
+   ACL_CFLAGS=""
+-  ACL_LIBS=""
++  ACL_LIBS="-lposix1e"
+   with_acl=no
+   if test "x$ac_cv_header_sys_acl_h:x$with_linux" = "xyes:xyes"; then
+     ACL_LIBS="-lacl"
+@@ -76042,7 +76043,7 @@ fi
+ ac_fn_c_check_decl "$LINENO" "BRDGADD" "ac_cv_have_decl_BRDGADD" "#include <stdint.h>
+                 #include <net/if.h>
+                 #include <net/ethernet.h>
+-                #include <net/if_bridgevar.h>
++                #include <net/bridge/if_bridgevar.h>
+ 
+ "
+ if test "x$ac_cv_have_decl_BRDGADD" = xyes; then :

--- a/ports/devel/libvirt/dragonfly/patch-src_qemu_qemu__process.c
+++ b/ports/devel/libvirt/dragonfly/patch-src_qemu_qemu__process.c
@@ -1,0 +1,11 @@
+--- src/qemu/qemu_process.c.orig	2018-10-31 15:17:57 UTC
++++ src/qemu/qemu_process.c
+@@ -27,7 +27,7 @@
+ #include <sys/stat.h>
+ #if defined(__linux__)
+ # include <linux/capability.h>
+-#elif defined(__FreeBSD__)
++#elif defined(__FreeBSD__) && !defined(__DragonFly__)
+ # include <sys/param.h>
+ # include <sys/cpuset.h>
+ #endif

--- a/ports/devel/libvirt/dragonfly/patch-src_util_virnetdevbridge.c
+++ b/ports/devel/libvirt/dragonfly/patch-src_util_virnetdevbridge.c
@@ -1,0 +1,52 @@
+--- src/util/virnetdevbridge.c.orig	2018-11-05 11:30:03 UTC
++++ src/util/virnetdevbridge.c
+@@ -69,7 +69,7 @@
+ 
+ #if defined(HAVE_BSD_BRIDGE_MGMT)
+ # include <net/ethernet.h>
+-# include <net/if_bridgevar.h>
++# include <net/bridge/if_bridgevar.h>
+ #endif
+ 
+ #define VIR_FROM_THIS VIR_FROM_NONE
+@@ -579,6 +579,12 @@ int virNetDevBridgeAddPort(const char *b
+                            const char *ifname)
+ {
+     struct ifbreq req;
++#if defined(__DragonFly__)
++    struct ifreq ifr;
++    int flags, s;
++
++    memset(&ifr, 0, sizeof(ifr));
++#endif
+ 
+     memset(&req, 0, sizeof(req));
+     if (virStrcpyStatic(req.ifbr_ifsname, ifname) < 0) {
+@@ -588,6 +594,27 @@ int virNetDevBridgeAddPort(const char *b
+         return -1;
+     }
+ 
++#if defined(__DragonFly__)
++    snprintf(ifr.ifr_name, IF_NAMESIZE, "%s", ifname);
++
++    if ((s = socket(AF_LOCAL, SOCK_DGRAM, 0)) < 0) {
++      virReportSystemError(errno, "%s",
++                             _("Cannot open network interface control socket"));
++      return -1;
++    }
++
++    /* Set the interface UP */
++    flags = IFF_UP;
++    ifr.ifr_flags |= flags & 0xFFFF;
++    ifr.ifr_flagshigh |= flags >> 16;
++    if (ioctl(s, SIOCSIFFLAGS, &ifr) < 0) {
++      perror("SIOCSIFFLAGS");
++      close(s);
++      return -1;
++    }
++    close(s);
++#endif
++
+     if (virNetDevBridgeCmd(brname, BRDGADD, &req, sizeof(req)) < 0) {
+         virReportSystemError(errno,
+                              _("Unable to add bridge %s port %s"), brname, ifname);


### PR DESCRIPTION
- Identify as freebsd in configure, too.
- To add a member to bridge(4) it has to be up.

Note: This requires dragonly master after commit baf84f0ae5e (Nov 5th 2018)