### PR TITLE
Change the location of input.h.

### DIFF
--- a/ports/x11-toolkits/gtk30/dragonfly/patch-gdk_wayland_gdkdevice-wayland.c
+++ b/ports/x11-toolkits/gtk30/dragonfly/patch-gdk_wayland_gdkdevice-wayland.c
@@ -9,7 +9,7 @@
  #include <sys/time.h>
  #include <sys/mman.h>
 -#include <linux/input.h>
-+#include <dev/misc/evdev/input.h>
++#include <compat/linux/input.h>
  
  #define BUTTON_BASE (BTN_LEFT - 1) /* Used to translate to 1-indexed buttons */
  


### PR DESCRIPTION
* Starting with DragonFly 5.4.0, we export input.h to userland at

  /usr/include/compat/linux

  in the long run, this will reduce the number patches for both dports and ravenports.