### PR TITLE
security/fakeroot - Fix some ACL warnings

### DIFF
--- a/ports/security/fakeroot/Makefile.DragonFly
+++ b/ports/security/fakeroot/Makefile.DragonFly
@@ -1,0 +1,1 @@
+CONFIGURE_ENV+=  LIBS="-lposix1e"


### PR DESCRIPTION
Link against -lposix1e to silence some warnings about ACLs.