### PR TITLE
lang/libobjc2 - Fix build

### DIFF
--- a/ports/lang/libobjc2/dragonfly/patch-CMakeLists.txt
+++ b/ports/lang/libobjc2/dragonfly/patch-CMakeLists.txt
@@ -1,0 +1,29 @@
+--- CMakeLists.txt.orig	2015-08-07 11:33:41 UTC
++++ CMakeLists.txt
+@@ -4,6 +4,8 @@ cmake_minimum_required(VERSION 2.8)
+ project(libobjc)
+ enable_language(ASM)
+ 
++INCLUDE (CheckCXXSourceCompiles)
++
+ set(CMAKE_C_FLAGS_DEBUG "-g -O0 -fno-inline ${CMAKE_C_FLAGS_DEBUG}")
+ set(CMAKE_C_FLAGS_RELEASE "-O3 ${CMAKE_C_FLAGS_RELEASE}")
+ set(CMAKE_C_FLAGS "-std=gnu99 ${CMAKE_C_FLAGS}")
+@@ -370,3 +372,17 @@ if (TESTS)
+ 	add_subdirectory(Test)
+ endif (TESTS)
+ 
++CHECK_CXX_SOURCE_COMPILES("
++	#include <stdlib.h>
++	extern \"C\" {
++	__attribute__((weak))
++	void *__cxa_allocate_exception(size_t thrown_size) noexcept;
++	}
++	#include <exception>
++	int main() { return 0; }" CXA_ALLOCATE_EXCEPTION_NOEXCEPT_COMPILES)
++
++if (CXA_ALLOCATE_EXCEPTION_NOEXCEPT_COMPILES)
++	add_definitions(-DCXA_ALLOCATE_EXCEPTION_SPECIFIER=noexcept)
++else ()
++	add_definitions(-DCXA_ALLOCATE_EXCEPTION_SPECIFIER=)
++endif ()

--- a/ports/lang/libobjc2/dragonfly/patch-objcxx__eh.cc
+++ b/ports/lang/libobjc2/dragonfly/patch-objcxx__eh.cc
@@ -1,0 +1,19 @@
+--- objcxx_eh.cc.orig	2019-01-30 15:03:04 UTC
++++ objcxx_eh.cc
+@@ -8,6 +8,7 @@ extern "C"
+ {
+ #include "objc/runtime.h"
+ };
++#ifndef _TYPEINFO
+ namespace __cxxabiv1
+ {
+ 	struct __class_type_info;
+@@ -48,7 +49,7 @@ namespace std
+ 				                void **thrown_object) const;
+ 	};
+ }
+-
++#endif
+ using namespace std;
+ 
+ 

--- a/ports/lang/libobjc2/dragonfly/patch-objcxx__eh.h
+++ b/ports/lang/libobjc2/dragonfly/patch-objcxx__eh.h
@@ -1,0 +1,22 @@
+--- objcxx_eh.h.orig	2015-08-07 11:33:41 UTC
++++ objcxx_eh.h
+@@ -5,8 +5,18 @@ extern "C" {
+  * Allocates a C++ exception.  This function is part of the Itanium C++ ABI and
+  * is provided externally.
+  */
++/*
++ * Note: Recent versions of libsupc++ already provide a prototype for
++ * __cxa__allocate_exception(). Since the libsupc++ version is defined with
++ * _GLIBCXX_NOTHROW, clang gives a type mismatch error.
++ */
++#ifndef __cplusplus
++#undef CXA_ALLOCATE_EXCEPTION_SPECIFIER
++#define CXA_ALLOCATE_EXCEPTION_SPECIFIER
++#endif
+ __attribute__((weak))
+-void *__cxa_allocate_exception(size_t thrown_size);
++void *__cxa_allocate_exception(size_t thrown_size) CXA_ALLOCATE_EXCEPTION_SPECIFIER;
++
+ /**
+  * Initialises an exception object returned by __cxa_allocate_exception() for
+  * storing an Objective-C object.  The return value is the location of the


### PR DESCRIPTION
- Commit 682717b from gnustep/libobjc2 from GitHub
- Only define type_info the typeinfo header is not included already.
- This is untested, only fixes the build.