### PR TITLE
nginx-devel: Unbreak building.

### DIFF
--- a/ports/www/nginx-devel/dragonfly/patch-src_os_unix_ngx__file__aio__read.c
+++ b/ports/www/nginx-devel/dragonfly/patch-src_os_unix_ngx__file__aio__read.c
@@ -1,0 +1,11 @@
+--- src/os/unix/ngx_file_aio_read.c.orig	2018-10-24 18:29:08.441786000 +0200
++++ src/os/unix/ngx_file_aio_read.c	2018-10-24 18:29:37.032383000 +0200
+@@ -110,7 +110,7 @@ ngx_file_aio_read(ngx_file_t *file, u_ch
+ #if (NGX_HAVE_KQUEUE)
+     aio->aiocb.aio_sigevent.sigev_notify_kqueue = ngx_kqueue;
+     aio->aiocb.aio_sigevent.sigev_notify = SIGEV_KEVENT;
+-    aio->aiocb.aio_sigevent.sigev_value.sigval_ptr = ev;
++    aio->aiocb.aio_sigevent.sigev_value.sival_ptr = ev;
+ #endif
+     ev->handler = ngx_file_aio_event_handler;
+ 


### PR DESCRIPTION
This patch has been upstreamed; and should be removed upon 1.15.9.