### PR TITLE
devel/meson: Attempt to fix unconditional RUNPATH deletion.

### DIFF
--- a/ports/devel/meson/dragonfly/patch-messon
+++ b/ports/devel/meson/dragonfly/patch-messon
@@ -1,0 +1,57 @@
+--- mesonbuild/scripts/depfixer.py.orig	2018-12-09 14:27:16 UTC
++++ mesonbuild/scripts/depfixer.py
+@@ -15,6 +15,7 @@
+ 
+ import sys, struct
+ import shutil, subprocess
++import platform
+ 
+ from ..mesonlib import OrderedSet
+ 
+@@ -293,6 +294,32 @@ class Elf(DataSizes):
+         self.fix_rpathtype_entry(new_rpath, DT_RPATH)
+         self.fix_rpathtype_entry(new_rpath, DT_RUNPATH)
+ 
++    def adjust_new_rpath(self, old, new):
++        if platform.system().lower() == 'dragonfly':
++            # Compiler implictly might set rpaths like:
++            # /lib/priv/
++            # /usr/lib/priv/
++            # /usr/lib/gcc80/
++            # /usr/local/foo/bar/
++            baseprefix = ["/lib", "/usr/lib", "/usr/local"]
++            if not isinstance(old, str):
++                old = old.decode()
++            oldlist = old.split(":")
++            base = []
++            for path in oldlist:
++                if path.startswith(tuple(baseprefix)):
++                    base.append(path)
++            # Prepend base paths from old_rpath first.
++            if base:
++                if new:
++                    if not isinstance(new, str):
++                        new = new.decode()
++                    return ":".join(base) + ":" + new
++                else:
++                    return ":".join(base)
++        # No adjustments.
++        return new;
++
+     def fix_rpathtype_entry(self, new_rpath, entrynum):
+         if isinstance(new_rpath, str):
+             new_rpath = new_rpath.encode('utf8')
+@@ -303,6 +330,13 @@ class Elf(DataSizes):
+             return
+         self.bf.seek(rp_off)
+         old_rpath = self.read_str()
++
++        # Try to adjust new_rpath, if there was previous rpath.
++        if old_rpath:
++            new_rpath = self.adjust_new_rpath(old_rpath, new_rpath)
++            if isinstance(new_rpath, str):
++                new_rpath = new_rpath.encode('utf8')
++
+         if len(old_rpath) < len(new_rpath):
+             sys.exit("New rpath must not be longer than the old one.")
+         # The linker does read-only string deduplication. If there is a


### PR DESCRIPTION
This should unbreak several things. We need to preserve rpaths
for compiler implicit things like -L/usr/lib/gcc80/ etc.