### PR TITLE
Do not use <sys/termios.h>, use <termios.h>.

### DIFF
--- a/ports/devel/9base/dragonfly/patch-lib9_readcons.c
+++ b/ports/devel/9base/dragonfly/patch-lib9_readcons.c
@@ -1,0 +1,12 @@
+--- lib9/readcons.c.orig	2010-06-04 10:46:05 UTC
++++ lib9/readcons.c
+@@ -2,7 +2,9 @@
+ #define NOPLAN9DEFINES
+ #include <libc.h>
+ #include <termios.h>
++#if !defined(__DragonFly__) && !defined(__FreeBSD__)
+ #include <sys/termios.h>
++#endif
+ 
+ static int
+ rawx(int fd, int echoing)

--- a/ports/devel/anjuta/dragonfly/patch-libanjuta_anjuta-utils.c
+++ b/ports/devel/anjuta/dragonfly/patch-libanjuta_anjuta-utils.c
@@ -1,0 +1,14 @@
+--- libanjuta/anjuta-utils.c.intermediate	2019-03-20 08:26:29 UTC
++++ libanjuta/anjuta-utils.c
+@@ -39,7 +39,11 @@
+ #include <sys/stat.h>
+ #include <sys/types.h>
+ #include <sys/fcntl.h>
++#if !defined(__DragonFly__) && !defined(__FreeBSD__)
+ #include <sys/termios.h>
++#else
++#include <termios.h>
++#endif
+ #include <dirent.h>
+ #include <unistd.h>
+ #include <stdio.h>

--- a/ports/devel/libfixposix/dragonfly/patch-src_lib_ioctl.c
+++ b/ports/devel/libfixposix/dragonfly/patch-src_lib_ioctl.c
@@ -1,0 +1,14 @@
+--- src/lib/ioctl.c.orig	2018-02-19 22:24:10 UTC
++++ src/lib/ioctl.c
+@@ -30,7 +30,11 @@
+ #include <lfp/errno.h>
+ 
+ #include <string.h>
++#if !defined(__DragonFly__) && !defined(__FreeBSD__)
+ #include <sys/termios.h>
++#else
++#include <termios.h>
++#endif
+ 
+ DSO_PUBLIC int
+ lfp_tty_attach(const char *path)

--- a/ports/devel/libfixposix/dragonfly/patch-src_lib_spawnattr.c
+++ b/ports/devel/libfixposix/dragonfly/patch-src_lib_spawnattr.c
@@ -1,0 +1,14 @@
+--- src/lib/spawnattr.c.orig	2018-02-19 22:24:10 UTC
++++ src/lib/spawnattr.c
+@@ -33,7 +33,11 @@
+ #include <stdio.h>
+ #include <limits.h>
+ #include <sys/ioctl.h>
++#if !defined(__DragonFly__) && !defined(__FreeBSD__)
+ #include <sys/termios.h>
++#else
++#include <termios.h>
++#endif
+ 
+ #include "spawn.h"
+ 

--- a/ports/devel/p5-Term-Size/dragonfly/patch-Size.xs
+++ b/ports/devel/p5-Term-Size/dragonfly/patch-Size.xs
@@ -1,0 +1,11 @@
+--- Size.xs.orig	2008-08-16 14:05:36 UTC
++++ Size.xs
+@@ -6,7 +6,7 @@ extern "C" {
+ #include "perl.h"
+ #include "XSUB.h"
+ 
+-#ifndef _AIX
++#if !defined(_AIX) && !defined(__DragonFly__) && !defined(__FreeBSD__)
+ #include <sys/termios.h>
+ #else
+ #include <termios.h>

--- a/ports/devel/qca/dragonfly/patch-src_support_console.cpp
+++ b/ports/devel/qca/dragonfly/patch-src_support_console.cpp
@@ -1,0 +1,11 @@
+--- src/support/console.cpp.orig	2017-02-06 12:29:44 UTC
++++ src/support/console.cpp
+@@ -30,7 +30,7 @@
+ #ifdef Q_OS_WIN
+ # include <windows.h>
+ #else
+-# ifdef Q_OS_ANDROID
++# if defined(Q_OS_ANDROID) || defined(Q_OS_FREEBSD)
+ #  include <termios.h>
+ # else
+ #  include <sys/termios.h>

--- a/ports/dns/totd/dragonfly/patch-totd.h
+++ b/ports/dns/totd/dragonfly/patch-totd.h
@@ -1,0 +1,14 @@
+--- totd.h.orig	2005-01-29 18:51:36 UTC
++++ totd.h
+@@ -49,7 +49,11 @@
+ #ifdef HAVE_SYS_SOCKIO_H
+ #include <sys/sockio.h>
+ #endif
++#if !defined(__DragonFly__) && !defined(__FreeBSD__)
+ #include <sys/termios.h>
++#else
++#include <termios.h>
++#endif
+ #include <net/if.h>
+ #include <netinet/in.h>
+ #include <arpa/inet.h>

--- a/ports/emulators/stella/dragonfly/patch-src_unix_SerialPortUNIX.cxx
+++ b/ports/emulators/stella/dragonfly/patch-src_unix_SerialPortUNIX.cxx
@@ -1,0 +1,14 @@
+--- src/unix/SerialPortUNIX.cxx.orig	2018-06-10 12:14:00 UTC
++++ src/unix/SerialPortUNIX.cxx
+@@ -19,7 +19,11 @@
+ #include <sys/stat.h>
+ #include <fcntl.h>
+ #include <unistd.h>
++#if !defined(__DragonFly__) && !defined(_FreeBSD__)
+ #include <sys/termios.h>
++#else
++#include <termios.h>
++#endif
+ #include <sys/types.h>
+ #include <sys/ioctl.h>
+ #include <cstring>

--- a/ports/games/tads/dragonfly/patch-osunixt.h
+++ b/ports/games/tads/dragonfly/patch-osunixt.h
@@ -1,0 +1,11 @@
+--- osunixt.h.intermediate	2019-03-20 08:42:18 UTC
++++ osunixt.h
+@@ -105,7 +105,7 @@ Tue Nov 22 15:16:10 EST 1994    Dave Bag
+ #define OS_ULONG_DEFINED
+ #endif
+ 
+-#if defined(SGI_IRIX) || defined(LINUX_386) || defined(IBM_AIX)
++#if defined(SGI_IRIX) || defined(LINUX_386) || defined(IBM_AIX) || defined(FREEBSD_386)
+ #define TERMIOS_IS_NOT_IN_SYS
+ #endif
+ 

--- a/ports/games/tbclock/dragonfly/patch-draw.c
+++ b/ports/games/tbclock/dragonfly/patch-draw.c
@@ -1,0 +1,14 @@
+--- draw.c.orig	2007-02-28 13:23:47
++++ draw.c
+@@ -27,7 +27,11 @@
+ 
+ 
+ #include <sys/ioctl.h>
++#if !defined(__DragonFly__) && !defined(__FreeBSD__)
+ #include <sys/termios.h>
++#else
++#include <termios.h>
++#endif
+ 
+ #include <unistd.h>
+ #include <string.h>

--- a/ports/games/uhexen/dragonfly/patch-src_i__fbsdvideo.c
+++ b/ports/games/uhexen/dragonfly/patch-src_i__fbsdvideo.c
@@ -1,0 +1,11 @@
+--- src/i_fbsdvideo.c.orig	2001-12-02 08:51:58 UTC
++++ src/i_fbsdvideo.c
+@@ -8,7 +8,7 @@
+ #include <sys/fbio.h>
+ #include <sys/kbio.h>
+ #include <sys/consio.h>
+-#include <sys/termios.h>
++#include <termios.h>
+ #include <sys/mman.h>
+ #include <stdlib.h>
+ #include <unistd.h>

--- a/ports/graphics/hiptext/dragonfly/patch-artiste.cc
+++ b/ports/graphics/hiptext/dragonfly/patch-artiste.cc
@@ -1,0 +1,14 @@
+--- artiste.cc.intermediate	2019-03-20 08:11:50 UTC
++++ artiste.cc
+@@ -7,7 +7,11 @@
+ #include <stdio.h>
+ #include <signal.h>
+ #include <sys/ioctl.h>
++#if !defined(__DragonFly__) && !defined(__FreeBSD__)
+ #include <sys/termios.h>
++#else
++#include <termios.h>
++#endif
+ #include <sys/select.h>
+ #include <gflags/gflags.h>
+ #include <glog/logging.h>

--- a/ports/irc/epic4/dragonfly/patch-source_term.c
+++ b/ports/irc/epic4/dragonfly/patch-source_term.c
@@ -1,0 +1,11 @@
+--- source/term.c.orig	2013-02-17 13:04:18 UTC
++++ source/term.c
+@@ -57,7 +57,7 @@
+  */
+ 
+ 
+-#ifdef _ALL_SOURCE
++#if defined(_ALL_SOURCE) || defined(__DragonFly__) || defined(__FreeBSD__)
+ #include <termios.h>
+ #else
+ #include <sys/termios.h>

--- a/ports/irc/epic4/dragonfly/patch-source_wserv.c
+++ b/ports/irc/epic4/dragonfly/patch-source_wserv.c
@@ -1,0 +1,11 @@
+--- source/wserv.c.orig	2003-04-24 22:04:51 UTC
++++ source/wserv.c
+@@ -45,7 +45,7 @@
+ #include "config.h"
+ #include "irc_std.h"
+ #include <sys/ioctl.h>
+-#ifdef _ALL_SOURCE
++#if defined(_ALL_SOURCE) || defined(__DragonFly__) || defined(__FreeBSD__)
+ #include <termios.h>
+ #else
+ #include <sys/termios.h>

--- a/ports/japanese/edict/dragonfly/patch-xjdfrontend.c
+++ b/ports/japanese/edict/dragonfly/patch-xjdfrontend.c
@@ -1,0 +1,15 @@
+--- xjdfrontend.c.intermediate	2019-03-19 15:50:43 UTC
++++ xjdfrontend.c
+@@ -37,8 +37,12 @@ order to enable this, people should comp
+ #include <sgtty.h>
+ #else
+ #ifdef __POSIX__
++#if !defined(__DragonFly__) && !defined(__FreeBSD__)
+ #include <sys/termios.h>
+ #else
++#include <termios.h>
++#endif
++#else
+ #include <termio.h>
+ #endif
+ #endif

--- a/ports/lang/rexx-imc/dragonfly/patch-interface.c
+++ b/ports/lang/rexx-imc/dragonfly/patch-interface.c
@@ -1,0 +1,14 @@
+--- interface.c.orig	2000-11-01 18:04:27 UTC
++++ interface.c
+@@ -20,7 +20,11 @@
+ #include <sys/uio.h>
+ #endif
+ #ifdef STUFF_STACK
++#if !defined(__DragonFly__) && !defined(__FreeBSD__)
+ #include<sys/termios.h>
++#else
++#include <termios.h>
++#endif
+ #endif
+ 
+ struct status{        /* Saved things from a previous incarnation of REXX */

--- a/ports/mail/xmail/Makefile.DragonFly
+++ b/ports/mail/xmail/Makefile.DragonFly
@@ -1,1 +1,0 @@
-USES+= alias

--- a/ports/mail/xmail/dragonfly/patch-callMail.c
+++ b/ports/mail/xmail/dragonfly/patch-callMail.c
@@ -1,0 +1,36 @@
+--- callMail.c.intermediate	2019-03-20 07:40:44 UTC
++++ callMail.c
+@@ -38,10 +38,14 @@
+ #include	<sys/select.h>
+ #endif
+ 
+-#if	!(defined(SYSV) || defined(linux) || defined(__FreeBSD__)) || defined(clipper)
++#if	!(defined(SYSV) || defined(linux) || defined(__FreeBSD__) || defined(__DragonFly__)) || defined(clipper)
+ #include	<sgtty.h>
+ #else
++#if !defined(__FreeBSD__) && !defined(__DragonFly__)
+ #include	<sys/termios.h>
++#else
++#include	<termios.h>
++#endif
+ #include	<fcntl.h>
+ #if	defined(att)
+ #include	<sys/stropts.h>
+@@ -206,7 +210,7 @@ void
+ callMail(argv)
+ char *argv[];
+ {
+-#if defined(linux) || defined(__FreeBSD__) || (defined(SYSV) && !defined(clipper))
++#if defined(linux) || defined(__FreeBSD__) || defined(__DragonFly__) || (defined(SYSV) && !defined(clipper))
+  struct termios	tio;
+ #else	
+  struct sgttyb	Sgtty;
+@@ -222,7 +226,7 @@ char *argv[];
+ /*
+ ** Set minimal requirements for slave connection (no echo, no NL->CR, keep TABS)
+ */
+-#if defined(linux) || defined(__FreeBSD__) || (defined(SYSV) && !defined(clipper))
++#if defined(linux) || defined(__FreeBSD__) || defined(__DragonFly__) || (defined(SYSV) && !defined(clipper))
+  tcgetattr(slave, &tio);
+  tio.c_oflag &= ~(OCRNL|ONLCR|ONLRET|OXTABS);
+  tio.c_iflag &= ~IXOFF;

--- a/ports/mail/xmail/dragonfly/patch-callbacks.c
+++ b/ports/mail/xmail/dragonfly/patch-callbacks.c
@@ -1,0 +1,11 @@
+--- callbacks.c.intermediate	2019-03-20 07:40:44 UTC
++++ callbacks.c
+@@ -43,7 +43,7 @@ extern int	noshare errno;
+ extern int	noshare sys_nerr;
+ extern char	noshare *sys_errlist[];
+ #else
+-#if !defined(__FreeBSD__)
++#if !defined(__FreeBSD__) && !defined(__DragonFly__)
+ extern int	errno;
+ extern int	sys_nerr;
+ extern char	*sys_errlist[];

--- a/ports/misc/deco/dragonfly/patch-tty.c
+++ b/ports/misc/deco/dragonfly/patch-tty.c
@@ -1,0 +1,14 @@
+--- tty.c.orig	1997-07-18 14:58:32 UTC
++++ tty.c
+@@ -12,7 +12,11 @@
+  */
+ 
+ #if HAVE_TERMIOS_H
++#if !defined(__DragonFly__) && !defined(__FreeBSD__)
+ #   include <sys/termios.h>
++#else
++#   include <termios.h>
++#endif
+ #   if HAVE_SYS_IOCTL_H
+ #      include <sys/ioctl.h>
+ #   endif

--- a/ports/net-mgmt/wmi-client/dragonfly/patch-Samba_source_winexe_winexe.c
+++ b/ports/net-mgmt/wmi-client/dragonfly/patch-Samba_source_winexe_winexe.c
@@ -1,0 +1,14 @@
+--- Samba/source/winexe/winexe.c.orig	2008-07-30 19:44:55 UTC
++++ Samba/source/winexe/winexe.c
+@@ -17,7 +17,11 @@
+ 
+ #include <sys/fcntl.h>
+ #include <sys/unistd.h>
++#if !defined(__DragonFly__) && !defined(__FreeBSD__)
+ #include <sys/termios.h>
++#else
++#include <termios.h>
++#endif
+ #include <signal.h>
+ 
+ struct program_args {

--- a/ports/net/nettest/dragonfly/patch-nettestd.c
+++ b/ports/net/nettest/dragonfly/patch-nettestd.c
@@ -1,0 +1,14 @@
+--- nettestd.c.intermediate	2019-03-20 12:56:17 UTC
++++ nettestd.c
+@@ -60,7 +60,11 @@ char copyright[] =
+ #include <sys/uio.h>
+ #include <sys/ioctl.h>
+ #include <syslog.h>
++#if !defined(__DragonFly__) && !defined(__FreeBSD__)
+ #include <sys/termios.h>
++#else
++#include <termios.h>
++#endif
+ 
+ #ifdef	WAIT3CODE
+ dochild()

--- a/ports/security/bugs/Makefile.DragonFly
+++ b/ports/security/bugs/Makefile.DragonFly
@@ -1,1 +1,0 @@
-USES+= alias

--- a/ports/security/bugs/dragonfly/patch-apps_extra.c
+++ b/ports/security/bugs/dragonfly/patch-apps_extra.c
@@ -1,0 +1,38 @@
+--- apps/extra.c.orig	2003-09-15 15:17:55 UTC
++++ apps/extra.c
+@@ -75,7 +75,7 @@ char
+ bcrypt_vol (int tempvar)
+ {
+   char c;
+-#if defined(__FreeBSD__) | defined (__NetBSD__) | defined (__OpenBSD__) 
++#if defined(__FreeBSD__) | defined (__NetBSD__) | defined (__OpenBSD__) | defined (__DragonFly__)
+   struct termios conf;
+ #else
+   struct termio conf;
+@@ -86,7 +86,7 @@ bcrypt_vol (int tempvar)
+ /*
+  * Take the configuration
+  */
+-#if defined(__FreeBSD__)
++#if defined(__FreeBSD__) || defined(__DragonFly__)
+   ioctl (0, TIOCGETA, &conf);
+ #else
+   ioctl (0, TCGETA, &conf);
+@@ -104,7 +104,7 @@ bcrypt_vol (int tempvar)
+ /*
+  * Initialisation of the new configuration
+  */ 
+-#if defined(__FreeBSD__)
++#if defined(__FreeBSD__) || defined(__DragonFly__)
+   ioctl (0, TIOCSETA, &conf);
+ #else
+   ioctl (0, TCSETA, &conf);
+@@ -122,7 +122,7 @@ bcrypt_vol (int tempvar)
+ /*
+  * Validation of the old configuration
+  */
+-#if defined(__FreeBSD__)
++#if defined(__FreeBSD__) || defined(__DragonFly__)
+   ioctl (0, TIOCSETA, &conf);
+ #else
+   ioctl (0, TCSETA, &conf);

--- a/ports/security/bugs/dragonfly/patch-include_extra.h
+++ b/ports/security/bugs/dragonfly/patch-include_extra.h
@@ -1,0 +1,16 @@
+--- include/extra.h.orig	2003-09-15 15:42:26 UTC
++++ include/extra.h
+@@ -33,8 +33,12 @@
+ 
+ #include <stdio.h>
+ 
+-#if defined(__FreeBSD__) | defined (__OpenBSD__) | defined (__NetBSD__)  
++#if defined(__FreeBSD__) | defined (__OpenBSD__) | defined (__NetBSD__) | defined (__DragonFly__)
++#if !defined(__DragonFly__) && !defined(__FreeBSD__)
+ #include <sys/termios.h>
++#else
++#include <termios.h>
++#endif
+ #include <sys/ttycom.h>
+ #else 
+ #include <termio.h>

--- a/ports/sysutils/ldapvi/dragonfly/patch-common.h
+++ b/ports/sysutils/ldapvi/dragonfly/patch-common.h
@@ -1,0 +1,14 @@
+--- common.h.intermediate	2019-03-20 17:52:56 UTC
++++ common.h
+@@ -31,7 +31,11 @@
+ #include <strings.h>
+ #include <sys/ioctl.h>
+ #include <sys/stat.h>
++#if !defined(__DragonFly__) && !defined(__FreeBSD__)
+ #include <sys/termios.h>
++#else
++#include <termios.h>
++#endif
+ #include <sys/time.h>
+ #include <sys/types.h>
+ #include <sys/wait.h>

--- a/ports/sysutils/ldapvi/dragonfly/patch-error.c
+++ b/ports/sysutils/ldapvi/dragonfly/patch-error.c
@@ -1,0 +1,14 @@
+--- error.c.orig	2007-05-05 10:17:26 UTC
++++ error.c
+@@ -25,7 +25,11 @@
+ #include <strings.h>
+ #include <sys/ioctl.h>
+ #include <sys/stat.h>
++#if !defined(__DragonFly__) && !defined(__FreeBSD__)
+ #include <sys/termios.h>
++#else
++#include <termios.h>
++#endif
+ #include <sys/time.h>
+ #include <sys/types.h>
+ #include <sys/wait.h>

--- a/ports/sysutils/ldapvi/dragonfly/patch-port.c
+++ b/ports/sysutils/ldapvi/dragonfly/patch-port.c
@@ -1,0 +1,14 @@
+--- port.c.orig	2007-05-05 10:17:26 UTC
++++ port.c
+@@ -26,7 +26,11 @@
+ #include <strings.h>
+ #include <sys/ioctl.h>
+ #include <sys/stat.h>
++#if !defined(__DragonFly__) && !defined(__FreeBSD__)
+ #include <sys/termios.h>
++#else
++#include <termios.h>
++#endif
+ #include <sys/types.h>
+ #include <unistd.h>
+ 

--- a/ports/textproc/mdocml/dragonfly/patch-main.c
+++ b/ports/textproc/mdocml/dragonfly/patch-main.c
@@ -1,0 +1,14 @@
+--- main.c.orig	2018-08-08 14:51:51 UTC
++++ main.c
+@@ -21,7 +21,11 @@
+ #include <sys/types.h>
+ #include <sys/ioctl.h>
+ #include <sys/param.h>	/* MACHINE */
++#if !defined(__DragonFly__) && !defined(__FreeBSD__)
+ #include <sys/termios.h>
++#else
++#include <termios.h>
++#endif
+ #include <sys/wait.h>
+ 
+ #include <assert.h>

--- a/ports/vietnamese/vnless/dragonfly/patch-screen.c
+++ b/ports/vietnamese/vnless/dragonfly/patch-screen.c
@@ -1,0 +1,14 @@
+--- screen.c.intermediate	2019-03-20 18:11:54 UTC
++++ screen.c
+@@ -13,7 +13,11 @@
+ 
+ #if TERMIO
+ # ifdef BSD4_4
++#if !defined(__DragonFly__) && !defined(__FreeBSD__)
+ #include <sys/termios.h>
++#else
++#include <termios.h>
++#endif
+ # else
+ #include <termio.h>
+ # endif

--- a/ports/x11-toolkits/vte3/dragonfly/patch-src_vte.cc
+++ b/ports/x11-toolkits/vte3/dragonfly/patch-src_vte.cc
@@ -1,0 +1,13 @@
+Add missing <termios.h>, other sources include both with guards.
+--- src/vte.cc.orig	2018-05-21 19:31:53 UTC
++++ src/vte.cc
+@@ -31,6 +31,9 @@
+ #ifdef HAVE_SYS_TERMIOS_H
+ #include <sys/termios.h>
+ #endif
++#ifdef HAVE_TERMIOS_H
++#include <termios.h>
++#endif
+ 
+ #include <glib.h>
+ #include <glib/gi18n-lib.h>

--- a/ports/x11/mlterm/dragonfly/patch-baselib_src_bl__pty__streams.c
+++ b/ports/x11/mlterm/dragonfly/patch-baselib_src_bl__pty__streams.c
@@ -1,0 +1,11 @@
+--- baselib/src/bl_pty_streams.c.orig	2018-10-27 14:29:17 UTC
++++ baselib/src/bl_pty_streams.c
+@@ -23,7 +23,7 @@
+ #include <sys/ioctl.h>
+ #include <sys/stat.h>
+ #include <unistd.h>
+-#ifdef __ANDROID__
++#if defined(__ANDROID__) || defined(__DragonFly__) || defined(__FreeBSD__)
+ #include <termios.h>
+ #else
+ #include <sys/termios.h>


### PR DESCRIPTION
In preparations for base changes.

Requested-by: swildner