### PR TITLE
Fix devel/libevdev build

### DIFF
--- a/ports/devel/libevdev/newport/Makefile
+++ b/ports/devel/libevdev/newport/Makefile
@@ -1,0 +1,41 @@
+# $FreeBSD: head/devel/libevdev/Makefile 487789 2018-12-19 09:09:11Z zeising $
+
+PORTNAME=	libevdev
+PORTVERSION=	1.5.9
+CATEGORIES=	devel
+MASTER_SITES=	http://freedesktop.org/software/${PORTNAME}/
+
+MAINTAINER=	hselasky@FreeBSD.org
+COMMENT=	Linux Event Device library
+
+LICENSE=	MIT # without linux/*.h
+LICENSE_FILE=	${WRKSRC}/COPYING
+
+BUILD_DEPENDS=	${LOCALBASE}/include/linux/input.h:devel/evdev-proto
+
+USES=		gmake libtool localbase pathfix pkgconfig python:build tar:xz
+EXTRACT_AFTER_ARGS=	--exclude include # v4l_compat
+GNU_CONFIGURE=	yes
+CONFIGURE_ENV=	ac_cv_path_DOXYGEN="" ac_cv_path_VALGRIND=""
+INSTALL_TARGET=	install-strip
+USE_LDCONFIG=	yes
+
+# Test requires /dev/uinput and should be run as root
+.if exists(/dev/uinput)
+TEST_USES+=	pkgconfig
+TEST_DEPENDS=	checkmk:devel/check
+TEST_TARGET=	check
+TEST_WRKSRC=	${WRKSRC}/test
+.endif
+
+post-patch:
+	@${REINPLACE_CMD} -e '/input\.h/s,top_srcdir,LOCALBASE,g' \
+		${WRKSRC}/libevdev/Makefile.in
+	@${REINPLACE_CMD} -e '/^LIBS = /s/$$/ -pthread -lrt/' \
+		${WRKSRC}/tools/Makefile.in
+	@${REINPLACE_CMD} -e 's|program_invocation_short_name|getprogname()|' \
+		${WRKSRC}/tools/mouse-dpi-tool.c \
+		${WRKSRC}/tools/touchpad-edge-detector.c \
+		${WRKSRC}/tools/libevdev-tweak-device.c
+
+.include <bsd.port.mk>

--- a/ports/devel/libevdev/newport/distinfo
+++ b/ports/devel/libevdev/newport/distinfo
@@ -1,0 +1,2 @@
+SHA256 (libevdev-1.5.9.tar.xz) = e1663751443bed9d3e76a4fe2caf6fa866a79705d91cacad815c04e706198a75
+SIZE (libevdev-1.5.9.tar.xz) = 408200

--- a/ports/devel/libevdev/newport/dragonfly/patch-tools_mouse-dpi-tool.c
+++ b/ports/devel/libevdev/newport/dragonfly/patch-tools_mouse-dpi-tool.c
@@ -1,0 +1,100 @@
+--- tools/mouse-dpi-tool.c.orig	2019-05-02 15:11:57.000000000 +0300
++++ tools/mouse-dpi-tool.c	2019-05-13 14:00:46.760307000 +0300
+@@ -26,7 +26,13 @@
+ #endif
+ 
+ #include <libevdev/libevdev.h>
++#if defined(__DragonFly__)
++#include <sys/types.h>
++#include <sys/event.h>
++#include <sys/time.h>
++#else
+ #include <sys/signalfd.h>
++#endif
+ #include <errno.h>
+ #include <fcntl.h>
+ #include <limits.h>
+@@ -145,6 +151,75 @@ handle_event(struct measurements *m, con
+ 	return 0;
+ }
+ 
++#if defined(__DragonFly__)
++static int
++mainloop(struct libevdev *dev, struct dimensions *dim) {
++	int kq, nev;
++	struct kevent change[2];
++	struct kevent events[2];
++	int libevdev_fd;
++	struct sigaction sa;
++
++	memset(&sa, 0, sizeof(struct sigaction));
++	sa.sa_handler = SIG_IGN;
++	sigaction(SIGINT, &sa, NULL);
++
++	kq = kqueue();
++	if (kq == -1) {
++		fprintf(stderr, "Error initializing kqueue: %s\n",
++		        strerror(errno));
++		return (EXIT_FAILURE);
++	}
++
++	libevdev_fd = libevdev_get_fd(dev);
++	EV_SET(&change[0], libevdev_fd, EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0,
++	       NULL);
++	EV_SET(&change[1], SIGINT, EVFILT_SIGNAL, EV_ADD | EV_ENABLE, 0, 0,
++	       NULL);
++
++	if (kevent(kq, change, 2, NULL, 0, NULL) == -1) {
++		fprintf(stderr, "Error adding events: %s\n", strerror(errno));
++		close(kq);
++		return (EXIT_FAILURE);
++	}
++
++	for (;;) {
++		struct input_event ev;
++		int rc;
++
++		nev = kevent(kq, NULL, 0, events, 2, NULL);
++
++		if (nev == 0) {
++			break;
++		} else if (nev == -1) {
++			if (errno == EINTR) {
++				continue;
++			} else {
++				fprintf(stderr, "Error from kqueue: %s\n",
++				    strerror(errno));
++				return (EXIT_FAILURE);
++			}
++		} else if ((nev > 0) && (events[1].data >= 1)) {
++			break;
++		}
++
++		do {
++			rc = libevdev_next_event(dev, LIBEVDEV_READ_FLAG_NORMAL, &ev);
++			if (rc == LIBEVDEV_READ_STATUS_SYNC) {
++				fprintf(stderr, "Error: cannot keep up\n");
++				return 1;
++			} else if (rc != -EAGAIN && rc < 0) {
++				fprintf(stderr, "Error: %s\n", strerror(-rc));
++				return 1;
++			} else if (rc == LIBEVDEV_READ_STATUS_SUCCESS) {
++				handle_event(dim, &ev);
++			}
++		} while (rc != -EAGAIN);
++	}
++
++	return 0;
++}
++#else  /* Linux */
+ static int
+ mainloop(struct libevdev *dev, struct measurements *m) {
+ 	struct pollfd fds[2];
+@@ -183,6 +258,7 @@ mainloop(struct libevdev *dev, struct me
+ 
+ 	return 0;
+ }
++#endif
+ 
+ static inline double
+ mean_frequency(struct measurements *m)

--- a/ports/devel/libevdev/newport/dragonfly/patch-tools_touchpad-edge-detector.c
+++ b/ports/devel/libevdev/newport/dragonfly/patch-tools_touchpad-edge-detector.c
@@ -1,0 +1,100 @@
+--- tools/touchpad-edge-detector.c.orig	2019-05-02 15:11:50.000000000 +0300
++++ tools/touchpad-edge-detector.c	2019-05-13 14:01:12.060452000 +0300
+@@ -26,7 +26,13 @@
+ #endif
+ 
+ #include <libevdev/libevdev.h>
++#if defined(__DragonFly__)
++#include <sys/types.h>
++#include <sys/event.h>
++#include <sys/time.h>
++#else
+ #include <sys/signalfd.h>
++#endif
+ #include <errno.h>
+ #include <fcntl.h>
+ #include <limits.h>
+@@ -103,6 +109,75 @@ handle_event(struct dimensions *d, const
+ 	return 0;
+ }
+ 
++#if defined(__DragonFly__)
++static int
++mainloop(struct libevdev *dev, struct dimensions *dim) {
++	int kq, nev;
++	struct kevent change[2];
++	struct kevent events[2];
++	int libevdev_fd;
++	struct sigaction sa;
++
++	memset(&sa, 0, sizeof(struct sigaction));
++	sa.sa_handler = SIG_IGN;
++	sigaction(SIGINT, &sa, NULL);
++
++	kq = kqueue();
++	if (kq == -1) {
++		fprintf(stderr, "Error initializing kqueue: %s\n",
++		        strerror(errno));
++		return (EXIT_FAILURE);
++	}
++
++	libevdev_fd = libevdev_get_fd(dev);
++	EV_SET(&change[0], libevdev_fd, EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0,
++	       NULL);
++	EV_SET(&change[1], SIGINT, EVFILT_SIGNAL, EV_ADD | EV_ENABLE, 0, 0,
++	       NULL);
++
++	if (kevent(kq, change, 2, NULL, 0, NULL) == -1) {
++		fprintf(stderr, "Error adding events: %s\n", strerror(errno));
++		close(kq);
++		return (EXIT_FAILURE);
++	}
++
++	for (;;) {
++		struct input_event ev;
++		int rc;
++
++		nev = kevent(kq, NULL, 0, events, 2, NULL);
++
++		if (nev == 0) {
++			break;
++		} else if (nev == -1) {
++			if (errno == EINTR) {
++				continue;
++			} else {
++				fprintf(stderr, "Error from kqueue: %s\n",
++				    strerror(errno));
++				return (EXIT_FAILURE);
++			}
++		} else if ((nev > 0) && (events[1].data >= 1)) {
++			break;
++		}
++
++		do {
++			rc = libevdev_next_event(dev, LIBEVDEV_READ_FLAG_NORMAL, &ev);
++			if (rc == LIBEVDEV_READ_STATUS_SYNC) {
++				fprintf(stderr, "Error: cannot keep up\n");
++				return 1;
++			} else if (rc != -EAGAIN && rc < 0) {
++				fprintf(stderr, "Error: %s\n", strerror(-rc));
++				return 1;
++			} else if (rc == LIBEVDEV_READ_STATUS_SUCCESS) {
++				handle_event(dim, &ev);
++			}
++		} while (rc != -EAGAIN);
++	}
++
++	return 0;
++}
++#else  /* Linux */
+ static int
+ mainloop(struct libevdev *dev, struct dimensions *dim) {
+ 	struct pollfd fds[2];
+@@ -141,6 +216,7 @@ mainloop(struct libevdev *dev, struct di
+ 
+ 	return 0;
+ }
++#endif
+ 
+ static inline void
+ pid_vid_matchstr(struct libevdev *dev, char *match, size_t sz)

--- a/ports/devel/libevdev/newport/files/patch-libevdev_libevdev-uinput.c
+++ b/ports/devel/libevdev/newport/files/patch-libevdev_libevdev-uinput.c
@@ -1,0 +1,40 @@
+--- libevdev/libevdev-uinput.c.orig	2017-05-04 00:37:30 UTC
++++ libevdev/libevdev-uinput.c
+@@ -182,6 +182,7 @@ libevdev_uinput_get_fd(const struct libevdev_uinput *u
+ 	return uinput_dev->fd;
+ }
+ 
++#if defined(linux)
+ static int is_event_device(const struct dirent *dent) {
+ 	return strncmp("event", dent->d_name, 5) == 0;
+ }
+@@ -213,10 +214,12 @@ fetch_device_node(const char *path)
+ static int is_input_device(const struct dirent *dent) {
+ 	return strncmp("input", dent->d_name, 5) == 0;
+ }
++#endif
+ 
+ static int
+ fetch_syspath_and_devnode(struct libevdev_uinput *uinput_dev)
+ {
++#if defined(linux)
+ 	struct dirent **namelist;
+ 	int ndev, i;
+ 	int rc;
+@@ -290,6 +293,16 @@ fetch_syspath_and_devnode(struct libevdev_uinput *uinp
+ 	free(namelist);
+ 
+ 	return uinput_dev->devnode ? 0 : -1;
++#elif defined(__FreeBSD__)
++	char devnode[80];
++	if (ioctl(uinput_dev->fd, UI_GET_SYSNAME(sizeof(devnode)), devnode) < 0)
++		return -1;
++	asprintf(&uinput_dev->devnode, "/dev/input/%s", devnode);
++	uinput_dev->syspath = strdup(uinput_dev->devnode);
++	return 0;
++#else
++	return -1;
++#endif
+ }
+ 
+ static int

--- a/ports/devel/libevdev/newport/files/patch-test_test-libevdev-events.c
+++ b/ports/devel/libevdev/newport/files/patch-test_test-libevdev-events.c
@@ -1,0 +1,20 @@
+--- test/test-libevdev-events.c.orig	2017-05-04 00:37:30 UTC
++++ test/test-libevdev-events.c
+@@ -1057,7 +1057,7 @@ START_TEST(test_syn_delta_late_sync)
+ 	} while (rc >= 0);
+ 
+ 	/* force enough events to trigger a SYN_DROPPED */
+-	for (i = 0; i < 100; i++) {
++	for (i = 0; i < 200; i++) {
+ 		uinput_device_event(uidev, EV_ABS, ABS_X, 100 + i);
+ 		uinput_device_event(uidev, EV_ABS, ABS_Y, 500 + i);
+ 		uinput_device_event(uidev, EV_ABS, ABS_MT_POSITION_X, 100 + i);
+@@ -1152,7 +1152,7 @@ START_TEST(test_syn_delta_late_sync)
+ 	} while (rc >= 0);
+ 
+ 	/* force enough events to trigger a SYN_DROPPED */
+-	for (i = 0; i < 100; i++) {
++	for (i = 0; i < 200; i++) {
+ 		uinput_device_event(uidev, EV_ABS, ABS_X, 100 + i);
+ 		uinput_device_event(uidev, EV_ABS, ABS_Y, 500 + i);
+ 		uinput_device_event(uidev, EV_ABS, ABS_MT_POSITION_X, 100 + i);

--- a/ports/devel/libevdev/newport/files/patch-test_test-libevdev-has-event.c
+++ b/ports/devel/libevdev/newport/files/patch-test_test-libevdev-has-event.c
@@ -1,0 +1,16 @@
+--- test/test-libevdev-has-event.c.orig	2017-05-04 00:37:30 UTC
++++ test/test-libevdev-has-event.c
+@@ -116,6 +116,13 @@ START_TEST(test_event_codes)
+ 			evbit++;
+ 			continue;
+ 		}
++#ifdef __FreeBSD__
++		/* Force feedback events are not supported by FreeBSD */
++		if (*evbit == EV_FF) {
++			evbit++;
++			continue;
++		}
++#endif
+ 
+ 		max = libevdev_event_type_get_max(*evbit);
+ 

--- a/ports/devel/libevdev/newport/files/patch-test_test-libevdev-init.c
+++ b/ports/devel/libevdev/newport/files/patch-test_test-libevdev-init.c
@@ -1,0 +1,11 @@
+--- test/test-libevdev-init.c.orig	2018-03-08 05:27:35 UTC
++++ test/test-libevdev-init.c
+@@ -577,7 +577,7 @@ START_TEST(test_set_clock_id)
+ 	rc = libevdev_set_clock_id(dev, CLOCK_MONOTONIC);
+ 	ck_assert_int_eq(rc, 0);
+ 
+-	rc = libevdev_set_clock_id(dev, CLOCK_MONOTONIC_RAW);
++	rc = libevdev_set_clock_id(dev, CLOCK_MONOTONIC_FAST);
+ 	ck_assert_int_eq(rc, -EINVAL);
+ 
+ 	uinput_device_free(uidev);

--- a/ports/devel/libevdev/newport/files/patch-test_test-main.c
+++ b/ports/devel/libevdev/newport/files/patch-test_test-main.c
@@ -1,0 +1,26 @@
+--- test/test-main.c.orig	2018-03-08 05:27:35 UTC
++++ test/test-main.c
+@@ -43,6 +43,7 @@ extern Suite *uinput_suite(void);
+ static int
+ is_debugger_attached(void)
+ {
++#if defined (linux)
+ 	int status;
+ 	int rc;
+ 	int pid = fork();
+@@ -66,6 +67,15 @@ is_debugger_attached(void)
+ 	}
+ 
+ 	return rc;
++#else
++	/*
++	 * Skip useless gdb test as setting CK_FORK environment variable in
++	 * absence of attached debugger gives no harm to user.
++	 * Moreover this test is broken on most nonlinux systems, look at
++	 * discussion here: http://stackoverflow.com/questions/3596781/
++	 */
++	return 1;
++#endif
+ }
+ 
+ int main(void)

--- a/ports/devel/libevdev/newport/pkg-descr
+++ b/ports/devel/libevdev/newport/pkg-descr
@@ -1,0 +1,8 @@
+libevdev is a wrapper library for evdev devices. It moves the common
+tasks when dealing with evdev devices into a library and provides a
+library interface to the callers, thus avoiding erroneous ioctls, etc.
+
+The eventual goal is that libevdev wraps all ioctls available to evdev
+devices, thus making direct access unnecessary.
+
+WWW: https://www.freedesktop.org/wiki/Software/libevdev/

--- a/ports/devel/libevdev/newport/pkg-plist
+++ b/ports/devel/libevdev/newport/pkg-plist
@@ -1,0 +1,11 @@
+bin/libevdev-tweak-device
+bin/mouse-dpi-tool
+bin/touchpad-edge-detector
+include/libevdev-1.0/libevdev/libevdev-uinput.h
+include/libevdev-1.0/libevdev/libevdev.h
+lib/libevdev.a
+lib/libevdev.so
+lib/libevdev.so.2
+lib/libevdev.so.2.1.21
+libdata/pkgconfig/libevdev.pc
+man/man3/libevdev.3.gz


### PR DESCRIPTION
* Make devel/libevdev a DragonFly dport in order to rid
  the port of libepoll-shim.

* Added two kqueue patches and deleted libepoll-shim dependency, 
  but otherwise the port is identical with the FreeBSD port.