### PR TITLE
Fix x11-toolkits/gtk30

### DIFF
--- a/ports/x11-toolkits/gtk30/Makefile.DragonFly
+++ b/ports/x11-toolkits/gtk30/Makefile.DragonFly
@@ -5,6 +5,8 @@
 BUILD_DEPENDS:=	${BUILD_DEPENDS:Nat-spi2-atk*}
 RUN_DEPENDS:=	${RUN_DEPENDS:Nat-spi2-atk*}
 
+WAYLAND_BUILD_DEPENDS+= ${LOCALBASE}/include/linux/input.h:devel/evdev-proto
+
 OPTIONS_DEFINE+=	DBUS
 OPTIONS_DEFAULT+=	DBUS
 

--- a/ports/x11-toolkits/gtk30/dragonfly/patch-gdk_wayland_gdkdevice-wayland.c
+++ b/ports/x11-toolkits/gtk30/dragonfly/patch-gdk_wayland_gdkdevice-wayland.c
@@ -5,7 +5,7 @@
  #include <linux/input.h>
  #endif
 +#ifdef __DragonFly__
-+#include <dev/misc/evdev/input.h>
++#include <linux/input.h>
 +#endif
  
  #define BUTTON_BASE (BTN_LEFT - 1) /* Used to translate to 1-indexed buttons */


### PR DESCRIPTION
* For now, use devel/evdev-proto for linux/input.h.