### PR TITLE
Add devel/git-lfs port

### DIFF
--- a/ports/devel/git-lfs/Makefile.DragonFly
+++ b/ports/devel/git-lfs/Makefile.DragonFly
@@ -1,0 +1,1 @@
+MANPAGES_BUILD_DEPENDS+= groff:textproc/groff

--- a/ports/devel/git-lfs/dragonfly/patch-lfshttp_certs_dragonfly.go
+++ b/ports/devel/git-lfs/dragonfly/patch-lfshttp_certs_dragonfly.go
@@ -1,0 +1,11 @@
+--- /dev/null	2019-09-25 23:24:38.410299978 +0800
++++ lfshttp/certs_dragonfly.go	2019-09-25 23:11:11.817478000 +0800
+@@ -0,0 +1,8 @@
++package lfshttp
++
++import "crypto/x509"
++
++func appendRootCAsForHostFromPlatform(pool *x509.CertPool, host string) *x509.CertPool {
++	// Do nothing, use golang default
++	return pool
++}


### PR DESCRIPTION
This port uses ronn(1) (from rubygem-ronn) to generate manpages, and ronn(1) further calls groff(1).  Therefore, need to add groff(1) to the build dependencies if the `MANPAGES` use flag is on.

Cheers,
Aaron