### PR TITLE
Fix bsd.commands.mk syntax error

### DIFF
--- a/special/Mk/diffs/bsd.commands.mk.diff
+++ b/special/Mk/diffs/bsd.commands.mk.diff
@@ -4,7 +4,7 @@
  
  _COMMANDSMKINCLUDED=	yes
  
-+.if ${AWK:Mawk}
++.if defined(AWK) && ${AWK} == "awk"
 +.undef AWK
 +.endif
  AWK?=			/usr/bin/awk


### PR DESCRIPTION
Fix a syntax error (encountered running `make -d g1 -rn` in
`/usr/dports`) in `bsd.commands.mk.diff` introduced a long time ago in
e87325a115e96880aa559578ceebd750a5ba059d, in what seems to have been an
attempt to cut down on verbosity.

The reverted code both allows the make debug graph to be printed and
expresses the intent of the test much better.