### PR TITLE
security/tinc{,-devel}: Use '/dev/{tun,tap}' by default

### DIFF
--- a/ports/security/tinc-devel/dragonfly/patch-src_bsd_device.c
+++ b/ports/security/tinc-devel/dragonfly/patch-src_bsd_device.c
@@ -1,0 +1,16 @@
+--- src/bsd/device.c.orig	2020-04-04 11:51:12 UTC
++++ src/bsd/device.c
+@@ -40,8 +40,13 @@
+ #include <net/if_utun.h>
+ #endif
+ 
++#if defined(HAVE_FREEBSD) || defined(HAVE_DRAGONFLY)
++#define DEFAULT_TUN_DEVICE "/dev/tun"  // Use the auto-clone device
++#define DEFAULT_TAP_DEVICE "/dev/tap"
++#else
+ #define DEFAULT_TUN_DEVICE "/dev/tun0"
+ #define DEFAULT_TAP_DEVICE "/dev/tap0"
++#endif
+ 
+ typedef enum device_type {
+ 	DEVICE_TYPE_TUN,

--- a/ports/security/tinc/dragonfly/patch-src_bsd_device.c
+++ b/ports/security/tinc/dragonfly/patch-src_bsd_device.c
@@ -1,0 +1,16 @@
+--- src/bsd/device.c.orig	2020-04-04 13:19:42 UTC
++++ src/bsd/device.c
+@@ -39,8 +39,13 @@
+ #include <net/if_utun.h>
+ #endif
+ 
++#if defined(HAVE_FREEBSD) || defined(HAVE_DRAGONFLY)
++#define DEFAULT_TUN_DEVICE "/dev/tun"  /* Use the auto-clone device */
++#define DEFAULT_TAP_DEVICE "/dev/tap"
++#else
+ #define DEFAULT_TUN_DEVICE "/dev/tun0"
+ #define DEFAULT_TAP_DEVICE "/dev/tap0"
++#endif
+ 
+ typedef enum device_type {
+ 	DEVICE_TYPE_TUN,


### PR DESCRIPTION
We don't create `/dev/tunX` or `/dev/tapX` anymore since commit https://github.com/DragonFlyBSD/DragonFlyBSD/commit/f1e9a4fff5aaac2be3a291dbfea94f94755991b8.  So update `security/tinc` and `security/tinc-devel` to use the auto-clone device `/dev/tun` or `/dev/tap` by default, which exists once the kernel module `if_tun` or `if_tap` is loaded.

Fixes https://github.com/DragonFlyBSD/DPorts/issues/213.