### PR TITLE
x11-drivers/xorg-drivers: reflect removal of xf86-video-intel29

### DIFF
--- a/ports/x11-drivers/xorg-drivers/diffs/Makefile.diff
+++ b/ports/x11-drivers/xorg-drivers/diffs/Makefile.diff
@@ -1,14 +1,14 @@
---- Makefile.orig	2017-02-06 15:21:58 UTC
-+++ Makefile
-@@ -21,7 +21,6 @@ INPUT_DRIVERS=		acecad \
- 			hyperpen \
+--- Makefile.orig	2020-04-07 08:41:57.817572000 +0200
++++ Makefile	2020-04-07 08:43:36.528006000 +0200
+@@ -18,7 +18,6 @@
+ 			evdev \
  			joystick \
  			keyboard \
 -			libinput \
  			mouse \
- 			mutouch \
- 			penmount \
-@@ -32,29 +31,30 @@ INPUT_DRIVERS=		acecad \
+ 			synaptics \
+ 			void \
+@@ -27,29 +26,30 @@
  VIDEO_DRIVERS=		apm \
  			ark \
  			ast \
@@ -50,39 +50,23 @@
  			voodoo
  
  OPTIONS_DEFAULT=	KEYBOARD \
-@@ -68,8 +68,8 @@ ${a:tu}_DESC=		Install ${a} ${type} driv
+@@ -64,8 +64,8 @@
  . endfor
  .endfor
  
 -OPTIONS_DEFINE_amd64=	AMDGPU ATI INTEL VMMOUSE VMWARE
 -OPTIONS_DEFAULT_amd64=	VESA
-+OPTIONS_DEFINE_x86_64=	AMDGPU ATI INTEL29 VMMOUSE VMWARE
-+OPTIONS_DEFAULT_x86_64=	ATI INTEL29 VESA
++OPTIONS_DEFINE_x86_64=	AMDGPU ATI INTEL VMMOUSE VMWARE
++OPTIONS_DEFAULT_x86_64=	ATI INTEL VESA
  
  OPTIONS_DEFINE_i386:=	${OPTIONS_DEFINE_amd64} GEODE
  OPTIONS_DEFAULT_i386:=	${OPTIONS_DEFAULT_amd64}
-@@ -80,20 +80,20 @@ OPTIONS_DEFAULT_sparc64=SUNFFB
- AMDGPU_DESC=		Install amdgpu video driver
- ATI_DESC=		Install ati (radeon) video driver 
- GEODE_DESC=		Install geode video driver
--INTEL_DESC=		Install intel video driver
-+INTEL29_DESC=		Install intel video driver
- SUNFFB_DESC=		Install sunffb video driver
- VMMOUSE_DESC=		Install vmmouse input driver
- VMWARE_DESC=		Install vmware video driver
- 
- # these drivers have a different module name compared to the plugin they install
--QUIRKS=		keyboard:kbd
-+QUIRKS=		keyboard:kbd intel29:intel
- 
+@@ -87,7 +87,7 @@
  .include <bsd.port.options.mk>
  
  # Manual add arch specific drivers so they be added to depend lines.
 -.if ${ARCH}==i386 || ${ARCH}==amd64
 +.if ${ARCH}==i386 || ${ARCH}==x86_64
  INPUT_DRIVERS+= vmmouse
--VIDEO_DRIVERS+=	amdgpu ati intel vmware
-+VIDEO_DRIVERS+=	amdgpu ati intel29 vmware
+ VIDEO_DRIVERS+=	amdgpu ati intel vmware
  .endif
- 
- .if ${ARCH}==i386


### PR DESCRIPTION
Use xf86-video-intel instead of removed xf86-video-intel29.