### PR TITLE
Fix EGL Window creation and prevent GLFW-Wayland from SEGFAULTING

### DIFF
--- a/ports/graphics/mesa-dri/dragonfly/patch-src_egl_drivers_dri2_egl_dri2.c
+++ b/ports/graphics/mesa-dri/dragonfly/patch-src_egl_drivers_dri2_egl_dri2.c
@@ -1,0 +1,15 @@
+diff --git a/src/egl/drivers/dri2/egl_dri2.c b/src/egl/drivers/dri2/egl_dri2.c
+index 2e51d28a8b9..95ee2f3a7b1 100644
+--- a/src/egl/drivers/dri2/egl_dri2.c
++++ b/src/egl/drivers/dri2/egl_dri2.c
+@@ -1005,8 +1005,8 @@ dri2_setup_screen(_EGLDisplay *disp)
+ #ifdef HAVE_LIBDRM
+       if (dri2_dpy->image->base.version >= 8 &&
+           dri2_dpy->image->createImageFromDmaBufs) {
+-         disp->Extensions.EXT_image_dma_buf_import = EGL_TRUE;
+-         disp->Extensions.EXT_image_dma_buf_import_modifiers = EGL_TRUE;
++         disp->Extensions.EXT_image_dma_buf_import = EGL_FALSE;
++         disp->Extensions.EXT_image_dma_buf_import_modifiers = EGL_FALSE;
+       }
+ #endif
+    }

--- a/ports/graphics/mesa-dri/dragonfly/patch-src_egl_drivers_dri2_platform_wayland.c
+++ b/ports/graphics/mesa-dri/dragonfly/patch-src_egl_drivers_dri2_platform_wayland.c
@@ -1,0 +1,13 @@
+diff --git a/src/egl/drivers/dri2/platform_wayland.c b/src/egl/drivers/dri2/platform_wayland.c
+index c4177f8799c..0dbc7aa4803 100644
+--- a/src/egl/drivers/dri2/platform_wayland.c
++++ b/src/egl/drivers/dri2/platform_wayland.c
+@@ -1347,7 +1347,7 @@ registry_handle_global_drm(void *data, struct wl_registry *registry,
+       dri2_dpy->wl_drm =
+          wl_registry_bind(registry, name, &wl_drm_interface, MIN2(version, 2));
+       wl_drm_add_listener(dri2_dpy->wl_drm, &drm_listener, dri2_dpy);
+-   } else if (strcmp(interface, "zwp_linux_dmabuf_v1") == 0 && version >= 3) {
++   } else if (false && strcmp(interface, "zwp_linux_dmabuf_v1") == 0 && version >= 3) {
+       dri2_dpy->wl_dmabuf =
+          wl_registry_bind(registry, name, &zwp_linux_dmabuf_v1_interface,
+                           MIN2(version, 3));

--- a/ports/graphics/mesa-dri/dragonfly/patch-src_egl_main_eglglobals.c
+++ b/ports/graphics/mesa-dri/dragonfly/patch-src_egl_main_eglglobals.c
@@ -1,0 +1,13 @@
+diff --git a/src/egl/main/eglglobals.c b/src/egl/main/eglglobals.c
+index 6811048bdf7..5eefbc9187b 100644
+--- a/src/egl/main/eglglobals.c
++++ b/src/egl/main/eglglobals.c
+@@ -136,7 +136,7 @@ _eglPointerIsDereferencable(void *p)
+ {
+    uintptr_t addr = (uintptr_t) p;
+    const long page_size = getpagesize();
+-#ifdef HAVE_MINCORE
++#if 0
+    unsigned char valid = 0;
+ 
+    if (p == NULL)


### PR DESCRIPTION
These are fixes that I needed to apply in order for glfwCreateWindow() to stop SEGFAULTING, with the main culprit being EXT_image_dma_buf usage, despite not being supported. 
The patches allow window creation on sway, with Mesa 18.3.2 and newer. However, due to EXT_KHR not being properly used, the window remains blank with Mesa 18.3.2, even though a context is successfully created. Proper EXT_KHR extension use was fixed at some point and with Mesa 20.2.0-devel (git-412e29c277) at the latest, window and context creation works without issue.

All patch files were diffed against Mesa 20.2.0-devel (git-412e29c277).