### PR TITLE
databases/rocksdb-lite : fix package

### DIFF
--- a/ports/databases/rocksdb/diffs/Makefile.diff
+++ b/ports/databases/rocksdb/diffs/Makefile.diff
@@ -1,6 +1,6 @@
---- Makefile.orig	2019-11-02 19:40:49 UTC
-+++ Makefile
-@@ -14,7 +14,6 @@ LICENSE_COMB=	dual
+--- Makefile.orig	2020-07-09 16:55:57.676392000 +0200
++++ Makefile	2020-07-09 16:56:32.356499000 +0200
+@@ -14,7 +14,6 @@
  LICENSE_FILE_APACHE20=	${WRKSRC}/LICENSE.Apache
  LICENSE_FILE_GPLv2=	${WRKSRC}/COPYING
  
@@ -8,3 +8,19 @@
  BROKEN_armv6?=		does not build: db/c.cc:2281:44: implicit conversion loses integer precision: 'uint64_t' (aka 'unsigned long long') to 'size_t' (aka 'unsigned int')
  BROKEN_armv7?=		does not build: /nxb-bin/usr/bin/ld: undefined reference to symbol `__gnu_Unwind_Find_exidx@@FBSD_1.4' (try adding -lc) #'`
  BROKEN_powerpc64=	does not build: util/crc32c.cc:435:22: 'arch_ppc_probe' was not declared in this scope
+@@ -58,13 +57,13 @@
+ 
+ .if !defined(LITE)
+ CONFLICTS_INSTALL=	rocksdb-lite
+-PLIST_SUB+=	LITE="@comment "
++PLIST_SUB+=	LITE="@comment " NOLITE=""
+ .else
+ PKGNAMESUFFIX=	-lite
+ CONFLICTS_INSTALL=	rocksdb
+ CFLAGS+=	-DROCKSDB_LITE=1
+ MAKE_ENV+=	LIBNAME=librocksdb${PKGNAMESUFFIX} DISABLE_JEMALLOC=1
+-PLIST_SUB+=	LITE=""
++PLIST_SUB+=	LITE="" NOLITE="@comment "
+ .endif
+ 
+ .include <bsd.port.pre.mk>

--- a/ports/databases/rocksdb/diffs/pkg-plist.diff
+++ b/ports/databases/rocksdb/diffs/pkg-plist.diff
@@ -1,0 +1,18 @@
+--- pkg-plist.orig	2020-07-09 16:30:53.902786000 +0200
++++ pkg-plist	2020-07-09 16:31:00.382800000 +0200
+@@ -104,9 +104,9 @@
+ %%LITE%%lib/librocksdb-lite.so.%%SHLIB_VER%%
+ %%LITE%%lib/librocksdb-lite.so.%%PORTVERSION%%
+ %%LITE%%lib/librocksdb-lite_tools.a
+-lib/librocksdb.a
+-lib/librocksdb.so
+-lib/librocksdb.so.6
+-lib/librocksdb.so.%%SHLIB_VER%%
+-lib/librocksdb.so.%%PORTVERSION%%
+-lib/librocksdb_tools.a
++%%NOLITE%%lib/librocksdb.a
++%%NOLITE%%lib/librocksdb.so
++%%NOLITE%%lib/librocksdb.so.6
++%%NOLITE%%lib/librocksdb.so.%%SHLIB_VER%%
++%%NOLITE%%lib/librocksdb.so.%%PORTVERSION%%
++%%NOLITE%%lib/librocksdb_tools.a


### PR DESCRIPTION
For some reason the build of the lib version was also trying to package the non-lite files in the lib dir (which are not built in that case, I wonder why that doesn't break on FreeBSD side), so I had to manually exclude them with the %%NOLITE%% conditionnal when building -lite variant.

These files are the following :
lib/librocksdb.a
lib/librocksdb.so
lib/librocksdb.so.6
lib/librocksdb.so.%%SHLIB_VER%%
lib/librocksdb.so.%%PORTVERSION%%
lib/librocksdb_tools.a

I did try to rebuild both rocksdb and rocksdb-lite after the change.