### PR TITLE
math/moab

### DIFF
--- a/ports/math/moab/Makefile.DragonFly
+++ b/ports/math/moab/Makefile.DragonFly
@@ -1,3 +1,3 @@
-
-# ...
-OPTIONS_DEFAULT:=	${OPTIONS_DEFAULT:NMPI}
+CMAKE_ARGS+= -DMPI_C_COMPILER="${LOCALBASE}/mpi/openmpi/bin/mpicc"
+CMAKE_ARGS+= -DMPI_CXX_COMPILER="${LOCALBASE}/mpi/openmpi/bin/mpicxx"
+CMAKE_ARGS+= -DMPI_Fortran_COMPILER="${LOCALBASE}/mpi/openmpi/bin/mpifort"

--- a/ports/math/moab/diffs/patch-pkg-plist.diff
+++ b/ports/math/moab/diffs/patch-pkg-plist.diff
@@ -1,0 +1,11 @@
+--- pkg-plist.orig	2020-07-10 15:22:54.381919000 +0200
++++ pkg-plist	2020-07-10 15:22:37.991869000 +0200
+@@ -76,7 +76,7 @@
+ include/moab/NestedRefineTemplates.hpp
+ include/moab/OrientedBox.hpp
+ include/moab/OrientedBoxTreeTool.hpp
+-include/moab/ParCommGraph.hpp
++%%MPI%%include/moab/ParCommGraph.hpp
+ %%MPI%%include/moab/ParallelComm.hpp
+ %%MPI%%include/moab/ParallelData.hpp
+ %%MPI%%include/moab/ParallelMergeMesh.hpp


### PR DESCRIPTION
On this one I've seen MPI was the default on FreeBSD, so I tried to fix it as well. But I don't know as zrj disabled it before, so feel free to pick the first only or both commit.