### PR TITLE
x11-toolkits/p5-Alien-wxWidgets : fix package

### DIFF
--- a/ports/x11-toolkits/p5-Alien-wxWidgets/diffs/Makefile.diff
+++ b/ports/x11-toolkits/p5-Alien-wxWidgets/diffs/Makefile.diff
@@ -1,0 +1,20 @@
+--- Makefile.orig	2020-07-13 18:48:12.854268000 +0200
++++ Makefile	2020-07-13 18:48:32.514324000 +0200
+@@ -14,7 +14,7 @@
+ LICENSE=	ART10 GPLv1+
+ LICENSE_COMB=	dual
+ 
+-BUILD_DEPENDS=	${RUN_DEPENDS}
++BUILD_DEPENDS=	${RUN_DEPENDS} p5-LWP-Protocol-https>=6.07:www/p5-LWP-Protocol-https
+ RUN_DEPENDS=	p5-Module-Pluggable>=5.1:devel/p5-Module-Pluggable
+ 
+ NO_ARCH=	yes
+@@ -31,7 +31,7 @@
+ 
+ post-install:
+ 	# file name is function of wx version, add it dynamically
+-	@(cd ${STAGEDIR}${PREFIX}; ${FIND} * -type f -name gtk2_\* -print \
++	@(cd ${STAGEDIR}${PREFIX}; ${FIND} * -type f -name gtk_\* -print \
+ 		>> ${TMPPLIST})
+ 
+ .include <bsd.port.mk>

--- a/ports/x11-toolkits/p5-Alien-wxWidgets/diffs/pkg-plist.diff
+++ b/ports/x11-toolkits/p5-Alien-wxWidgets/diffs/pkg-plist.diff
@@ -1,0 +1,8 @@
+--- pkg-plist.orig	2020-07-13 18:48:49.064348000 +0200
++++ pkg-plist	2020-07-13 18:49:11.734411000 +0200
+@@ -1,5 +1,4 @@
+ %%SITE_ARCH%%/Alien/wxWidgets.pm
+-%%SITE_ARCH%%/Alien/wxWidgets/Config/gtk_3_0_5_uni_gcc_3_4.pm
+ %%SITE_ARCH%%/Alien/wxWidgets/Utility.pm
+ %%PERL5_MAN3%%/Alien::wxWidgets.3.gz
+ %%PERL5_MAN3%%/Alien::wxWidgets::Utility.3.gz


### PR DESCRIPTION
Possibly something is still missing to get a perl module named correctly "gtk_3_0_5_uni_gcc_3_4.pm" for FreeBSD vs "gtk_3_0_5_uni_nc_0.pm" in our case.

I've checked, so far that package didn't even ship a file. Let's say it's a step forward :)