### PR TITLE
lang/sbcl : fix build

### DIFF
--- a/ports/lang/sbcl/diffs/Makefile.diff
+++ b/ports/lang/sbcl/diffs/Makefile.diff
@@ -1,15 +1,15 @@
---- Makefile.orig	2020-06-28 18:44:21 UTC
-+++ Makefile
-@@ -97,7 +97,7 @@ SAFEPOINT_IMPLIES=	THREADS
- SBCL_VARS=		XC_HOST="${BOOT_WRKSRC}/src/runtime/sbcl --core ${BOOT_WRKSRC}/output/${CORE} --noinform --disable-debugger --no-sysinit --no-userinit"
- SBCL_DISTFILES=		${PORTNAME}-${SBCL_BOOT_LIST:M${ARCHOS_PATTERN}}-binary${EXTRACT_SUFX}:binaries
+--- Makefile.orig	2020-07-21 11:25:36.830243000 +0200
++++ Makefile	2020-07-21 11:27:19.870415000 +0200
+@@ -53,7 +53,7 @@
  
--THREADS_VARS=		MAKE_SH_ARGS+="--with-sb-thread --with-restore-fs-segment-register-from-tls"
-+THREADS_VARS=		MAKE_SH_ARGS+="--with-sb-thread --without-restore-fs-segment-register-from-tls"
- THREADS_VARS_OFF=	MAKE_SH_ARGS+="--without-sb-thread --without-restore-fs-segment-register-from-tls"
+ # All options explained into file: ${WRKSRC}/base-target-features.lisp-expr
+ OPTIONS_DEFINE=	DOCS QSHOW RENAME SAFEPOINT THREADS UNICODE XREF ZLIB
+-OPTIONS_DEFAULT=	RENAME SBCL THREADS UNICODE
++OPTIONS_DEFAULT=	RENAME SBCL UNICODE
  
- UNICODE_VARS=		MAKE_SH_ARGS+="--with-sb-unicode"
-@@ -113,7 +113,7 @@ PORTDOCS=	*
+ QSHOW_DESC=	C runtime with low-level debugging output
+ RENAME_DESC=	Rename suffix .core to _core
+@@ -113,7 +113,7 @@
  
  .include <bsd.port.options.mk>
  
@@ -18,7 +18,7 @@
  BOOT_WRKSRC=	${WRKDIR}/${PORTNAME}-${SBCL_BOOT_LIST:M${ARCHOS_PATTERN}}
  
  # for port maintenance, invoke "make makesum PLUS_BOOTSTRAPS=1"
-@@ -126,7 +126,7 @@ DISTFILES:=	${DISTFILES} ${PORTNAME}-${B
+@@ -126,7 +126,7 @@
  .endif
  
  # Old FreeBSD bootstraps feature the older core name for SBCL bootstrap


### PR DESCRIPTION
@tuxillo, from https://github.com/jrmarino/ravensource/blob/63c53237fb7b07b8ec69df48e826b697f440ed1a/bucket_FA/sbcl/specification

I notice that :

OPT_ON[dragonfly]=	DRAGONFLY
OPT_ON[freebsd]=	FREEBSD CONCURRENCY

and 

[CONCURRENCY].CMAKE_ARGS_OFF=		--without-sb-thread
					--without-restore-fs-segment-register-from-tls
[CONCURRENCY].CMAKE_ARGS_ON=		--with-sb-thread
					--with-restore-fs-segment-register-from-tls

So basically CONCURRENCY is the same set of options as what THREAD is in our Makefile, so I put back the THREADS_VARS to what it was and just disable the THREAD options for us.

I let you try, but it's building for me :)