### PR TITLE
Fix: emulators/bochs TERM option and serial port

### DIFF
--- a/ports/emulators/bochs/Makefile.DragonFly
+++ b/ports/emulators/bochs/Makefile.DragonFly
@@ -1,3 +1,8 @@
+# When TERM option is selected, we need ncurses from dports.
+TERM_USES+=  ncurses
+
 dfly-patch:
 	${REINPLACE_CMD} -e 's|__FreeBSD__|__DragonFly__|' \
 		${WRKSRC}/iodev/network/eth_socket.cc
+	${REINPLACE_CMD} -e 's|__FreeBSD__|__DragonFly__|' \
+		${WRKSRC}/iodev/serial.h


### PR DESCRIPTION
1) When "TERM" option is selected we need ncurses from dports.
2) Fixing serial.h to work with DragonFly BSD. With this fix serial port is working - tested.

--- please review and fix if appropriate.