### PR TITLE
Fix net/gerbera

### DIFF
--- a/ports/net/gerbera/Makefile.DragonFly
+++ b/ports/net/gerbera/Makefile.DragonFly
@@ -1,0 +1,9 @@
+# needs <filesystem>
+BUILD_DEPENDS+= cxxfs_gcc8>0:misc/cxxfs_gcc8
+CXXFLAGS+=      -isystem ${LOCALBASE}/cxxfs_gcc8
+LDFLAGS+=       -L${LOCALBASE}/cxxfs_gcc8
+
+# libnpupnp (e.g., v4.1.5) fails to listen socket on DragonFly and
+# needs further fix.  However, libupnp works well, so switch to it
+# for the moment.
+OPTIONS_DEFAULT:=${OPTIONS_DEFAULT:NLIBNPUPNP} LIBUPNP


### PR DESCRIPTION
* Gerbera requires C++17 filesystem feature, which is not available in
  the base GCC 8.0.  Pull in the 'misc/cxxfs_gcc8' port to fix this
  requirement.

* Switch the default UPnP library from libnpupnp to libupnp, because
  libnpupnp (e.g., v4.1.5) fails to listen socket on DragonFly and thus
  needs further fix; libupnp works well.