### PR TITLE
Create symbolic links libopensmtpd.so.0 ...

### DIFF
--- a/ports/mail/libopensmtpd/newport/Makefile
+++ b/ports/mail/libopensmtpd/newport/Makefile
@@ -19,16 +19,22 @@ USES=	gmake
 CFLAGS+=	-I${LOCALBASE}/include
 LDFLAGS+=	-L${LOCALBASE}/lib
 
+SOVERSION=	0.1.0
+SOSHORTVERSION= ${SOVERSION:C/\.[0-9].[0-9]$//}
+
+PLIST_SUB+=	SOVERSION=${SOVERSION} \
+		SOSHORTVERSION=${SOSHORTVERSION}
+
 post-patch:
 	${RM} ${BUILD_WRKSRC}/Makefile
 	${MV} ${BUILD_WRKSRC}/Makefile.gnu ${BUILD_WRKSRC}/Makefile
 
 do-install:
-	${INSTALL_LIB} ${WRKSRC}/libopensmtpd.so.0.1.0 ${STAGEDIR}${PREFIX}/lib/
+	${INSTALL_LIB} ${WRKSRC}/libopensmtpd.so.${SOVERSION} ${STAGEDIR}${PREFIX}/lib/
 	${INSTALL_DATA} ${WRKSRC}/opensmtpd.h ${STAGEDIR}${PREFIX}/include/
 
 post-install:
-	${LN} -s libopensmtpd.so.0.1.0 ${STAGEDIR}${PREFIX}/lib/libopensmtpd.so.0
-	${LN} -s libopensmtpd.so.0.1.0 ${STAGEDIR}${PREFIX}/lib/libopensmtpd.so
+	${LN} -s libopensmtpd.so.${SOVERSION} ${STAGEDIR}${PREFIX}/lib/libopensmtpd.so.${SOSHORTVERSION}
+	${LN} -s libopensmtpd.so.${SOVERSION} ${STAGEDIR}${PREFIX}/lib/libopensmtpd.so
 
 .include <bsd.port.mk>

--- a/ports/mail/libopensmtpd/newport/Makefile
+++ b/ports/mail/libopensmtpd/newport/Makefile
@@ -23,11 +23,12 @@ post-patch:
 	${RM} ${BUILD_WRKSRC}/Makefile
 	${MV} ${BUILD_WRKSRC}/Makefile.gnu ${BUILD_WRKSRC}/Makefile
 
-post-build:
-	${MV} ${WRKSRC}/libopensmtpd.so.0.1.0 ${WRKSRC}/libopensmtpd.so
-
 do-install:
-	${INSTALL_LIB} ${WRKSRC}/libopensmtpd.so ${STAGEDIR}${PREFIX}/lib/
+	${INSTALL_LIB} ${WRKSRC}/libopensmtpd.so.0.1.0 ${STAGEDIR}${PREFIX}/lib/
 	${INSTALL_DATA} ${WRKSRC}/opensmtpd.h ${STAGEDIR}${PREFIX}/include/
+
+post-install:
+	${LN} -s libopensmtpd.so.0.1.0 ${STAGEDIR}${PREFIX}/lib/libopensmtpd.so.0
+	${LN} -s libopensmtpd.so.0.1.0 ${STAGEDIR}${PREFIX}/lib/libopensmtpd.so
 
 .include <bsd.port.mk>

--- a/ports/mail/libopensmtpd/newport/pkg-plist
+++ b/ports/mail/libopensmtpd/newport/pkg-plist
@@ -1,4 +1,4 @@
 lib/libopensmtpd.so
-lib/libopensmtpd.so.0
-lib/libopensmtpd.so.0.1.0
+lib/libopensmtpd.so.%%SOSHORTVERSION%%
+lib/libopensmtpd.so.%%SOVERSION%%
 include/opensmtpd.h

--- a/ports/mail/libopensmtpd/newport/pkg-plist
+++ b/ports/mail/libopensmtpd/newport/pkg-plist
@@ -1,2 +1,4 @@
 lib/libopensmtpd.so
+lib/libopensmtpd.so.0
+lib/libopensmtpd.so.0.1.0
 include/opensmtpd.h


### PR DESCRIPTION
This is required for `opensmptd-filter-dkim` to work properly, which wants `libopensmtpd.so.0`.