### PR TITLE
security/py-nassl: Fix build phase

### DIFF
--- a/ports/security/py-nassl/Makefile.DragonFly
+++ b/ports/security/py-nassl/Makefile.DragonFly
@@ -1,0 +1,1 @@
+LIB_DEPENDS+=	libcrypt.so:security/libxcrypt


### PR DESCRIPTION
I ran [sample_client.py](https://github.com/nabla-c0d3/nassl/blob/release/sample_client.py) from upstream git repo and it worked, however during `dsynth test` i noticed a warning: 
```
actual-package-depends: dependency on /usr/lib/libcrypt.so not registered (normal if it belongs to base)
```
I'm not sure where it's coming from.