### PR TITLE
Fix `service h2o configtest`

### DIFF
--- a/ports/www/h2o/diffs/files_h2o.in.diff
+++ b/ports/www/h2o/diffs/files_h2o.in.diff
@@ -1,0 +1,11 @@
+--- files/h2o.in.orig	2022-09-13 23:02:33 UTC
++++ files/h2o.in
+@@ -37,7 +37,7 @@ command_args="-m daemon -c ${h2o_config}"
+ procname="%%LOCALBASE%%/bin/perl"
+ 
+ h2o_configtest() {
+-	"${command}" -c "${h2o_config}" -t
++	env "${h2o_env}" "${command}" -c "${h2o_config}" -t
+ }
+ 
+ run_rc_command "$1"


### PR DESCRIPTION
- Running `service h2o configtest` fails as it does not find Perl.

- Running `/usr/local/etc/rc.d/h2o configtest` usually works as it has /usr/local/bin in PATH.

- FreeBSD is not affected as their /usr/sbin/service binary starts the h2o script with `env -L -/daemon`, which populates the env with those defined in /etc/login.conf for login class `daemon`, which happens to include /usr/local/bin in the PATH. This works, but is not really their intention, as /usr/local/etc/rc.d/h2o explicitly defines `h2o_perl` and should pass this as H2O_PERL environment variable!