### PR TITLE
java/eclipse : unbreak build phase by updating Makefile.DragonFly

### DIFF
--- a/ports/java/eclipse/Makefile.DragonFly
+++ b/ports/java/eclipse/Makefile.DragonFly
@@ -1,3 +1,3 @@
 # org.eclipse.sdk.ide-freebsd.gtk.x86_64.tar.gz
-MAVEN_ECLIPSE:=  -Dnative=gtk.freebsd.amd64 -Dcomparator.repo=file://${WRKDIR}/${GH_PROJECT}-${PORTVERSION}/p2-stub -DforceContextQualifier=v${ECLIPSE_TSTAMP}
-ECLIPSE_RESULT:= eclipse.platform.releng.tychoeclipsebuilder/sdk/target/products/org.eclipse.sdk.ide-freebsd.gtk.amd64.tar.gz
+MAVEN_ECLIPSE:= -Dnative=gtk.freebsd.amd64 -Dmaven.repo.local=${WRKDIR}/eclipse-maven-repo-${PORTVERSION} -DforceContextQualifier=v${ECLIPSE_TSTAMP}
+ECLIPSE_RESULT:= eclipse.platform.releng.tychoeclipsebuilder/eclipse.platform.repository/target/products/org.eclipse.sdk.ide-freebsd.gtk.amd64.tar.gz


### PR DESCRIPTION
Reached [ERROR] Failed to execute goal org.eclipse.tycho:tycho-p2-director-plugin:3.0.0-SNAPSHOT:archive-products (archive-products) on project eclipse.platform.repository: Error packing product: Problem creating zip: Execution exception: Java heap space -> [Help 1]

I guess it will be hard to go further on my machine.