### PR TITLE
x11-drivers/xorgxrdp : use --use-strict-locations for configure phase

### DIFF
--- a/ports/x11-drivers/xorgxrdp/Makefile.DragonFly
+++ b/ports/x11-drivers/xorgxrdp/Makefile.DragonFly
@@ -1,0 +1,1 @@
+CONFIGURE_ARGS:=  --enable-strict-locations

--- a/ports/x11-drivers/xorgxrdp/diffs/pkg-plist.diff
+++ b/ports/x11-drivers/xorgxrdp/diffs/pkg-plist.diff
@@ -1,0 +1,10 @@
+--- pkg-plist.orig	2023-01-02 19:50:10.243006000 +0100
++++ pkg-plist	2023-01-02 19:50:37.513370000 +0100
+@@ -1,5 +1,5 @@
+-@dir /etc/X11/xrdp
+-/etc/X11/xrdp/xorg.conf
++@dir etc/X11/xrdp
++etc/X11/xrdp/xorg.conf
+ lib/xorg/modules/drivers/xrdpdev_drv.a
+ lib/xorg/modules/drivers/xrdpdev_drv.so
+ lib/xorg/modules/input/xrdpkeyb_drv.a


### PR DESCRIPTION
otherwise xorg.conf end up in /etc/X11/xrdp as seen in the changes brought by https://github.com/neutrinolabs/xorgxrdp/commit/60afc114d936bbf8a5e4b9fb3ba3f8de59d07c39