### PR TITLE
sysutils/dmidecode: Emulate FreeBSD to support UEFI-only systems

### DIFF
--- a/ports/sysutils/dmidecode/Makefile.DragonFly
+++ b/ports/sysutils/dmidecode/Makefile.DragonFly
@@ -1,0 +1,1 @@
+USES+=	alias


### PR DESCRIPTION
On UEFI-only systems, the SMBIOS Entry Point structure must be located by the SMBIOS_TABLE_GUID configuration table, which is now exported via the 'hint.smbios.0.mem' following the FreeBSD's way.

Patch sysutils/dmidecode to use the kenv.

See also: https://github.com/DragonFlyBSD/DragonFlyBSD/commit/5e488df32cb01056a5b714a522e51c69ab7b4612