### PR TITLE
multimedia/gstreamer1-libav : disable tests target as it requires gst…

### DIFF
--- a/ports/multimedia/gstreamer1-libav/Makefile.DragonFly
+++ b/ports/multimedia/gstreamer1-libav/Makefile.DragonFly
@@ -1,0 +1,1 @@
+MESON_ARGS+=	-Dtests=disabled


### PR DESCRIPTION
…reamer-check, disabled in multimedia/gstreamer1 because of POSIX timers not available