### PR TITLE
devel/llvm11: Remove patch which is only for LLDB

### DIFF
--- a/ports/devel/llvm11/diffs/REMOVE
+++ b/ports/devel/llvm11/diffs/REMOVE
@@ -1,1 +1,2 @@
 files/clang/patch-fformat_extensions.diff
+files/patch-swig


### PR DESCRIPTION
Remove patch which is only for LLDB