### PR TITLE
graphics/spirv-tools: Use gcc12 and use -Wno-error=maybe-uninitialized

### DIFF
--- a/ports/graphics/spirv-tools/Makefile.DragonFly
+++ b/ports/graphics/spirv-tools/Makefile.DragonFly
@@ -1,0 +1,2 @@
+USE_GCC_VERSION=12
+CXXFLAGS+= -Wno-error=maybe-uninitialized


### PR DESCRIPTION
decoration_manager.cpp:541 complains about being possibly uninitialized. However, it is initialized at line 540.