### PR TITLE
net/minidlna: Ignore sparseness check to make 'rescan' work

### DIFF
--- a/ports/net/minidlna/dragonfly/patch-monitor.c
+++ b/ports/net/minidlna/dragonfly/patch-monitor.c
@@ -1,0 +1,21 @@
+--- monitor.c.orig	2023-05-31 08:25:59 UTC
++++ monitor.c
+@@ -355,7 +355,17 @@ monitor_insert_directory(int fd, char *n
+ 		{
+ 			monitor_insert_directory(fd, esc_name, path_buf);
+ 		}
+-		else if( type == TYPE_FILE && check_notsparse(path_buf)) {
++		else if( type == TYPE_FILE && access(path_buf, R_OK) == 0) {
++			/*
++			 * Ignore the sparseness check on DragonFly to make the
++			 * rescanning work.  Although SEEK_HOLE is declared,
++			 * it's not implemented in lseek(2).  In addition, the
++			 * sparseness check by block count is broken for
++			 * filesystems with compression or deduplication, such
++			 * as HAMMER2.  Therefore, just disable the sparseness
++			 * check here and ignore the potential issues of Samba
++			 * client dealing with sparse files.
++			 */
+ 			monitor_insert_file(esc_name, path_buf);
+ 		}
+ 		free(esc_name);


### PR DESCRIPTION
The sparseness check function `check_notsparse()` isn't supported by DragonFly, and it caused the 'rescan' to not work; i.e., updated files were not indexed upon startup when the `-r` option was specified.

Just ignore the sparseness check to make the 'rescan' work as expected.

By the way, the `-r` option is recommended to add for minidlna; for example, add this to `/etc/rc.conf`:

```
minidlna_enable="YES"
minidlna_flags="-r"
```