### PR TITLE
Fix crash when cpu_count() is called with logical=False.

### DIFF
--- a/ports/sysutils/py-psutil/dragonfly/patch-psutil___psutil__bsd.c
+++ b/ports/sysutils/py-psutil/dragonfly/patch-psutil___psutil__bsd.c
@@ -1,5 +1,5 @@
---- psutil/_psutil_bsd.c.orig	2023-04-17 15:01:41 UTC
-+++ psutil/_psutil_bsd.c
+--- psutil/_psutil_bsd.c.orig	2024-03-20 12:50:43.531541000 +0200
++++ psutil/_psutil_bsd.c	2024-03-20 12:52:26.812446000 +0200
 @@ -105,6 +105,17 @@
      #ifndef DTYPE_VNODE
          #define DTYPE_VNODE 1
@@ -137,7 +137,7 @@
  #elif defined(PSUTIL_OPENBSD)
      if ((p)->p_flag & P_SYSTEM) {
  #endif
-@@ -1076,14 +1142,16 @@ static PyMethodDef mod_methods[] = {
+@@ -1076,18 +1142,23 @@ static PyMethodDef mod_methods[] = {
      {"proc_num_fds", psutil_proc_num_fds, METH_VARARGS},
      {"proc_open_files", psutil_proc_open_files, METH_VARARGS},
  #endif
@@ -156,7 +156,14 @@
      {"proc_getrlimit", psutil_proc_getrlimit, METH_VARARGS},
      {"proc_memory_maps", psutil_proc_memory_maps, METH_VARARGS},
      {"proc_setrlimit", psutil_proc_setrlimit, METH_VARARGS},
-@@ -1159,6 +1227,12 @@ static PyMethodDef mod_methods[] = {
+ #endif
++#if defined(PSUTIL_DRAGONFLY)
++    {"cpu_count_cores", psutil_cpu_count_cores, METH_VARARGS},
++#endif
+     {"proc_environ", psutil_proc_environ, METH_VARARGS},
+
+     // --- system-related functions
+@@ -1159,6 +1230,12 @@ static PyMethodDef mod_methods[] = {
      if (PyModule_AddIntConstant(mod, "SZOMB", SZOMB)) INITERR;
      if (PyModule_AddIntConstant(mod, "SWAIT", SWAIT)) INITERR;
      if (PyModule_AddIntConstant(mod, "SLOCK", SLOCK)) INITERR;


### PR DESCRIPTION
* Add cpu_count_cores() to list of symbols in _psutil_bsd.c.

Before:

>>> import psutil
>>> psutil.cpu_count()
8
>>> psutil.cpu_count(logical=True)
8
>>> psutil.cpu_count(logical=False)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module> File "/usr/local/lib/python3.9/site-packages/psutil/__init__.py", line 1591, in cpu_count ret = _psplatform.cpu_count_cores() File "/usr/local/lib/python3.9/site-packages/psutil/_psbsd.py", line 286, in cpu_count_cores return cext.cpu_count_cores() AttributeError: module 'psutil._psutil_bsd' has no attribute 'cpu_count_cores'
>>>

After:

>>> import psutil
>>> psutil.cpu_count()
8
>>> psutil.cpu_count(logical=True)
8
>>> psutil.cpu_count(logical=False)
4
>>>