### PR TITLE
x11-drivers/xf86-video-vesa: adopt freebsd workaround

### DIFF
--- a/ports/x11-drivers/xf86-video-vesa/dragonfly/patch-src_vesa.c
+++ b/ports/x11-drivers/xf86-video-vesa/dragonfly/patch-src_vesa.c
@@ -1,0 +1,11 @@
+--- src/vesa.c.orig	2024-07-11 09:29:26 UTC
++++ src/vesa.c
+@@ -464,7 +464,7 @@ VESAPciProbe(DriverPtr drv, int entity_n
+     if (pScrn != NULL) {
+ 	VESAPtr pVesa;
+ 
+-#ifndef __FreeBSD__
++#ifndef __DragonFly__
+ 	if (pci_device_has_kernel_driver(dev)) {
+ 	    ErrorF("vesa: Ignoring device with a bound kernel driver\n");
+ 	    return FALSE;


### PR DESCRIPTION
DragonFlyBSD adoption of [this commit](https://github.com/freebsd/freebsd-ports/commit/b6d89731d542582d2cc751e7a56b78df76a38ce7)