### PR TITLE
Updating devel/tree-sitter to match latest FreeBSD port

### DIFF
--- a/ports/devel/tree-sitter/STATUS
+++ b/ports/devel/tree-sitter/STATUS
@@ -1,3 +1,3 @@
 PORT
-Last attempt: 0.20.8
-Last success: 0.20.8
+Last attempt: 0.22.6
+Last success: 0.22.6

--- a/ports/devel/tree-sitter/diffs/Makefile.diff
+++ b/ports/devel/tree-sitter/diffs/Makefile.diff
@@ -1,0 +1,12 @@
+diff --git a/devel/tree-sitter/Makefile b/devel/tree-sitter/Makefile
+index c751e4a17e1..a0b51645e27 100644
+--- a/devel/tree-sitter/Makefile
++++ b/devel/tree-sitter/Makefile
+@@ -1,6 +1,6 @@
+ PORTNAME=	tree-sitter
+ DISTVERSIONPREFIX=	v
+-DISTVERSION=	0.20.8
++DISTVERSION=	0.22.6
+ CATEGORIES=	devel
+ 
+ MAINTAINER=	adamw@FreeBSD.org


### PR DESCRIPTION
This PR upgrades devel/tree-sitter to match the latest FreeBSD port. This port is required for editors/neovim 10.1 (matching latest FreeBSD port) to build.