### PR TITLE
Updating editors/neovim to match 2024Q3 in FreeBSD ports

### DIFF
--- a/ports/editors/neovim/dragonfly/patch-src_nvim_os_process.c
+++ b/ports/editors/neovim/dragonfly/patch-src_nvim_os_process.c
@@ -1,10 +1,10 @@
---- src/nvim/os/process.c.orig	2018-06-10 22:46:49 UTC
-+++ src/nvim/os/process.c
-@@ -12,13 +12,13 @@
- # include <tlhelp32.h>  // for CreateToolhelp32Snapshot
+--- src/nvim/os/process.c.orig	Thu May 16 12:34:32 2024
++++ src/nvim/os/process.c	Mon Sep
+@@ -15,13 +15,13 @@
+ # include <tlhelp32.h>
  #endif
  
--#if defined(__FreeBSD__)  // XXX: OpenBSD ?
+-#if defined(__FreeBSD__)
 +#if defined(__FreeBSD__) || defined(__DragonFly__)
  # include <string.h>
  # include <sys/types.h>
@@ -16,12 +16,12 @@
  # include <sys/param.h>
  #endif
  
-@@ -155,6 +155,9 @@ int os_proc_children(int ppid, int **pro
+@@ -156,6 +156,9 @@ int os_proc_children(int ppid, int **proc_list, size_t
  # elif defined(__FreeBSD__)
  #  define KP_PID(o) o.ki_pid
  #  define KP_PPID(o) o.ki_ppid
 +# elif defined(__DragonFly__)
-+#  define KP_PID(o)  o.kp_pid
++#  define KP_PID(o) o.kp_pid
 +#  define KP_PPID(o) o.kp_ppid
  # else
  #  define KP_PID(o) o.p_pid


### PR DESCRIPTION
This patch updates the failed build of editors/neovim to allow it to build properly under the 2024Q3 branch in FreeBSD ports.

Apologies for the duplicate PR, I did not realize what I did to fix my branch would close the previous one.