### PR TITLE
This patch enables bzip3 as a port for DragonFlyBSD.

### DIFF
--- a/ports/archivers/bzip3/Makefile.DragonFly
+++ b/ports/archivers/bzip3/Makefile.DragonFly
@@ -1,1 +1,0 @@
-IGNORE=   unmaintained, please request fixing to users mailing list

--- a/ports/archivers/bzip3/dragonfly/patch-include_common.h
+++ b/ports/archivers/bzip3/dragonfly/patch-include_common.h
@@ -1,0 +1,14 @@
+--- include/common.h.orig	Wed Dec  6 17:20:36 2023
++++ include/common.h	Thu Dec
+@@ -77,9 +77,9 @@ static void write_neutral_s32(u8 * data, s32 value) {
+     #define prefetchw(address) __builtin_prefetch((const void *)(address), 1, 0)
+ #elif defined(_M_IX86) || defined(_M_AMD64) || defined(__x86_64__) || defined(i386) || defined(__i386__) || \
+     defined(__i386)
+-    #include <intrin.h>
++    #include <x86intrin.h>
+     #define prefetch(address) _mm_prefetch((const void *)(address), _MM_HINT_NTA)
+-    #define prefetchw(address) _m_prefetchw((const void *)(address))
++    #define prefetchw(address) _m_prefetchw((void *)(address))
+ #elif defined(_M_ARM) || defined(__ARM_ARCH_7__) || defined(__ARM_ARCH_7A__) || defined(__ARM_ARCH_7R__) || \
+     defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7S__)
+     #include <intrin.h>


### PR DESCRIPTION
This patch removes the Makefile.DragonFly so the port will build, and modifies the 'include/common.h' file to allow for sucessfully building, installing, and running bzip3.

Port was tested by creating a bzip3 archive on a DragonFlyBSD machine and extracting it on a Linux machine with bzip3; then creating another bzip3 archive on Linux and extracting it using DragonFlyBSD, as well as the typical dsynth tests.