### PR TITLE
Updating port for net/sacc

### DIFF
--- a/ports/net/sacc/dragonfly/patch-ui__ti.c
+++ b/ports/net/sacc/dragonfly/patch-ui__ti.c
@@ -1,0 +1,11 @@
+--- ui_ti.c.orig	Mon Dec 23 08:16:12 2024
++++ ui_ti.c	Mon Dec
+@@ -2,7 +2,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
+-#include <term.h>
++#include <ncurses/term.h>
+ #include <termios.h>
+ #include <unistd.h>
+ #include <sys/types.h>


### PR DESCRIPTION
This patch updates net/sacc to match the version on the 2024Q3 branch of FreeBSD's ports tree.