### PR TITLE
security/ca_root_nss: Patch pkg-plist to not run certctl

### DIFF
--- a/ports/security/ca_root_nss/diffs/pkg-plist.diff
+++ b/ports/security/ca_root_nss/diffs/pkg-plist.diff
@@ -1,0 +1,9 @@
+--- pkg-plist.orig	2025-05-07 10:04:12 UTC
++++ pkg-plist
+@@ -2,6 +2,4 @@
+ @sample etc/ssl/cert.pem.sample
+ @sample openssl/cert.pem.sample
+ %%ETCSYMLINK%%/etc/ssl/cert.pem
+-@postexec certctl rehash
+-@postunexec certctl rehash
+ @postexec [ ! -e %%LOCALBASE%%/bin/cert-sync ] || %%LOCALBASE%%/bin/cert-sync --quiet %%PREFIX%%/share/certs/ca-root-nss.crt


### PR DESCRIPTION
certctl is a in-base utility in FreeBSD that manages certificates and trust stores.  We don't have it and I don't think we current need to port it over, because we don't yet have /etc/openssl/certs and other trust stores.

See also: https://lists.dragonflybsd.org/pipermail/users/2025-May/452480.html