### PR TITLE
x11-drivers/xf86-video-intel: Fix gem mmap ioctl

### DIFF
--- a/ports/x11-drivers/xf86-video-intel/dragonfly/patch-src_sna_kgem.c
+++ b/ports/x11-drivers/xf86-video-intel/dragonfly/patch-src_sna_kgem.c
@@ -1,11 +1,21 @@
---- src/sna/kgem.c.intermediate	2020-04-04 23:50:24 UTC
-+++ src/sna/kgem.c
-@@ -74,7 +74,7 @@ search_snoop_cache(struct kgem *kgem, un
- #define DBG_NO_USERPTR 0
- #define DBG_NO_UNSYNCHRONIZED_USERPTR 0
- #define DBG_NO_COHERENT_MMAP_GTT 0
--#define DBG_NO_LLC 0
-+#define DBG_NO_LLC 1
- #define DBG_NO_SEMAPHORES 0
- #define DBG_NO_MADV 0
- #define DBG_NO_UPLOAD_CACHE 0
+--- src/sna/kgem.c.orig	Tue May 13 02:19:56 2025
++++ src/sna/kgem.c	Tue May
+@@ -682,7 +682,7 @@ retry_wc:
+ 
+ static void *__kgem_bo_map__cpu(struct kgem *kgem, struct kgem_bo *bo)
+ {
+-	struct local_i915_gem_mmap arg;
++	struct local_i915_gem_mmap2 arg;
+ 	int err;
+ 
+ 	VG_CLEAR(arg);
+@@ -691,7 +691,8 @@ static void *__kgem_bo_map__cpu(struct kgem *kgem, str
+ retry:
+ 	arg.handle = bo->handle;
+ 	arg.size = bytes(bo);
+-	if ((err = do_ioctl(kgem->fd, LOCAL_IOCTL_I915_GEM_MMAP, &arg))) {
++	arg.flags = 0;
++	if ((err = do_ioctl(kgem->fd, LOCAL_IOCTL_I915_GEM_MMAP_v2, &arg))) {
+ 		DBG(("%s: failed %d, throttling/cleaning caches\n",
+ 		     __FUNCTION__, err));
+ 		assert(err != -EINVAL || bo->prime);


### PR DESCRIPTION
__kgem_bo_map__cpu uses old version of I915_GEM_MMAP ioctl and is rejected by the i915 driver. It causes the xorg driver to fallback to memcpy'ing buffers, which is slow. Patch it to use newer version of ioctl.