### PR TITLE
x11-servers/xorg-server: Re-enable glamor hw accel, disabled by default

### DIFF
--- a/ports/x11-servers/xorg-server/dragonfly/patch-hw_xfree86_drivers_modesetting_driver.c
+++ b/ports/x11-servers/xorg-server/dragonfly/patch-hw_xfree86_drivers_modesetting_driver.c
@@ -1,12 +1,11 @@
---- hw/xfree86/drivers/modesetting/driver.c.orig	2020-01-13 22:57:05 UTC
+--- hw/xfree86/drivers/modesetting/driver.c.orig	2025-06-10 06:55:30 UTC
 +++ hw/xfree86/drivers/modesetting/driver.c
-@@ -749,8 +749,7 @@ try_enable_glamor(ScrnInfoPtr pScrn)
+@@ -925,7 +925,7 @@ try_enable_glamor(ScrnInfoPtr pScrn)
      modesettingPtr ms = modesettingPTR(pScrn);
      const char *accel_method_str = xf86GetOptValString(ms->drmmode.Options,
                                                         OPTION_ACCEL_METHOD);
 -    Bool do_glamor = (!accel_method_str ||
--                      strcmp(accel_method_str, "glamor") == 0);
-+    Bool do_glamor = FALSE;
++    Bool do_glamor = (accel_method_str &&
+                       strcmp(accel_method_str, "glamor") == 0);
  
      ms->drmmode.glamor = FALSE;
- 


### PR DESCRIPTION
Intel i915 in master branch now supports hardware acceleration, bring back "AccelMethod" option to Xorg server, disabled by default for backwards compatibility.