### PR TITLE
sysutils/nut: Fix build and verified it works

### DIFF
--- a/ports/sysutils/nut/Makefile.DragonFly
+++ b/ports/sysutils/nut/Makefile.DragonFly
@@ -1,1 +1,0 @@
-DFLY_UNMAINTAINED= yes

--- a/ports/sysutils/nut/dragonfly/patch-drivers_libusb1.c
+++ b/ports/sysutils/nut/dragonfly/patch-drivers_libusb1.c
@@ -1,0 +1,22 @@
+--- drivers/libusb1.c.orig	Sun Nov  2 12:24:30 2025
++++ drivers/libusb1.c	Mon Nov
+@@ -54,7 +54,19 @@ static void nut_libusb_close(libusb_device_handle *ude
+  */
+ void nut_usb_addvars(void)
+ {
++#if defined(__DragonFly__) && __DragonFly_version < 600514
++	const struct libusb_version {
++		const uint16_t major;
++		const uint16_t minor;
++		const uint16_t micro;
++	} _v = {
++		.major = 1,
++		.minor = 0,
++		.micro = 0,
++	}, *v = &_v;
++#else
+ 	const struct libusb_version	*v = libusb_get_version();
++#endif
+ 
+ 	/* allow -x vendor=X, vendorid=X, product=X, productid=X, serial=X */
+ 	addvar(VAR_VALUE, "vendor", "Regular expression to match UPS Manufacturer string");


### PR DESCRIPTION
Stub the required libusb_get_version() function and make it build on DragonFly.  I've added this libusb function in base [0][1], so check for it as well.

I've tested that NUT worked well with APC Back-UPS BK650M2-CH.

[0] https://github.com/DragonFlyBSD/DragonFlyBSD/commit/562980527a90b306615806248ec16ac270412443
[1] https://github.com/DragonFlyBSD/DragonFlyBSD/commit/e3289943f50e07a01d419666bca1f3a2db930456