### PR TITLE
Renamed ProcessList to ProcessTable version 3.3.0

### DIFF
--- a/ports/sysutils/htop/dragonfly/patch-dragonflybsd_DragonFlyBSDProcessTable.c
+++ b/ports/sysutils/htop/dragonfly/patch-dragonflybsd_DragonFlyBSDProcessTable.c
@@ -1,18 +1,19 @@
---- dragonflybsd/DragonFlyBSDProcessList.c.orig	2018-04-10 13:42:59 UTC
-+++ dragonflybsd/DragonFlyBSDProcessList.c
-@@ -451,7 +451,7 @@ void ProcessList_goThroughEntries(Proces
+--- dragonflybsd/DragonFlyBSDProcessTable.c.orig	2025-12-15 16:14:45.299402000 +0000
++++ dragonflybsd/DragonFlyBSDProcessTable.c	2025-12-15 16:17:17.149434000 +0000
+@@ -168,7 +168,7 @@
+          proc->pgrp = kproc->kp_pgid;		// process group id
           proc->session = kproc->kp_sid;
-          proc->tty_nr = kproc->kp_tdev;		// control terminal device number
           proc->st_uid = kproc->kp_uid;		// user ID
 -         proc->processor = kproc->kp_lwp.kl_origcpu;
 +         proc->processor = kproc->kp_lwp.kl_cpuid;
           proc->starttime_ctime = kproc->kp_start.tv_sec;
-          proc->user = UsersTable_getRef(this->usersTable, proc->st_uid);
- 
-@@ -576,3 +576,21 @@ void ProcessList_goThroughEntries(Proces
-       proc->updated = true;
+          Process_fillStarttimeBuffer(proc);
+          proc->user = UsersTable_getRef(host->usersTable, proc->st_uid);
+@@ -319,4 +319,22 @@
+       proc->super.show = ! ((hideKernelThreads && Process_isKernelThread(proc)) || (hideUserlandThreads && Process_isUserlandThread(proc)));
+       proc->super.updated = true;
     }
- }
++}
 +
 +char **DragonFlyBSDGet_env(pid_t pid) {
 +
@@ -30,4 +31,4 @@
 +   env = kvm_getenvv(kd, kp, 0);
 +   kvm_close(kd);
 +   return env;
-+}
+ }


### PR DESCRIPTION
In the htop project, the file dragonflybsd/DragonFlyBSDProcessList.c was renamed to dragonflybsd/DragonFlyBSDProcessTable.c starting from version 3.3.0.