### PR TITLE
fix(net/bsdrcmds): suppress -Werror warnings on DragonFly

### DIFF
--- a/ports/net/bsdrcmds/Makefile.DragonFly
+++ b/ports/net/bsdrcmds/Makefile.DragonFly
@@ -1,2 +1,4 @@
 
 OPTIONS_DEFAULT:=	${OPTIONS_DEFAULT:NLIBBLACKLIST}
+CFLAGS+=	-Wno-misleading-indentation
+CFLAGS+=	-Wno-unused-const-variable


### PR DESCRIPTION
## Summary
AI-assisted fix for `net/bsdrcmds` build failure on DragonFlyBSD.

## Triage Analysis
- **Classification**: compile-error
- **Confidence**: high
- **Root Cause**: The rshd.c source triggers -Werror build failures due to:
  1. Misleading indentation warning at line 443
  2. Unused `copyright` variable at line 38

## Changes
- `ports/net/bsdrcmds/Makefile.DragonFly`: Added CFLAGS to suppress the specific warnings:
  - `-Wno-misleading-indentation`
  - `-Wno-unused-const-variable`
- Also includes the existing `OPTIONS_DEFAULT` fix to disable LIBBLACKLIST (FreeBSD-only feature)

## Rebuild Result
Build succeeded on DragonFlyBSD VM (dsynth force).

```
[000] SUCCESS net/bsdrcmds                                             00:00:03
    packages built: 1
           failed: 0
```

Package created: `bsdrcmds-20171003.01_1.pkg`

---
*This PR was generated by the agentic build system.*