### PR TITLE
collectd5: add `share/` prefix for manual pages

### DIFF
--- a/ports/net-mgmt/collectd5/diffs/pkg-plist.diff
+++ b/ports/net-mgmt/collectd5/diffs/pkg-plist.diff
@@ -30,3 +30,40 @@
  %%JAVA%%%%DATADIR%%/java/collectd-api.jar
  %%JAVA%%%%DATADIR%%/java/generic-jmx.jar
  %%ZOOKEEPER%%lib/collectd/zookeeper.so
+@@ -118,20 +118,20 @@ libdata/pkgconfig/libcollectdclient.pc
+ %%PERL%%%%SITE_PERL%%/Collectd/Plugins/OpenVZ.pm
+ %%PERL%%%%SITE_PERL%%/Collectd.pm
+ %%PERL%%%%SITE_PERL%%/Collectd/Unixsock.pm
+-man/man1/collectd-nagios.1.gz
+-man/man1/collectd-tg.1.gz
+-man/man1/collectd.1.gz
+-man/man1/collectdctl.1.gz
+-man/man1/collectdmon.1.gz
+-man/man5/collectd-email.5.gz
+-man/man5/collectd-exec.5.gz
+-man/man5/collectd-java.5.gz
+-man/man5/collectd-lua.5.gz
+-man/man5/collectd-perl.5.gz
+-man/man5/collectd-python.5.gz
+-man/man5/collectd-snmp.5.gz
+-man/man5/collectd-threshold.5.gz
+-man/man5/collectd-unixsock.5.gz
+-man/man5/collectd.conf.5.gz
+-man/man5/types.db.5.gz
++share/man/man1/collectd-nagios.1.gz
++share/man/man1/collectd-tg.1.gz
++share/man/man1/collectd.1.gz
++share/man/man1/collectdctl.1.gz
++share/man/man1/collectdmon.1.gz
++share/man/man5/collectd-email.5.gz
++share/man/man5/collectd-exec.5.gz
++share/man/man5/collectd-java.5.gz
++share/man/man5/collectd-lua.5.gz
++share/man/man5/collectd-perl.5.gz
++share/man/man5/collectd-python.5.gz
++share/man/man5/collectd-snmp.5.gz
++share/man/man5/collectd-threshold.5.gz
++share/man/man5/collectd-unixsock.5.gz
++share/man/man5/collectd.conf.5.gz
++share/man/man5/types.db.5.gz
+ @dir /var/db/collectd


### PR DESCRIPTION
Tried to reverse what the delta port fix should be from

`sudo -H git -C /usr/dports diff net-mgmt/collectd5 | tee collectd5.patch`:
```
diff --git a/net-mgmt/collectd5/pkg-plist b/net-mgmt/collectd5/pkg-plist
index 24488267013..f4a76dc258e 100644
--- a/net-mgmt/collectd5/pkg-plist
+++ b/net-mgmt/collectd5/pkg-plist
@@ -118,20 +118,20 @@ libdata/pkgconfig/libcollectdclient.pc
 %%PERL%%%%SITE_PERL%%/Collectd/Plugins/OpenVZ.pm
 %%PERL%%%%SITE_PERL%%/Collectd.pm
 %%PERL%%%%SITE_PERL%%/Collectd/Unixsock.pm
-man/man1/collectd-nagios.1.gz
-man/man1/collectd-tg.1.gz
-man/man1/collectd.1.gz
-man/man1/collectdctl.1.gz
-man/man1/collectdmon.1.gz
-man/man5/collectd-email.5.gz
-man/man5/collectd-exec.5.gz
-man/man5/collectd-java.5.gz
-man/man5/collectd-lua.5.gz
-man/man5/collectd-perl.5.gz
-man/man5/collectd-python.5.gz
-man/man5/collectd-snmp.5.gz
-man/man5/collectd-threshold.5.gz
-man/man5/collectd-unixsock.5.gz
-man/man5/collectd.conf.5.gz
-man/man5/types.db.5.gz
+share/man/man1/collectd-nagios.1.gz
+share/man/man1/collectd-tg.1.gz
+share/man/man1/collectd.1.gz
+share/man/man1/collectdctl.1.gz
+share/man/man1/collectdmon.1.gz
+share/man/man5/collectd-email.5.gz
+share/man/man5/collectd-exec.5.gz
+share/man/man5/collectd-java.5.gz
+share/man/man5/collectd-lua.5.gz
+share/man/man5/collectd-perl.5.gz
+share/man/man5/collectd-python.5.gz
+share/man/man5/collectd-snmp.5.gz
+share/man/man5/collectd-threshold.5.gz
+share/man/man5/collectd-unixsock.5.gz
+share/man/man5/collectd.conf.5.gz
+share/man/man5/types.db.5.gz
 @dir /var/db/collectd
```