### PR TITLE
builderhooks: add dsynth tracker hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ From the repository root, use:
 The wrapper bootstraps `scripts/generator/.venv` automatically on first run and
 dispatches to the installed `dportsv3` console entrypoint.
 
+For a disposable DragonFly chroot development shell, see
+`scripts/tools/dports-dev-env` and `docs/dev-chroot-environment.md`.
+
 ## Organization
 
 - **docs/**  

--- a/docs/dev-chroot-environment.md
+++ b/docs/dev-chroot-environment.md
@@ -1,0 +1,82 @@
+# Dev Chroot Environment
+
+`scripts/tools/dports-dev-env` creates a throwaway DragonFly chroot for port
+development while reusing cached inputs.
+
+Current scope:
+
+- backend: `chroot` only
+- rootfs source: latest `DragonFly-x86_64-*.world.tar.gz` from Avalon releases
+- DeltaPorts checkout: mounted live from the host
+- FreeBSD ports source: persistent mirror plus branch worktree
+
+## Requirements
+
+- run as `root`
+- host commands: `curl`, `tar`, `git`, `chroot`, `mount_null`, `mount_procfs`
+- network access to Avalon and the FreeBSD ports git remote
+
+## Create One Environment
+
+```bash
+sudo scripts/tools/dports-dev-env create --target @2026Q2 --origin editors/vim --shell
+```
+
+This will:
+
+1. discover the latest DragonFly `*world*` asset on Avalon,
+2. cache the downloaded archive,
+3. extract it once into the shared base cache,
+4. create a throwaway env root from that cache,
+5. mount the host DeltaPorts checkout into `/work/DeltaPorts`,
+6. create or refresh a cached FreeBSD ports worktree for the target branch,
+7. mount that worktree into `/work/freebsd-ports`,
+8. attempt to bootstrap a few development tools inside the chroot,
+9. run `compose` with `--oracle-profile off`,
+10. drop you into a shell if `--shell` was requested.
+
+## Enter Later
+
+```bash
+sudo scripts/tools/dports-dev-env shell 2026Q2-editors_vim
+```
+
+## Destroy
+
+```bash
+sudo scripts/tools/dports-dev-env destroy 2026Q2-editors_vim
+```
+
+## List
+
+```bash
+scripts/tools/dports-dev-env list
+```
+
+## Default Layout
+
+By default the helper stores state under `~/.cache/dports-dev/`:
+
+- `base-downloads/`: downloaded Avalon archives
+- `base-extracted/`: extracted reusable clean rootfs trees
+- `repos/freebsd-ports.git/`: persistent git mirror
+- `worktrees/freebsd-ports/<branch>/`: cached worktrees
+- `envs/<name>/root/`: throwaway chroot root
+
+## In-Chroot Helpers
+
+The shell defines:
+
+- `regen`: rerun compose for the environment target
+- `reapply`: rerun `dsl apply` for the selected origin
+- `showenv`: print `DPORTS_*` environment variables
+
+## Notes
+
+- `compose` failures do not delete the environment; the root is kept for manual
+  inspection.
+- Tool bootstrapping is best-effort beyond the required package list. The exact
+  package name providing `genpatch` may need adjustment for your host package
+  repositories.
+- The helper is intentionally structured around a `BACKEND` field in state so a
+  future jail backend can reuse the same UX.

--- a/scripts/builderhooks/README.tracker-hooks.md
+++ b/scripts/builderhooks/README.tracker-hooks.md
@@ -1,0 +1,38 @@
+# dsynth tracker hooks
+
+These hooks connect dsynth build events to the `dportsv3 tracker` server.
+
+Files:
+
+- `tracker_common.sh`: shared helper logic
+- `dportsv3-tracker.conf.example`: config template
+- `hook_run_start`, `hook_run_end`: tracker run lifecycle
+- `hook_pkg_start` / `hook_pkg_started`: enqueue + mark building
+- `hook_pkg_success`, `hook_pkg_failure`, `hook_pkg_ignored`,
+  `hook_pkg_skipped`: final result recording
+
+Install pattern:
+
+```bash
+install -d /etc/dsynth
+install -m 755 scripts/builderhooks/hook_* /etc/dsynth/
+install -m 755 scripts/builderhooks/tracker_common.sh /etc/dsynth/
+install -m 644 scripts/builderhooks/dportsv3-tracker.conf.example \
+  /etc/dsynth/dportsv3-tracker.conf
+```
+
+Then edit `/etc/dsynth/dportsv3-tracker.conf` for:
+
+- `DPORTSV3_BIN`
+- `DPORTSV3_TRACKER_URL`
+- `DPORTSV3_TRACKER_TARGET`
+- `DPORTSV3_TRACKER_BUILD_TYPE`
+
+Notes:
+
+- hooks log failures but exit successfully so dsynth builds continue if the
+  tracker is unavailable
+- `hook_pkg_start` and `hook_pkg_started` are both provided to cover local
+  dsynth variants
+- per-port start hooks enqueue the port before calling `mark-building`, which
+  matches tracker DB expectations

--- a/scripts/builderhooks/README.tracker-hooks.md
+++ b/scripts/builderhooks/README.tracker-hooks.md
@@ -36,3 +36,6 @@ Notes:
   dsynth variants
 - per-port start hooks enqueue the port before calling `mark-building`, which
   matches tracker DB expectations
+- if `start-build` fails (for example because an active run already exists for
+  the same target/build type), tracking is disabled for the rest of that dsynth
+  run instead of reusing a stale run id from a previous build

--- a/scripts/builderhooks/dportsv3-tracker.conf.example
+++ b/scripts/builderhooks/dportsv3-tracker.conf.example
@@ -1,0 +1,22 @@
+# dsynth tracker hook configuration
+
+# Absolute path to the repo-root wrapper or another installed dportsv3 binary.
+DPORTSV3_BIN=/absolute/path/to/DeltaPorts/dportsv3
+
+# Tracker server base URL.
+DPORTSV3_TRACKER_URL=http://127.0.0.1:8080
+
+# Build target associated with this dsynth profile.
+DPORTSV3_TRACKER_TARGET=@2026Q1
+
+# Tracker build type for this dsynth run.
+DPORTSV3_TRACKER_BUILD_TYPE=test
+
+# Directory used to store per-profile active run state.
+DPORTSV3_TRACKER_STATE_DIR=/var/db/dsynth-tracker
+
+# Hook-local log file. Hook failures are logged here and do not fail dsynth.
+DPORTSV3_TRACKER_HOOK_LOG=/var/log/dsynth-tracker-hooks.log
+
+# Optional external log URL prefix. If set, result hooks append `/ORIGIN`.
+# DPORTSV3_TRACKER_LOG_URL_BASE=https://logs.example/dsynth

--- a/scripts/builderhooks/hook_pkg_failure
+++ b/scripts/builderhooks/hook_pkg_failure
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+. "$(dirname "$0")/tracker_common.sh"
+tracker_record_result

--- a/scripts/builderhooks/hook_pkg_ignored
+++ b/scripts/builderhooks/hook_pkg_ignored
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+. "$(dirname "$0")/tracker_common.sh"
+tracker_record_result

--- a/scripts/builderhooks/hook_pkg_skipped
+++ b/scripts/builderhooks/hook_pkg_skipped
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+. "$(dirname "$0")/tracker_common.sh"
+tracker_record_result

--- a/scripts/builderhooks/hook_pkg_start
+++ b/scripts/builderhooks/hook_pkg_start
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+. "$(dirname "$0")/tracker_common.sh"
+tracker_mark_building

--- a/scripts/builderhooks/hook_pkg_started
+++ b/scripts/builderhooks/hook_pkg_started
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+. "$(dirname "$0")/tracker_common.sh"
+tracker_mark_building

--- a/scripts/builderhooks/hook_pkg_success
+++ b/scripts/builderhooks/hook_pkg_success
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+. "$(dirname "$0")/tracker_common.sh"
+tracker_record_result

--- a/scripts/builderhooks/hook_run_end
+++ b/scripts/builderhooks/hook_run_end
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+. "$(dirname "$0")/tracker_common.sh"
+tracker_run_end

--- a/scripts/builderhooks/hook_run_start
+++ b/scripts/builderhooks/hook_run_start
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+. "$(dirname "$0")/tracker_common.sh"
+tracker_run_start

--- a/scripts/builderhooks/tracker_common.sh
+++ b/scripts/builderhooks/tracker_common.sh
@@ -1,0 +1,230 @@
+#!/bin/sh
+
+set -u
+
+HOOK_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+TRACKER_CONFIG_PATH=${DPORTSV3_TRACKER_CONFIG:-"$HOOK_DIR/dportsv3-tracker.conf"}
+
+if [ -z "${DPORTSV3_BIN:-}" ] && [ -x "$HOOK_DIR/../../dportsv3" ]; then
+    DPORTSV3_BIN="$HOOK_DIR/../../dportsv3"
+fi
+
+if [ -z "${DPORTSV3_TRACKER_STATE_DIR:-}" ]; then
+    DPORTSV3_TRACKER_STATE_DIR="$HOOK_DIR/.tracker-state"
+fi
+
+if [ -z "${DPORTSV3_TRACKER_HOOK_LOG:-}" ]; then
+    DPORTSV3_TRACKER_HOOK_LOG="$HOOK_DIR/dportsv3-tracker-hooks.log"
+fi
+
+tracker_log() {
+    mkdir -p -- "$(dirname -- "$DPORTSV3_TRACKER_HOOK_LOG")" 2>/dev/null || true
+    printf '%s %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$*" >> "$DPORTSV3_TRACKER_HOOK_LOG" 2>/dev/null || true
+}
+
+tracker_fail_soft() {
+    tracker_log "ERROR: $*"
+    exit 0
+}
+
+tracker_load_config() {
+    if [ -f "$TRACKER_CONFIG_PATH" ]; then
+        # shellcheck disable=SC1090
+        . "$TRACKER_CONFIG_PATH"
+    fi
+
+    : "${PROFILE:=unknown}"
+
+    if [ -z "${DPORTSV3_BIN:-}" ]; then
+        tracker_fail_soft "DPORTSV3_BIN is not configured"
+    fi
+    if [ ! -x "$DPORTSV3_BIN" ]; then
+        tracker_fail_soft "DPORTSV3_BIN is not executable: $DPORTSV3_BIN"
+    fi
+    if [ -z "${DPORTSV3_TRACKER_URL:-}" ]; then
+        tracker_fail_soft "DPORTSV3_TRACKER_URL is not configured"
+    fi
+    if [ -z "${DPORTSV3_TRACKER_TARGET:-}" ]; then
+        tracker_fail_soft "DPORTSV3_TRACKER_TARGET is not configured"
+    fi
+    if [ -z "${DPORTSV3_TRACKER_BUILD_TYPE:-}" ]; then
+        DPORTSV3_TRACKER_BUILD_TYPE=test
+    fi
+
+    mkdir -p -- "$DPORTSV3_TRACKER_STATE_DIR" 2>/dev/null || true
+    TRACKER_STATE_FILE="$DPORTSV3_TRACKER_STATE_DIR/${PROFILE}.env"
+}
+
+tracker_load_state() {
+    if [ ! -f "$TRACKER_STATE_FILE" ]; then
+        tracker_fail_soft "missing tracker state file: $TRACKER_STATE_FILE"
+    fi
+    # shellcheck disable=SC1090
+    . "$TRACKER_STATE_FILE"
+    if [ -z "${RUN_ID:-}" ]; then
+        tracker_fail_soft "tracker state file missing RUN_ID: $TRACKER_STATE_FILE"
+    fi
+}
+
+tracker_write_state() {
+    tmp_file="$TRACKER_STATE_FILE.tmp.$$"
+    umask 077
+    cat > "$tmp_file" <<EOF
+RUN_ID=${RUN_ID}
+TARGET=${DPORTSV3_TRACKER_TARGET}
+BUILD_TYPE=${DPORTSV3_TRACKER_BUILD_TYPE}
+PORTS_QUEUED=${PORTS_QUEUED:-0}
+EOF
+    mv -f -- "$tmp_file" "$TRACKER_STATE_FILE"
+}
+
+tracker_clear_state() {
+    rm -f -- "$TRACKER_STATE_FILE"
+}
+
+tracker_pkg_version() {
+    pkgfile=${PKGNAME##*/}
+    pkgfile=${pkgfile%.*}
+    printf '%s\n' "${pkgfile##*-}"
+}
+
+tracker_run_start() {
+    tracker_load_config
+
+    output=$(
+        "$DPORTSV3_BIN" tracker start-build \
+            --target "$DPORTSV3_TRACKER_TARGET" \
+            --type "$DPORTSV3_TRACKER_BUILD_TYPE" \
+            --server "$DPORTSV3_TRACKER_URL" 2>&1
+    ) || tracker_fail_soft "start-build failed: $output"
+
+    RUN_ID=$(printf '%s\n' "$output" | awk '{print $4}')
+    case "$RUN_ID" in
+    ''|*[!0-9]*)
+        tracker_fail_soft "unable to parse run id from start-build output: $output"
+        ;;
+    esac
+
+    tracker_write_state
+    tracker_log "started tracker run $RUN_ID for profile=$PROFILE target=$DPORTSV3_TRACKER_TARGET type=$DPORTSV3_TRACKER_BUILD_TYPE queued=${PORTS_QUEUED:-0}"
+    exit 0
+}
+
+tracker_enqueue_one() {
+    origin=$1
+    version=$2
+
+    tmp_json=$(mktemp "$DPORTSV3_TRACKER_STATE_DIR/enqueue.${PROFILE}.XXXXXX.json") || \
+        tracker_fail_soft "failed to allocate temp json file"
+    cat > "$tmp_json" <<EOF
+[{"origin":"$origin","version":"$version"}]
+EOF
+
+    if [ -n "${PORTS_QUEUED:-}" ] && [ "$PORTS_QUEUED" -gt 0 ] 2>/dev/null; then
+        output=$(
+            "$DPORTSV3_BIN" tracker enqueue-ports \
+                --run "$RUN_ID" \
+                --file "$tmp_json" \
+                --total "$PORTS_QUEUED" \
+                --server "$DPORTSV3_TRACKER_URL" 2>&1
+        ) || {
+            rm -f -- "$tmp_json"
+            tracker_fail_soft "enqueue-ports failed for $origin: $output"
+        }
+    else
+        output=$(
+            "$DPORTSV3_BIN" tracker enqueue-ports \
+                --run "$RUN_ID" \
+                --file "$tmp_json" \
+                --server "$DPORTSV3_TRACKER_URL" 2>&1
+        ) || {
+            rm -f -- "$tmp_json"
+            tracker_fail_soft "enqueue-ports failed for $origin: $output"
+        }
+    fi
+
+    rm -f -- "$tmp_json"
+}
+
+tracker_mark_building() {
+    tracker_load_config
+    tracker_load_state
+
+    if [ -z "${ORIGIN:-}" ]; then
+        tracker_fail_soft "missing ORIGIN for pkg start hook"
+    fi
+    if [ -z "${PKGNAME:-}" ]; then
+        tracker_fail_soft "missing PKGNAME for pkg start hook"
+    fi
+
+    version=$(tracker_pkg_version)
+    tracker_enqueue_one "$ORIGIN" "$version"
+
+    output=$(
+        "$DPORTSV3_BIN" tracker mark-building \
+            --run "$RUN_ID" \
+            --origin "$ORIGIN" \
+            --server "$DPORTSV3_TRACKER_URL" 2>&1
+    ) || tracker_fail_soft "mark-building failed for $ORIGIN: $output"
+
+    tracker_log "marked building run=$RUN_ID origin=$ORIGIN version=$version"
+    exit 0
+}
+
+tracker_record_result() {
+    tracker_load_config
+    tracker_load_state
+
+    if [ -z "${ORIGIN:-}" ]; then
+        tracker_fail_soft "missing ORIGIN for pkg result hook"
+    fi
+    if [ -z "${PKGNAME:-}" ]; then
+        tracker_fail_soft "missing PKGNAME for pkg result hook"
+    fi
+
+    version=$(tracker_pkg_version)
+    log_url_arg=
+    if [ -n "${DPORTSV3_TRACKER_LOG_URL_BASE:-}" ]; then
+        log_url=${DPORTSV3_TRACKER_LOG_URL_BASE%/}/${ORIGIN}
+        log_url_arg="--log-url $log_url"
+    fi
+
+    if [ -n "$log_url_arg" ]; then
+        output=$(
+            "$DPORTSV3_BIN" tracker record-result \
+                --run "$RUN_ID" \
+                --origin "$ORIGIN" \
+                --version "$version" \
+                --result "$RESULT" \
+                --log-url "$log_url" \
+                --server "$DPORTSV3_TRACKER_URL" 2>&1
+        ) || tracker_fail_soft "record-result failed for $ORIGIN: $output"
+    else
+        output=$(
+            "$DPORTSV3_BIN" tracker record-result \
+                --run "$RUN_ID" \
+                --origin "$ORIGIN" \
+                --version "$version" \
+                --result "$RESULT" \
+                --server "$DPORTSV3_TRACKER_URL" 2>&1
+        ) || tracker_fail_soft "record-result failed for $ORIGIN: $output"
+    fi
+
+    tracker_log "recorded result run=$RUN_ID origin=$ORIGIN version=$version result=$RESULT"
+    exit 0
+}
+
+tracker_run_end() {
+    tracker_load_config
+    tracker_load_state
+
+    output=$(
+        "$DPORTSV3_BIN" tracker finish-build \
+            --run "$RUN_ID" \
+            --server "$DPORTSV3_TRACKER_URL" 2>&1
+    ) || tracker_fail_soft "finish-build failed for run $RUN_ID: $output"
+
+    tracker_log "finished tracker run $RUN_ID for profile=$PROFILE built=${PORTS_BUILT:-0} failed=${PORTS_FAILED:-0} ignored=${PORTS_IGNORED:-0} skipped=${PORTS_SKIPPED:-0}"
+    tracker_clear_state
+    exit 0
+}

--- a/scripts/builderhooks/tracker_common.sh
+++ b/scripts/builderhooks/tracker_common.sh
@@ -61,6 +61,9 @@ tracker_load_state() {
     fi
     # shellcheck disable=SC1090
     . "$TRACKER_STATE_FILE"
+    if [ "${TRACKING_DISABLED:-0}" = "1" ]; then
+        exit 0
+    fi
     if [ -z "${RUN_ID:-}" ]; then
         tracker_fail_soft "tracker state file missing RUN_ID: $TRACKER_STATE_FILE"
     fi
@@ -82,6 +85,18 @@ tracker_clear_state() {
     rm -f -- "$TRACKER_STATE_FILE"
 }
 
+tracker_disable_state() {
+    reason=$1
+    tmp_file="$TRACKER_STATE_FILE.tmp.$$"
+    umask 077
+    cat > "$tmp_file" <<EOF
+TRACKING_DISABLED=1
+EOF
+    mv -f -- "$tmp_file" "$TRACKER_STATE_FILE"
+    tracker_log "tracking disabled for profile=$PROFILE: $reason"
+    exit 0
+}
+
 tracker_pkg_version() {
     pkgfile=${PKGNAME##*/}
     pkgfile=${pkgfile%.*}
@@ -90,13 +105,14 @@ tracker_pkg_version() {
 
 tracker_run_start() {
     tracker_load_config
+    tracker_clear_state
 
     output=$(
         "$DPORTSV3_BIN" tracker start-build \
             --target "$DPORTSV3_TRACKER_TARGET" \
             --type "$DPORTSV3_TRACKER_BUILD_TYPE" \
             --server "$DPORTSV3_TRACKER_URL" 2>&1
-    ) || tracker_fail_soft "start-build failed: $output"
+    ) || tracker_disable_state "start-build failed: $output"
 
     RUN_ID=$(printf '%s\n' "$output" | awk '{print $4}')
     case "$RUN_ID" in

--- a/scripts/builderhooks/tracker_common.sh
+++ b/scripts/builderhooks/tracker_common.sh
@@ -130,7 +130,7 @@ tracker_enqueue_one() {
     origin=$1
     version=$2
 
-    tmp_json=$(mktemp "$DPORTSV3_TRACKER_STATE_DIR/enqueue.${PROFILE}.XXXXXX.json") || \
+    tmp_json=$(mktemp "$DPORTSV3_TRACKER_STATE_DIR/enqueue.${PROFILE}.XXXXXX") || \
         tracker_fail_soft "failed to allocate temp json file"
     cat > "$tmp_json" <<EOF
 [{"origin":"$origin","version":"$version"}]

--- a/scripts/generator/dportsv3/tracker/db.py
+++ b/scripts/generator/dportsv3/tracker/db.py
@@ -13,6 +13,17 @@ VALID_BUILD_RESULTS = frozenset({"success", "failure", "skipped", "ignored"})
 DEFAULT_BUILD_TYPES = ("test", "release")
 
 
+def open_db(db_path: str | Path) -> sqlite3.Connection:
+    """Open one configured SQLite connection for tracker operations."""
+    path_text = str(db_path)
+    conn = sqlite3.connect(path_text, check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    if path_text != ":memory:":
+        conn.execute("PRAGMA journal_mode = WAL")
+    return conn
+
+
 class ActiveBuildError(RuntimeError):
     """Raised when a target/build_type already has an active run."""
 
@@ -31,11 +42,7 @@ class ActiveBuildError(RuntimeError):
 def init_db(db_path: str | Path) -> sqlite3.Connection:
     """Initialize the tracker schema and return one configured connection."""
     path_text = str(db_path)
-    conn = sqlite3.connect(path_text, check_same_thread=False)
-    conn.row_factory = sqlite3.Row
-    conn.execute("PRAGMA foreign_keys = ON")
-    if path_text != ":memory:":
-        conn.execute("PRAGMA journal_mode = WAL")
+    conn = open_db(path_text)
 
     with conn:
         conn.executescript(

--- a/scripts/generator/dportsv3/tracker/server.py
+++ b/scripts/generator/dportsv3/tracker/server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+from contextlib import contextmanager
 from importlib import util as importlib_util
 from pathlib import Path
 from typing import Any, cast
@@ -23,6 +24,7 @@ from dportsv3.tracker.db import (
     get_target_summary,
     init_db,
     list_build_runs,
+    open_db,
     record_results,
     update_port_status,
 )
@@ -123,7 +125,6 @@ def create_app(db_path: str | Path) -> Any:
 
     app: Any = FastAPI(title="DeltaPorts Build Tracker")
     app.state.db_path = str(db_path)
-    app.state.db_conn = None
     templates_dir = Path(__file__).with_name("templates")
     static_dir = Path(__file__).with_name("static")
     templates: Any = Jinja2Templates(directory=str(templates_dir))
@@ -132,19 +133,20 @@ def create_app(db_path: str | Path) -> Any:
 
     @app.on_event("startup")
     def _startup() -> None:
-        app.state.db_conn = init_db(app.state.db_path)
+        conn = init_db(app.state.db_path)
+        conn.close()
 
     @app.on_event("shutdown")
     def _shutdown() -> None:
-        if app.state.db_conn is not None:
-            app.state.db_conn.close()
-            app.state.db_conn = None
+        return None
 
+    @contextmanager
     def _conn() -> Any:
-        conn = app.state.db_conn
-        if conn is None:
-            raise RuntimeError("Tracker DB connection is not initialized")
-        return conn
+        conn = open_db(app.state.db_path)
+        try:
+            yield conn
+        finally:
+            conn.close()
 
     def _raise_http_error(exc: Exception) -> None:
         if isinstance(exc, ActiveBuildError):
@@ -165,12 +167,13 @@ def create_app(db_path: str | Path) -> Any:
     def start_build(payload: StartBuildRequest) -> dict[str, int]:
         run_id = 0
         try:
-            run_id = create_build_run(
-                _conn(),
-                target=payload.target,
-                build_type=payload.build_type,
-                started_at=payload.started_at,
-            )
+            with _conn() as conn:
+                run_id = create_build_run(
+                    conn,
+                    target=payload.target,
+                    build_type=payload.build_type,
+                    started_at=payload.started_at,
+                )
         except Exception as exc:
             _raise_http_error(exc)
             raise AssertionError("unreachable")
@@ -179,14 +182,15 @@ def create_app(db_path: str | Path) -> Any:
     @app.patch("/api/builds/{run_id}")
     def finish_build(run_id: int, payload: FinishBuildRequest) -> dict[str, bool]:
         try:
-            finish_build_run(
-                _conn(),
-                run_id=run_id,
-                finished_at=payload.finished_at,
-                commit_sha=payload.commit_sha,
-                commit_branch=payload.commit_branch,
-                commit_pushed_at=payload.commit_pushed_at,
-            )
+            with _conn() as conn:
+                finish_build_run(
+                    conn,
+                    run_id=run_id,
+                    finished_at=payload.finished_at,
+                    commit_sha=payload.commit_sha,
+                    commit_branch=payload.commit_branch,
+                    commit_pushed_at=payload.commit_pushed_at,
+                )
         except Exception as exc:
             _raise_http_error(exc)
         return {"ok": True}
@@ -198,13 +202,14 @@ def create_app(db_path: str | Path) -> Any:
     ) -> dict[str, int]:
         recorded = 0
         try:
-            run = get_build_run(_conn(), run_id)
-            recorded = record_results(
-                _conn(),
-                run_id=run_id,
-                target=str(run["target"]),
-                results=[item.model_dump() for item in payload.results],
-            )
+            with _conn() as conn:
+                run = get_build_run(conn, run_id)
+                recorded = record_results(
+                    conn,
+                    run_id=run_id,
+                    target=str(run["target"]),
+                    results=[item.model_dump() for item in payload.results],
+                )
         except Exception as exc:
             _raise_http_error(exc)
             raise AssertionError("unreachable")
@@ -213,12 +218,13 @@ def create_app(db_path: str | Path) -> Any:
     @app.post("/api/builds/{run_id}/queue", response_model=EnqueueResponse)
     def enqueue(run_id: int, payload: EnqueueRequest) -> dict[str, int]:
         try:
-            count = enqueue_ports(
-                _conn(),
-                run_id,
-                [item.model_dump() for item in payload.ports],
-                total_expected=payload.total_expected,
-            )
+            with _conn() as conn:
+                count = enqueue_ports(
+                    conn,
+                    run_id,
+                    [item.model_dump() for item in payload.ports],
+                    total_expected=payload.total_expected,
+                )
         except Exception as exc:
             _raise_http_error(exc)
             raise AssertionError("unreachable")
@@ -231,7 +237,8 @@ def create_app(db_path: str | Path) -> Any:
         payload: UpdatePortStatusRequest,
     ) -> dict[str, bool]:
         try:
-            update_port_status(_conn(), run_id, origin, payload.status)
+            with _conn() as conn:
+                update_port_status(conn, run_id, origin, payload.status)
         except Exception as exc:
             _raise_http_error(exc)
         return {"ok": True}
@@ -242,14 +249,16 @@ def create_app(db_path: str | Path) -> Any:
         build_type: str | None = None,
         limit: int = Query(default=20, ge=1, le=1000),
     ) -> list[dict[str, Any]]:
-        return list_build_runs(
-            _conn(), target=target, build_type=build_type, limit=limit
-        )
+        with _conn() as conn:
+            return list_build_runs(
+                conn, target=target, build_type=build_type, limit=limit
+            )
 
     @app.get("/api/builds/compare", response_model=BuildCompareOut)
     def api_compare_builds(a: int, b: int) -> dict[str, Any]:
         try:
-            return compare_builds(_conn(), a, b)
+            with _conn() as conn:
+                return compare_builds(conn, a, b)
         except Exception as exc:
             _raise_http_error(exc)
             raise AssertionError("unreachable")
@@ -257,10 +266,11 @@ def create_app(db_path: str | Path) -> Any:
     @app.get("/api/builds/{run_id}")
     def api_get_build(run_id: int) -> dict[str, Any]:
         try:
-            return {
-                "build_run": get_build_run(_conn(), run_id),
-                "results": get_build_results(_conn(), run_id),
-            }
+            with _conn() as conn:
+                return {
+                    "build_run": get_build_run(conn, run_id),
+                    "results": get_build_results(conn, run_id),
+                }
         except Exception as exc:
             _raise_http_error(exc)
             raise AssertionError("unreachable")
@@ -270,29 +280,33 @@ def create_app(db_path: str | Path) -> Any:
         target: str | None = None,
         origin: str | None = None,
     ) -> list[dict[str, Any]]:
-        return get_port_status(_conn(), target=target, origin=origin)
+        with _conn() as conn:
+            return get_port_status(conn, target=target, origin=origin)
 
     @app.get("/api/failures", response_model=list[PortStatusOut])
     def api_failures(target: str) -> list[dict[str, Any]]:
-        return get_failures(_conn(), target)
+        with _conn() as conn:
+            return get_failures(conn, target)
 
     @app.get("/api/diff", response_model=DiffOut)
     def api_diff(a: str, b: str) -> dict[str, Any]:
-        return get_diff(_conn(), a, b)
+        with _conn() as conn:
+            return get_diff(conn, a, b)
 
     @app.get("/", response_class=HTMLResponse)
     def dashboard_index(request: RequestType) -> Any:
-        active_builds = get_active_builds_summary(_conn())
-        return templates.TemplateResponse(
-            request,
-            "index.html",
-            {
-                "title": "Targets",
-                "targets": get_target_summary(_conn()),
-                "active_builds": active_builds,
-                "refresh_seconds": 30 if active_builds else None,
-            },
-        )
+        with _conn() as conn:
+            active_builds = get_active_builds_summary(conn)
+            return templates.TemplateResponse(
+                request,
+                "index.html",
+                {
+                    "title": "Targets",
+                    "targets": get_target_summary(conn),
+                    "active_builds": active_builds,
+                    "refresh_seconds": 30 if active_builds else None,
+                },
+            )
 
     @app.get("/target/{target}", response_class=HTMLResponse)
     def dashboard_target(
@@ -302,55 +316,63 @@ def create_app(db_path: str | Path) -> Any:
         q: str = "",
         page: int = Query(default=1, ge=1),
     ) -> Any:
-        rows = get_port_status(_conn(), target=target)
-        query = q.strip().lower()
-        if status_filter == "failures":
-            rows = [row for row in rows if row.get("last_attempt_result") == "failure"]
-        elif status_filter == "successes":
-            rows = [row for row in rows if row.get("last_attempt_result") == "success"]
-        if query:
-            rows = [row for row in rows if query in str(row.get("origin", "")).lower()]
-        page_size = 100
-        start = (page - 1) * page_size
-        page_rows = rows[start : start + page_size]
-        page_count = max(1, (len(rows) + page_size - 1) // page_size)
-        return templates.TemplateResponse(
-            request,
-            "target.html",
-            {
-                "title": target,
-                "target": target,
-                "rows": page_rows,
-                "status_filter": status_filter,
-                "query": q,
-                "page": page,
-                "page_count": page_count,
-                "page_size": page_size,
-                "total_rows": len(rows),
-            },
-        )
+        with _conn() as conn:
+            rows = get_port_status(conn, target=target)
+            query = q.strip().lower()
+            if status_filter == "failures":
+                rows = [
+                    row for row in rows if row.get("last_attempt_result") == "failure"
+                ]
+            elif status_filter == "successes":
+                rows = [
+                    row for row in rows if row.get("last_attempt_result") == "success"
+                ]
+            if query:
+                rows = [
+                    row for row in rows if query in str(row.get("origin", "")).lower()
+                ]
+            page_size = 100
+            start = (page - 1) * page_size
+            page_rows = rows[start : start + page_size]
+            page_count = max(1, (len(rows) + page_size - 1) // page_size)
+            return templates.TemplateResponse(
+                request,
+                "target.html",
+                {
+                    "title": target,
+                    "target": target,
+                    "rows": page_rows,
+                    "status_filter": status_filter,
+                    "query": q,
+                    "page": page,
+                    "page_count": page_count,
+                    "page_size": page_size,
+                    "total_rows": len(rows),
+                },
+            )
 
     @app.get("/target/{target}/{cat}/{port}", response_class=HTMLResponse)
     def dashboard_port_detail(
         request: RequestType, target: str, cat: str, port: str
     ) -> Any:
         origin = f"{cat}/{port}"
-        rows = get_port_status(_conn(), target=target, origin=origin)
-        if not rows:
-            raise HTTPException(
-                status_code=404, detail=f"Unknown port status: {target} {origin}"
+        with _conn() as conn:
+            rows = get_port_status(conn, target=target, origin=origin)
+            if not rows:
+                raise HTTPException(
+                    status_code=404, detail=f"Unknown port status: {target} {origin}"
+                )
+            return templates.TemplateResponse(
+                request,
+                "port_detail.html",
+                {
+                    "title": f"{origin} {target}",
+                    "target": target,
+                    "origin": origin,
+                    "status": rows[0],
+                    "history": get_port_history(conn, target, origin, limit=20),
+                },
             )
-        return templates.TemplateResponse(
-            request,
-            "port_detail.html",
-            {
-                "title": f"{origin} {target}",
-                "target": target,
-                "origin": origin,
-                "status": rows[0],
-                "history": get_port_history(_conn(), target, origin, limit=20),
-            },
-        )
 
     @app.get("/builds", response_class=HTMLResponse)
     def dashboard_builds(
@@ -359,32 +381,34 @@ def create_app(db_path: str | Path) -> Any:
         build_type: str | None = None,
         limit: int = Query(default=50, ge=1, le=500),
     ) -> Any:
-        runs = list_build_runs(
-            _conn(), target=target, build_type=build_type, limit=limit
-        )
-        compare_links = _resolve_compare_links(runs)
-        return templates.TemplateResponse(
-            request,
-            "builds.html",
-            {
-                "title": "Builds",
-                "runs": runs,
-                "compare_links": compare_links,
-                "target": target,
-                "build_type": build_type,
-            },
-        )
+        with _conn() as conn:
+            runs = list_build_runs(
+                conn, target=target, build_type=build_type, limit=limit
+            )
+            compare_links = _resolve_compare_links(runs)
+            return templates.TemplateResponse(
+                request,
+                "builds.html",
+                {
+                    "title": "Builds",
+                    "runs": runs,
+                    "compare_links": compare_links,
+                    "target": target,
+                    "build_type": build_type,
+                },
+            )
 
     @app.get("/builds/compare", response_class=HTMLResponse)
     def dashboard_build_compare(request: RequestType, a: int, b: int) -> Any:
-        return templates.TemplateResponse(
-            request,
-            "build_compare.html",
-            {
-                "title": "Build Compare",
-                "compare": compare_builds(_conn(), a, b),
-            },
-        )
+        with _conn() as conn:
+            return templates.TemplateResponse(
+                request,
+                "build_compare.html",
+                {
+                    "title": "Build Compare",
+                    "compare": compare_builds(conn, a, b),
+                },
+            )
 
     @app.get("/builds/{run_id}", response_class=HTMLResponse)
     def dashboard_build_detail(
@@ -392,31 +416,32 @@ def create_app(db_path: str | Path) -> Any:
         run_id: int,
         status_filter: str = Query(default="all", alias="filter"),
     ) -> Any:
-        payload = {
-            "build_run": get_build_run(_conn(), run_id),
-            "results": get_build_results(_conn(), run_id),
-        }
-        build = payload["build_run"]
-        results = payload["results"]
-        if status_filter == "failures":
-            results = [row for row in results if row.get("result") == "failure"]
-        elif status_filter == "successes":
-            results = [row for row in results if row.get("result") == "success"]
-        elif status_filter == "building":
-            results = [row for row in results if row.get("status") == "building"]
-        elif status_filter == "queued":
-            results = [row for row in results if row.get("status") == "queued"]
-        return templates.TemplateResponse(
-            request,
-            "build_detail.html",
-            {
-                "title": f"Build {run_id}",
-                "build": build,
-                "results": results,
-                "status_filter": status_filter,
-                "refresh_seconds": 10 if build.get("finished_at") is None else None,
-            },
-        )
+        with _conn() as conn:
+            payload = {
+                "build_run": get_build_run(conn, run_id),
+                "results": get_build_results(conn, run_id),
+            }
+            build = payload["build_run"]
+            results = payload["results"]
+            if status_filter == "failures":
+                results = [row for row in results if row.get("result") == "failure"]
+            elif status_filter == "successes":
+                results = [row for row in results if row.get("result") == "success"]
+            elif status_filter == "building":
+                results = [row for row in results if row.get("status") == "building"]
+            elif status_filter == "queued":
+                results = [row for row in results if row.get("status") == "queued"]
+            return templates.TemplateResponse(
+                request,
+                "build_detail.html",
+                {
+                    "title": f"Build {run_id}",
+                    "build": build,
+                    "results": results,
+                    "status_filter": status_filter,
+                    "refresh_seconds": 10 if build.get("finished_at") is None else None,
+                },
+            )
 
     @app.get("/diff", response_class=HTMLResponse)
     def dashboard_diff(
@@ -424,19 +449,20 @@ def create_app(db_path: str | Path) -> Any:
         a: str | None = None,
         b: str | None = None,
     ) -> Any:
-        targets = get_target_summary(_conn())
-        diff_payload = get_diff(_conn(), a, b) if a and b else None
-        return templates.TemplateResponse(
-            request,
-            "diff.html",
-            {
-                "title": "Target Diff",
-                "targets": targets,
-                "target_a": a,
-                "target_b": b,
-                "diff": diff_payload,
-            },
-        )
+        with _conn() as conn:
+            targets = get_target_summary(conn)
+            diff_payload = get_diff(conn, a, b) if a and b else None
+            return templates.TemplateResponse(
+                request,
+                "diff.html",
+                {
+                    "title": "Target Diff",
+                    "targets": targets,
+                    "target_a": a,
+                    "target_b": b,
+                    "diff": diff_payload,
+                },
+            )
 
     return app
 

--- a/scripts/generator/tests/test_tracker_api.py
+++ b/scripts/generator/tests/test_tracker_api.py
@@ -8,6 +8,7 @@ fastapi = pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
 
 from dportsv3.tracker.server import create_app
+import dportsv3.tracker.server as tracker_server
 
 
 @pytest.fixture
@@ -215,3 +216,37 @@ def test_api_status_failures_and_diff_endpoints(client: TestClient) -> None:
     assert [row["origin"] for row in failures.json()] == ["devel/foo"]
     assert diff.status_code == 200
     assert [row["origin"] for row in diff.json()["differ"]] == ["devel/foo"]
+
+
+def test_api_uses_fresh_db_connection_per_request(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    open_count = 0
+    real_open_db = tracker_server.open_db
+
+    def _counting_open_db(db_path: str | Path):
+        nonlocal open_count
+        open_count += 1
+        return real_open_db(db_path)
+
+    monkeypatch.setattr(tracker_server, "open_db", _counting_open_db)
+
+    app = create_app(tmp_path / "tracker.db")
+    with TestClient(app) as test_client:
+        start = test_client.post(
+            "/api/builds",
+            json={"target": "@main", "build_type": "test"},
+        )
+        assert start.status_code == 200
+        run_id = start.json()["id"]
+
+        enqueue = test_client.post(
+            f"/api/builds/{run_id}/queue",
+            json={"ports": [{"origin": "devel/foo", "version": "1.0"}]},
+        )
+        assert enqueue.status_code == 200
+
+        detail = test_client.get(f"/api/builds/{run_id}")
+        assert detail.status_code == 200
+
+    assert open_count >= 3

--- a/scripts/tools/dports-dev-env
+++ b/scripts/tools/dports-dev-env
@@ -1,0 +1,502 @@
+#!/bin/sh
+
+set -eu
+
+SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$SELF_DIR/../.." && pwd)
+
+DPORTS_DEV_CACHE_ROOT=${DPORTS_DEV_CACHE_ROOT:-${HOME}/.cache/dports-dev}
+DPORTS_DEV_ENVS_DIR=${DPORTS_DEV_ENVS_DIR:-$DPORTS_DEV_CACHE_ROOT/envs}
+DPORTS_DEV_BASE_DIR=${DPORTS_DEV_BASE_DIR:-$DPORTS_DEV_CACHE_ROOT/base-extracted}
+DPORTS_DEV_DOWNLOAD_DIR=${DPORTS_DEV_DOWNLOAD_DIR:-$DPORTS_DEV_CACHE_ROOT/base-downloads}
+DPORTS_DEV_REPOS_DIR=${DPORTS_DEV_REPOS_DIR:-$DPORTS_DEV_CACHE_ROOT/repos}
+DPORTS_DEV_WORKTREES_DIR=${DPORTS_DEV_WORKTREES_DIR:-$DPORTS_DEV_CACHE_ROOT/worktrees}
+DPORTS_DEV_AVALON_RELEASES_URL=${DPORTS_DEV_AVALON_RELEASES_URL:-https://avalon.dragonflybsd.org/snapshots/x86_64/assets/releases/}
+DPORTS_DEV_FREEBSD_PORTS_URL=${DPORTS_DEV_FREEBSD_PORTS_URL:-https://git.FreeBSD.org/ports.git}
+DPORTS_DEV_TOOL_PKGS_REQUIRED=${DPORTS_DEV_TOOL_PKGS_REQUIRED:-bash curl git patch jq}
+DPORTS_DEV_PYTHON_PKGS=${DPORTS_DEV_PYTHON_PKGS:-python313 python312 python311}
+DPORTS_DEV_TOOL_PKGS_OPTIONAL=${DPORTS_DEV_TOOL_PKGS_OPTIONAL:-python311 python312 python313 py311-pip py312-pip py313-pip genpatch}
+
+usage() {
+    cat <<'EOF'
+usage: scripts/tools/dports-dev-env ACTION [options]
+
+Actions:
+  create   Create one throwaway DragonFly chroot dev environment
+  shell    Enter one existing environment via chroot
+  destroy  Unmount and remove one environment
+  list     List known environments
+
+create options:
+  --name NAME          Environment name (default: derived from target/origin)
+  --target TARGET      Compose target, e.g. @2026Q2 (required)
+  --origin ORIGIN      Optional selected origin, e.g. editors/vim
+  --delta-root PATH    Host DeltaPorts checkout (default: this repo)
+  --backend NAME       Backend name (default: chroot)
+  --freebsd-branch BR  Override FreeBSD branch (default: derived from target)
+  --shell              Enter the shell after creation succeeds
+
+shell options:
+  NAME                 Environment name
+
+destroy options:
+  NAME                 Environment name
+
+Environment variables:
+  DPORTS_DEV_CACHE_ROOT
+  DPORTS_DEV_AVALON_RELEASES_URL
+  DPORTS_DEV_FREEBSD_PORTS_URL
+  DPORTS_DEV_TOOL_PKGS_REQUIRED
+  DPORTS_DEV_PYTHON_PKGS
+  DPORTS_DEV_TOOL_PKGS_OPTIONAL
+EOF
+}
+
+die() {
+    printf '%s\n' "dports-dev-env: $*" >&2
+    exit 1
+}
+
+log() {
+    printf '%s\n' "dports-dev-env: $*" >&2
+}
+
+need_cmd() {
+    command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+require_root() {
+    [ "$(id -u)" -eq 0 ] || die "must run as root"
+}
+
+ensure_dirs() {
+    mkdir -p "$DPORTS_DEV_CACHE_ROOT" "$DPORTS_DEV_ENVS_DIR" "$DPORTS_DEV_BASE_DIR" \
+        "$DPORTS_DEV_DOWNLOAD_DIR" "$DPORTS_DEV_REPOS_DIR" "$DPORTS_DEV_WORKTREES_DIR"
+}
+
+sanitize_name() {
+    printf '%s' "$1" | tr '/:@ ' '____' | tr -cd 'A-Za-z0-9._-'
+}
+
+target_to_branch() {
+    case "$1" in
+        @main) printf '%s\n' main ;;
+        @20[0-9][0-9]Q[1-4]) printf '%s\n' "${1#@}" ;;
+        *) die "unsupported target: $1" ;;
+    esac
+}
+
+default_env_name() {
+    target=$1
+    origin=${2:-}
+    base=$(sanitize_name "${target#@}")
+    if [ -n "$origin" ]; then
+        printf '%s\n' "${base}-$(sanitize_name "$origin")"
+    else
+        printf '%s\n' "$base"
+    fi
+}
+
+state_path() {
+    printf '%s/state.env\n' "$DPORTS_DEV_ENVS_DIR/$1"
+}
+
+root_path() {
+    printf '%s/root\n' "$DPORTS_DEV_ENVS_DIR/$1"
+}
+
+load_state() {
+    env_name=$1
+    state_file=$(state_path "$env_name")
+    [ -f "$state_file" ] || die "environment not found: $env_name"
+    # shellcheck disable=SC1090
+    . "$state_file"
+}
+
+write_state() {
+    env_name=$1
+    env_dir=$DPORTS_DEV_ENVS_DIR/$env_name
+    mkdir -p "$env_dir"
+    state_file=$(state_path "$env_name")
+    tmp_file="$state_file.tmp.$$"
+    umask 077
+    cat > "$tmp_file" <<EOF
+ENV_NAME=$ENV_NAME
+BACKEND=$BACKEND
+TARGET=$TARGET
+ORIGIN=$ORIGIN
+FREEBSD_BRANCH=$FREEBSD_BRANCH
+DELTA_ROOT=$DELTA_ROOT
+FREEBSD_WORKTREE=$FREEBSD_WORKTREE
+BASE_ARCHIVE=$BASE_ARCHIVE
+BASE_CACHE_KEY=$BASE_CACHE_KEY
+BASE_EXTRACTED_ROOT=$BASE_EXTRACTED_ROOT
+ROOT_DIR=$ROOT_DIR
+CREATED_AT=$CREATED_AT
+EOF
+    mv -f "$tmp_file" "$state_file"
+}
+
+fetch_latest_world_asset() {
+    listing=$(curl -fsSL "$DPORTS_DEV_AVALON_RELEASES_URL") || die "failed to fetch Avalon listing"
+    asset=$(printf '%s\n' "$listing" | grep -Eo 'DragonFly-x86_64-[^"<>[:space:]]*\.world\.tar\.gz' | sort -u | sort | tail -n 1)
+    [ -n "$asset" ] || die "could not locate DragonFly x86_64 world asset in Avalon listing"
+    printf '%s\n' "$asset"
+}
+
+ensure_base_archive() {
+    asset=$1
+    archive_path="$DPORTS_DEV_DOWNLOAD_DIR/$asset"
+    if [ ! -f "$archive_path" ]; then
+        log "downloading $asset"
+        curl -fL "$DPORTS_DEV_AVALON_RELEASES_URL/$asset" -o "$archive_path"
+    fi
+    printf '%s\n' "$archive_path"
+}
+
+ensure_base_extracted() {
+    cache_key=$1
+    archive_path=$2
+    extracted="$DPORTS_DEV_BASE_DIR/$cache_key"
+    if [ ! -d "$extracted" ]; then
+        tmp_dir="$extracted.tmp.$$"
+        rm -rf "$tmp_dir"
+        mkdir -p "$tmp_dir"
+        log "extracting $archive_path"
+        tar -xpf "$archive_path" -C "$tmp_dir"
+        mv "$tmp_dir" "$extracted"
+    fi
+    printf '%s\n' "$extracted"
+}
+
+copy_base_root() {
+    src=$1
+    dst=$2
+    [ ! -e "$dst" ] || die "destination already exists: $dst"
+    mkdir -p "$dst"
+    log "copying cached base into $dst"
+    tar -C "$src" -cpf - . | tar -C "$dst" -xpf -
+}
+
+ensure_freebsd_mirror() {
+    mirror="$DPORTS_DEV_REPOS_DIR/freebsd-ports.git"
+    if [ ! -d "$mirror" ]; then
+        log "creating FreeBSD ports mirror"
+        git clone --mirror "$DPORTS_DEV_FREEBSD_PORTS_URL" "$mirror"
+    else
+        log "updating FreeBSD ports mirror"
+        git --git-dir="$mirror" fetch --prune origin
+    fi
+    printf '%s\n' "$mirror"
+}
+
+ensure_freebsd_worktree() {
+    branch=$1
+    mirror=$2
+    worktree="$DPORTS_DEV_WORKTREES_DIR/freebsd-ports/$branch"
+    ref="refs/remotes/origin/$branch"
+    git --git-dir="$mirror" rev-parse --verify "$ref" >/dev/null 2>&1 || die "branch not found in FreeBSD mirror: $branch"
+    mkdir -p "$(dirname "$worktree")"
+    if [ ! -d "$worktree/.git" ]; then
+        log "creating FreeBSD worktree for $branch"
+        git --git-dir="$mirror" worktree add --force --detach "$worktree" "$ref"
+    else
+        log "refreshing FreeBSD worktree for $branch"
+        git -C "$worktree" reset --hard "$ref"
+        git -C "$worktree" clean -fdx
+    fi
+    printf '%s\n' "$worktree"
+}
+
+mount_if_needed() {
+    src=$1
+    dst=$2
+    mkdir -p "$dst"
+    if mount | grep -F " on $dst " >/dev/null 2>&1; then
+        return 0
+    fi
+    mount_null "$src" "$dst"
+}
+
+umount_if_needed() {
+    path=$1
+    if mount | grep -F " on $path " >/dev/null 2>&1; then
+        umount "$path"
+    fi
+}
+
+prepare_root_runtime() {
+    root_dir=$1
+    mkdir -p "$root_dir/dev" "$root_dir/proc" "$root_dir/work"
+    if [ -f /etc/resolv.conf ]; then
+        mkdir -p "$root_dir/etc"
+        cp /etc/resolv.conf "$root_dir/etc/resolv.conf"
+    fi
+    mount_if_needed /dev "$root_dir/dev"
+    if ! mount | grep -F " on $root_dir/proc " >/dev/null 2>&1; then
+        mount_procfs proc "$root_dir/proc"
+    fi
+}
+
+write_shell_rc() {
+    root_dir=$1
+    mkdir -p "$root_dir/root"
+    cat > "$root_dir/root/.dports-dev-env.sh" <<EOF
+export DELTAPORTS_ROOT=/work/DeltaPorts
+export FREEBSD_PORTS_ROOT=/work/freebsd-ports
+export DPORTS_DEV_ENV=$ENV_NAME
+export DPORTS_TARGET=$TARGET
+export DPORTS_ORIGIN=$ORIGIN
+export DPORTS_COMPOSE_ROOT=/work/artifacts/compose/$TARGET
+export PATH=/usr/local/bin:/usr/local/sbin:/bin:/sbin:/usr/bin:/usr/sbin
+
+if [ -n "\$DPORTS_ORIGIN" ] && [ -d "\$DPORTS_COMPOSE_ROOT/\$DPORTS_ORIGIN" ]; then
+    cd "\$DPORTS_COMPOSE_ROOT/\$DPORTS_ORIGIN"
+elif [ -d "\$DPORTS_COMPOSE_ROOT" ]; then
+    cd "\$DPORTS_COMPOSE_ROOT"
+else
+    cd /work/DeltaPorts
+fi
+
+regen() {
+    if [ -n "\$DPORTS_ORIGIN" ]; then
+        /work/DeltaPorts/dportsv3 compose --target "\$DPORTS_TARGET" --delta-root /work/DeltaPorts --freebsd-root /work/freebsd-ports --output "\$DPORTS_COMPOSE_ROOT" --replace-output --oracle-profile off --origin "\$DPORTS_ORIGIN"
+    else
+        /work/DeltaPorts/dportsv3 compose --target "\$DPORTS_TARGET" --delta-root /work/DeltaPorts --freebsd-root /work/freebsd-ports --output "\$DPORTS_COMPOSE_ROOT" --replace-output --oracle-profile off
+    fi
+}
+
+reapply() {
+    if [ -z "\$DPORTS_ORIGIN" ]; then
+        printf '%s\n' 'reapply requires the environment to have been created with --origin' >&2
+        return 1
+    fi
+    /work/DeltaPorts/dportsv3 dsl apply "/work/DeltaPorts/ports/\$DPORTS_ORIGIN/overlay.dops" --port-root "\$DPORTS_COMPOSE_ROOT/\$DPORTS_ORIGIN" --target "\$DPORTS_TARGET" --oracle-profile off
+}
+
+showenv() {
+    env | grep '^DPORTS_' | sort
+}
+
+if command -v bash >/dev/null 2>&1; then
+    export DPORTS_DEV_SHELL=\$(command -v bash)
+else
+    export DPORTS_DEV_SHELL=/bin/sh
+fi
+
+PS1="(dports-dev:$ENV_NAME) \${PS1:-\\u@\\h:\\w\\$ }"
+export PS1
+EOF
+}
+
+run_in_chroot() {
+    root_dir=$1
+    shift
+    chroot "$root_dir" /usr/bin/env -i HOME=/root TERM="${TERM:-xterm}" PATH=/usr/local/bin:/usr/local/sbin:/bin:/sbin:/usr/bin:/usr/sbin /bin/sh -lc "$*"
+}
+
+bootstrap_tools() {
+    root_dir=$1
+    if ! run_in_chroot "$root_dir" 'command -v pkg >/dev/null 2>&1'; then
+        if run_in_chroot "$root_dir" 'command -v python3 >/dev/null 2>&1'; then
+            log "pkg is not present in the extracted world; skipping tool bootstrap"
+            return 0
+        fi
+        die "pkg is not present in the extracted world and python3 is unavailable"
+    fi
+    run_in_chroot "$root_dir" 'ASSUME_ALWAYS_YES=yes pkg bootstrap -yf >/dev/null 2>&1 || true'
+    run_in_chroot "$root_dir" 'ASSUME_ALWAYS_YES=yes pkg update -f >/dev/null 2>&1 || true'
+    for pkg_name in $DPORTS_DEV_TOOL_PKGS_REQUIRED; do
+        run_in_chroot "$root_dir" "ASSUME_ALWAYS_YES=yes pkg install -y $pkg_name >/dev/null" || die "failed to install required package in chroot: $pkg_name"
+    done
+    for pkg_name in $DPORTS_DEV_PYTHON_PKGS; do
+        if run_in_chroot "$root_dir" 'command -v python3 >/dev/null 2>&1'; then
+            break
+        fi
+        run_in_chroot "$root_dir" "ASSUME_ALWAYS_YES=yes pkg install -y $pkg_name >/dev/null" || log "python candidate unavailable or failed: $pkg_name"
+    done
+    run_in_chroot "$root_dir" 'command -v python3 >/dev/null 2>&1' || die "failed to install a python3 runtime inside the chroot"
+    for pkg_name in $DPORTS_DEV_TOOL_PKGS_OPTIONAL; do
+        run_in_chroot "$root_dir" "ASSUME_ALWAYS_YES=yes pkg install -y $pkg_name >/dev/null" || log "optional package unavailable or failed: $pkg_name"
+    done
+}
+
+compose_inside_env() {
+    root_dir=$1
+    mkdir -p "$root_dir/work/artifacts/compose"
+    compose_cmd="/work/DeltaPorts/dportsv3 compose --target $TARGET --delta-root /work/DeltaPorts --freebsd-root /work/freebsd-ports --output /work/artifacts/compose/$TARGET --replace-output --oracle-profile off"
+    run_in_chroot "$root_dir" "$compose_cmd"
+}
+
+shell_into_env() {
+    env_name=$1
+    load_state "$env_name"
+    [ "$BACKEND" = "chroot" ] || die "unsupported backend in environment: $BACKEND"
+    prepare_root_runtime "$ROOT_DIR"
+    mount_if_needed "$DELTA_ROOT" "$ROOT_DIR/work/DeltaPorts"
+    mount_if_needed "$FREEBSD_WORKTREE" "$ROOT_DIR/work/freebsd-ports"
+    exec chroot "$ROOT_DIR" /usr/bin/env -i HOME=/root TERM="${TERM:-xterm}" PATH=/usr/local/bin:/usr/local/sbin:/bin:/sbin:/usr/bin:/usr/sbin /bin/sh -lc '. /root/.dports-dev-env.sh; exec "$DPORTS_DEV_SHELL" -l'
+}
+
+destroy_env() {
+    env_name=$1
+    load_state "$env_name"
+    umount_if_needed "$ROOT_DIR/work/freebsd-ports"
+    umount_if_needed "$ROOT_DIR/work/DeltaPorts"
+    umount_if_needed "$ROOT_DIR/proc"
+    umount_if_needed "$ROOT_DIR/dev"
+    rm -rf "$DPORTS_DEV_ENVS_DIR/$env_name"
+}
+
+list_envs() {
+    if [ ! -d "$DPORTS_DEV_ENVS_DIR" ]; then
+        exit 0
+    fi
+    for state_file in "$DPORTS_DEV_ENVS_DIR"/*/state.env; do
+        [ -f "$state_file" ] || continue
+        env_name=$(basename "$(dirname "$state_file")")
+        # shellcheck disable=SC1090
+        . "$state_file"
+        printf '%s\t%s\t%s\t%s\n' "$env_name" "$BACKEND" "$TARGET" "$ORIGIN"
+    done
+}
+
+create_env() {
+    require_root
+    need_cmd curl
+    need_cmd tar
+    need_cmd git
+    need_cmd chroot
+    need_cmd mount_null
+    need_cmd mount_procfs
+
+    TARGET=
+    ORIGIN=
+    DELTA_ROOT=$REPO_ROOT
+    BACKEND=chroot
+    FREEBSD_BRANCH=
+    ENV_NAME=
+    auto_shell=0
+
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --name)
+                [ "$#" -ge 2 ] || die "--name requires a value"
+                ENV_NAME=$2
+                shift 2
+                ;;
+            --target)
+                [ "$#" -ge 2 ] || die "--target requires a value"
+                TARGET=$2
+                shift 2
+                ;;
+            --origin)
+                [ "$#" -ge 2 ] || die "--origin requires a value"
+                ORIGIN=$2
+                shift 2
+                ;;
+            --delta-root)
+                [ "$#" -ge 2 ] || die "--delta-root requires a value"
+                DELTA_ROOT=$2
+                shift 2
+                ;;
+            --backend)
+                [ "$#" -ge 2 ] || die "--backend requires a value"
+                BACKEND=$2
+                shift 2
+                ;;
+            --freebsd-branch)
+                [ "$#" -ge 2 ] || die "--freebsd-branch requires a value"
+                FREEBSD_BRANCH=$2
+                shift 2
+                ;;
+            --shell)
+                auto_shell=1
+                shift
+                ;;
+            --help|-h)
+                usage
+                exit 0
+                ;;
+            *)
+                die "unknown create option: $1"
+                ;;
+        esac
+    done
+
+    [ -n "$TARGET" ] || die "--target is required"
+    [ "$BACKEND" = "chroot" ] || die "unsupported backend: $BACKEND"
+    [ -d "$DELTA_ROOT" ] || die "Delta root does not exist: $DELTA_ROOT"
+    [ -f "$DELTA_ROOT/dportsv3" ] || die "Delta root does not look like this repo: $DELTA_ROOT"
+
+    if [ -z "$FREEBSD_BRANCH" ]; then
+        FREEBSD_BRANCH=$(target_to_branch "$TARGET")
+    fi
+    if [ -z "$ENV_NAME" ]; then
+        ENV_NAME=$(default_env_name "$TARGET" "$ORIGIN")
+    fi
+
+    env_dir="$DPORTS_DEV_ENVS_DIR/$ENV_NAME"
+    ROOT_DIR=$(root_path "$ENV_NAME")
+    [ ! -e "$env_dir" ] || die "environment already exists: $ENV_NAME"
+
+    asset=$(fetch_latest_world_asset)
+    BASE_ARCHIVE=$(ensure_base_archive "$asset")
+    BASE_CACHE_KEY=${asset%.tar.gz}
+    BASE_EXTRACTED_ROOT=$(ensure_base_extracted "$BASE_CACHE_KEY" "$BASE_ARCHIVE")
+    FREEBSD_MIRROR=$(ensure_freebsd_mirror)
+    FREEBSD_WORKTREE=$(ensure_freebsd_worktree "$FREEBSD_BRANCH" "$FREEBSD_MIRROR")
+
+    copy_base_root "$BASE_EXTRACTED_ROOT" "$ROOT_DIR"
+    prepare_root_runtime "$ROOT_DIR"
+    mount_if_needed "$DELTA_ROOT" "$ROOT_DIR/work/DeltaPorts"
+    mount_if_needed "$FREEBSD_WORKTREE" "$ROOT_DIR/work/freebsd-ports"
+    mkdir -p "$ROOT_DIR/work/artifacts/compose"
+    CREATED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+    write_shell_rc "$ROOT_DIR"
+    write_state "$ENV_NAME"
+
+    bootstrap_tools "$ROOT_DIR"
+    if ! compose_inside_env "$ROOT_DIR"; then
+        log "compose failed; environment retained for manual investigation"
+        exit 1
+    fi
+
+    if [ "$auto_shell" -eq 1 ]; then
+        shell_into_env "$ENV_NAME"
+    fi
+
+    log "created environment $ENV_NAME"
+}
+
+main() {
+    ensure_dirs
+    action=${1:-}
+    case "$action" in
+        create)
+            shift
+            create_env "$@"
+            ;;
+        shell)
+            require_root
+            [ "$#" -eq 2 ] || die "shell requires an environment name"
+            shell_into_env "$2"
+            ;;
+        destroy)
+            require_root
+            [ "$#" -eq 2 ] || die "destroy requires an environment name"
+            destroy_env "$2"
+            ;;
+        list)
+            list_envs
+            ;;
+        --help|-h|help|'')
+            usage
+            ;;
+        *)
+            die "unknown action: $action"
+            ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
Add dsynth hook scripts that translate run start/end and per-port
state changes into `dportsv3 tracker` API calls for the current
build profile.

The hooks persist one active tracker run id per dsynth profile,
enqueue ports before marking them building, record final port
outcomes, and fail soft with hook-local logging so tracker outages
do not interrupt package builds.

Include a shared helper, a config template, support for both
`hook_pkg_start` and `hook_pkg_started`, and installation notes for
copying the hook set into `/etc/dsynth`.

Co-authored-by: OpenAI <noreply@openai.com>
