### PR TITLE
Fix apply: warnings must not mark a clean apply as failed

### DIFF
--- a/scripts/generator/dportsv3/engine/apply.py
+++ b/scripts/generator/dportsv3/engine/apply.py
@@ -518,7 +518,8 @@ def apply_plan(
             oracle_skipped=oracle_skipped,
         )
 
-    ok = not diagnostics and all(row.status != "failed" for row in op_results)
+    has_error = any(d.severity == "error" for d in diagnostics)
+    ok = not has_error and all(row.status != "failed" for row in op_results)
     return ApplyResult(
         ok=ok,
         context=context,

--- a/scripts/generator/tests/test_dportsv3_apply.py
+++ b/scripts/generator/tests/test_dportsv3_apply.py
@@ -1772,3 +1772,55 @@ def test_apply_plan_ci_unavailable_oracle_fails_without_strict(
     assert not result.ok
     assert result.oracle_failures == 1
     assert any(d.code == "E_APPLY_ORACLE_UNAVAILABLE" for d in result.diagnostics)
+
+
+def test_apply_plan_local_unavailable_oracle_warning_keeps_ok(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A clean apply stays ok=True when the only diagnostic is a
+    warning-severity oracle skip (bmake unavailable under the local profile).
+
+    Regression: ``ok = not diagnostics and ...`` used to treat any diagnostic
+    -- including a warning -- as failure, so every dops port mis-reported
+    E_COMPOSE_APPLY_FAILED on hosts without bmake.
+    """
+    makefile = tmp_path / "Makefile"
+    makefile.write_text("VAR= old\n")
+    plan = Plan(
+        port="category/name",
+        ops=[
+            PlanOp(
+                id="op-1",
+                target="@main",
+                kind="mk.var.set",
+                payload={"name": "VAR", "value": "new"},
+            )
+        ],
+    )
+
+    monkeypatch.setattr(
+        "dportsv3.engine.apply.run_bmake_oracle",
+        lambda *_args, **_kwargs: OracleResult(
+            ok=True,
+            profile="local",
+            checks_run=0,
+            warnings=["bmake not found in PATH"],
+            unavailable=True,
+            skipped=True,
+        ),
+    )
+
+    result = apply_plan(
+        plan,
+        port_root=tmp_path,
+        target="@main",
+        dry_run=True,
+        strict=False,
+        oracle_profile="local",
+    )
+
+    assert result.failed_ops == 0
+    assert result.error_count == 0
+    assert result.warning_count == 1
+    assert any(d.code == "W_APPLY_ORACLE_SKIPPED" for d in result.diagnostics)
+    assert result.ok


### PR DESCRIPTION
## Problem

`compose` reports `E_COMPOSE_APPLY_FAILED: <origin>: 0 op(s) failed [no per-op detail]` for every dops-mode port, even though all ops apply cleanly (`applied_ops == total_ops`, `errors == 0`) and the generated output is correct.

## Root cause

`apply_plan` (`scripts/generator/dportsv3/engine/apply.py`) computed:

```python
ok = not diagnostics and all(row.status != "failed" for row in op_results)
```

`not diagnostics` requires the diagnostics list to be completely empty, but warning-severity diagnostics live in that same list. On a host without `bmake`, the default `local` oracle profile emits a single warning `W_APPLY_ORACLE_SKIPPED` ("bmake not found in PATH"). That lone warning flips `ok` to `False`, so compose reports the apply as failed — with zero failed ops and zero errors, hence the self-contradictory "0 op(s) failed" message.

This is not specific to any one port: it affects every dops-mode port on any host where the oracle emits a warning (e.g. `bmake` absent). It went unnoticed because the apply test-suite runs with `oracle_profile="off"`, which never populates diagnostics.

## Fix

Only error-severity diagnostics (or a genuinely failed op) mark the apply as failed:

```python
has_error = any(d.severity == "error" for d in diagnostics)
ok = not has_error and all(row.status != "failed" for row in op_results)
```

Warnings are still recorded and surfaced; they just no longer masquerade as failures. Real oracle failures (`E_APPLY_ORACLE_FAILED`) and CI-profile unavailability (`E_APPLY_ORACLE_UNAVAILABLE`) remain error-severity and still yield `ok=False`.

## Test

Adds `test_apply_plan_local_unavailable_oracle_warning_keeps_ok`: a clean apply whose only diagnostic is a warning-severity oracle skip must keep `ok=True`, with the warning still present. Verified red-before / green-after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
