### PR TITLE
devel/glib20: fix build failure on DragonFly

### DIFF
--- a/ports/devel/glib20/dragonfly/patch-gio_meson.build
+++ b/ports/devel/glib20/dragonfly/patch-gio_meson.build
@@ -1,8 +1,6 @@
---- gio/meson.build.orig	2023-10-25 11:33:59 UTC
+--- gio/meson.build.orig	2026-02-20 00:00:00 UTC
 +++ gio/meson.build
-@@ -934,20 +934,6 @@ endif
- 
- # Dependencies used by executables below
+@@ -977,20 +977,3 @@
  have_libelf = false
 -libelf = dependency('libelf', version : '>= 0.8.12', required : false)
 -if libelf.found() and get_option('libelf').allowed()
@@ -11,13 +9,15 @@
 -  # This fallback is necessary on *BSD. elfutils isn't the only libelf
 -  # implementation, and *BSD usually includes their own libelf as a system
 -  # library which doesn't have a corresponding .pc file.
--  libelf = cc.find_library('elf', required : get_option ('libelf'))
+-  libelf = declare_dependency(link_args: '/lib/libelf.so.2')
 -  have_libelf = libelf.found()
 -  have_libelf = have_libelf and cc.has_function('elf_begin', dependencies : libelf)
 -  have_libelf = have_libelf and cc.has_function('elf_getshdrstrndx', dependencies : libelf)
 -  have_libelf = have_libelf and cc.has_function('elf_getshdrnum', dependencies : libelf)
 -  have_libelf = have_libelf and cc.has_header('libelf.h')
+-  # This check is necessary for Solaris & illumos, where 32-bit libelf
+-  # is incompatible with large-file mode, which meson forces to be enabled
+-  have_libelf = have_libelf and cc.compiles('#include <libelf.h>', name: 'libelf.h')
 -endif
  
  if have_libelf
-   glib_conf.set('HAVE_LIBELF', 1)

--- a/ports/devel/glib20/dragonfly/patch-gmodule_gmodule-dl.c
+++ b/ports/devel/glib20/dragonfly/patch-gmodule_gmodule-dl.c
@@ -1,20 +1,20 @@
---- gmodule/gmodule-dl.c.orig	Mon Aug 26 10:15:22 2024
-+++ gmodule/gmodule-dl.c	Wed Apr
+--- gmodule/gmodule-dl.c.orig	2026-02-20 00:00:00 UTC
++++ gmodule/gmodule-dl.c
 @@ -167,7 +167,7 @@ _g_module_self (void)
     * NULL is given, dlsym returns an appropriate pointer.
     */
    lock_dlerror ();
--#if defined(__BIONIC__) || defined(__NetBSD__) || defined(__FreeBSD__)
-+#if defined(__BIONIC__) || defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
+-#if defined(__ANDROID__) || defined(__NetBSD__)
++#if defined(__ANDROID__) || defined(__NetBSD__) || defined(__DragonFly__)
    handle = RTLD_DEFAULT;
  #else
    handle = dlopen (NULL, RTLD_GLOBAL | RTLD_LAZY);
-@@ -182,7 +182,7 @@ _g_module_self (void)
+@@ -182,7 +182,7 @@ _g_module_close (gpointer handle)
  static void
  _g_module_close (gpointer handle)
  {
--#if defined(__BIONIC__) || defined(__NetBSD__) || defined(__FreeBSD__)
-+#if defined(__BIONIC__) || defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
+-#if defined(__ANDROID__) || defined(__NetBSD__)
++#if defined(__ANDROID__) || defined(__NetBSD__) || defined(__DragonFly__)
    if (handle != RTLD_DEFAULT)
  #endif
      {

--- a/ports/devel/glib20/overlay.dops
+++ b/ports/devel/glib20/overlay.dops
@@ -3,6 +3,8 @@ type port
 reason "auto-converted from compat (Makefile.DragonFly + dragonfly/)"
 target @any
 
+mk add MAKE_ENV "LC_ALL=C"
+
 file materialize dragonfly/patch-gio_gunixmount.c -> dragonfly/patch-gio_gunixmount.c
 file materialize dragonfly/patch-gio_gunixmounts.c -> dragonfly/patch-gio_gunixmounts.c
 file materialize dragonfly/patch-gio_gunixvolume.c -> dragonfly/patch-gio_gunixvolume.c


### PR DESCRIPTION
> Generated by the DragonFly agentic build-fix loop and verified in a clean dev-env. Reviewed and accepted by operator `operator` before submission.

## Problem

The build failed on `@2026Q3` — classified `patch-error`, confidence `high`.

The DeltaPorts overlay patch `dragonfly/patch-gio_meson.build` no longer applies against glib 2.86.4. Upstream reworked the libelf fallback block in `gio/meson.build`, adding new conditionals and checks so that the single DragonFly hunk — which replaces `cc.find_library('elf', ...)` with a direct link to `/lib/libelf.so.2` — rejects against the moved context. This is a one-time source drift: the other three DragonFly patches apply cleanly, only this stale overlay patch fails.

**Evidence:**

- `1 out of 1 hunks failed--saving rejects to gio/meson.build.rej`
- `===>  FAILED Applying dragonfly patch-gio_meson.build`
- `===> FAILED to apply cleanly dragonfly patch(es)  patch-gio_meson.build`
- `===> Cleanly applied dragonfly patch(es)  patch-gio_gunixmount.c patch-gio_gunixmounts.c patch-gio_gunixvolume.c`

## Fix

The glib 2.86.4 bump drifted two DragonFly overlay patches and unmasked a locale issue in the `default` flavor's docutils manpage/doc generation. (1) `dragonfly/patch-gio_meson.build` was a stale 2023 full-block-removal whose `cc.find_library('elf', …)` context line no longer matched — FreeBSD's `files/patch-gio_meson.build` now applies first and rewrites that exact line to `declare_dependency(link_args: '/lib/libelf.so.2')`, so I re-cut the DragonFly patch to remove the (now `declare_dependency`-flavoured, plus the new Solaris/illumos `cc.compiles` check) libelf-detection block against the post-`files/*` context, preserving DragonFly's intent to disable libelf entirely. (2) `dragonfly/patch-gmodule_gmodule-dl.c` targeted `__BIONIC__`/`__FreeBSD__` which upstream renamed to `__ANDROID__` (and dropped `__FreeBSD__`); re-cut both hunks to add `|| defined(__DragonFly__)` to `defined(__ANDROID__) || defined(__NetBSD__)`. (3) Added `mk add MAKE_ENV "LC_ALL=C"` so docutils' `setlocale(LC_ALL, '')` in `rst2man`/`rst2html5` stops failing with `unsupported locale setting` in the default flavor.

## What changed

3 files changed, +15/-13

- `ports/devel/glib20/dragonfly/patch-gio_meson.build`
- `ports/devel/glib20/dragonfly/patch-gmodule_gmodule-dl.c`
- `ports/devel/glib20/overlay.dops`

## Verification

Built successfully in a DragonFly dev-env (dsynth) for target `@2026Q3`.
Verified 2026-08-29T20:02:46.918476+00:00.

## Provenance

- Operator: operator
- Agent: model=deepseek/deepseek-v4-pro attempts=1 tokens=2245576
