### PR TITLE
graphics/jpeg-turbo: fix build failure on DragonFly

### DIFF
--- a/ports/graphics/jpeg-turbo/overlay.dops
+++ b/ports/graphics/jpeg-turbo/overlay.dops
@@ -4,3 +4,7 @@ reason "auto-converted from compat (Makefile.DragonFly + dragonfly/)"
 target @any
 
 file materialize dragonfly/patch-cmakescripts_GNUInstallDirs.cmake -> dragonfly/patch-cmakescripts_GNUInstallDirs.cmake
+# -ffp-model=strict is an Intel/clang-only flag; DragonFly's base GCC 8.3
+# rejects it (unrecognized command line option), breaking the CMake compiler
+# sanity check. Drop it from CFLAGS.
+mk remove CFLAGS "-ffp-model=strict"


### PR DESCRIPTION
> Generated by the DragonFly agentic build-fix loop and verified in a clean dev-env. Reviewed and accepted by operator `operator` before submission.

## Problem

The build failed on `@2026Q3` — classified `configure-error`, confidence `high`, platform `dragonfly-specific`.

The Makefile appends `-ffp-model=strict` to `CFLAGS` unconditionally, but this flag is an Intel/Clang-specific option not recognized by DragonFly's GCC 8.3.0 (`/usr/bin/cc`). During the CMake compiler sanity check, the flag causes the test compile to fail with `unrecognized command line option '-ffp-model=strict'`, aborting configuration.

**Evidence:**

- `CFLAGS+=	-ffp-model=strict` in the Makefile (with comment referencing a libjpeg-turbo GitHub issue).
- `cc: error: unrecognized command line option '-ffp-model=strict'; did you mean '-Wno-restrict'?`
- `The C compiler "/usr/bin/cc" is not able to compile a simple test program.`

## Fix

The port's Makefile appends the Intel/clang-only flag `-ffp-model=strict` to CFLAGS unconditionally; DragonFly's base GCC 8.3 rejects it during CMake's compiler sanity check, aborting configure. Added a dops `mk remove` op to drop the token from CFLAGS so the port builds with DragonFly's default toolchain.

## What changed

1 file changed, +4/-0

- `ports/graphics/jpeg-turbo/overlay.dops`

## Verification

Built successfully in a DragonFly dev-env (dsynth) for target `@2026Q3`.
Verified 2026-08-29T23:03:54.339466+00:00.
Rebuild status: `success`.

## Provenance

- Operator: operator
- Agent: model=deepseek/deepseek-v4-pro attempts=1 tokens=172253
